### PR TITLE
Consistent ordering in schemas

### DIFF
--- a/dist/formats/answer/frontend/schema.json
+++ b/dist/formats/answer/frontend/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "links",
@@ -12,12 +11,25 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -29,119 +41,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_pages": {
-          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "meets_user_needs": {
-          "description": "The user needs this piece of content meets.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "organisations": {
-          "description": "All organisations linked to this content item. This should include lead organisations.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "parent": {
-          "description": "The parent content item.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policy_areas": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "primary_publishing_organisation": {
-          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "available_translations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "children": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policies": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "document_collections": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "child_taxons": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -306,140 +207,262 @@
         "written_statement"
       ]
     },
+    "email_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "available_translations": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "policies": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policy_areas": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "primary_publishing_organisation": {
+          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "answer"
       ]
     },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    "title": {
+      "type": "string"
     },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
-    "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
     },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
-    "frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "base_path",
-          "locale"
-        ],
-        "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
-          },
-          "document_type": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
             "type": "string"
-          },
-          "schema_name": {
-            "type": "string"
-          },
-          "public_updated_at": {
-            "type": "string"
-          },
-          "content_id": {
-            "$ref": "#/definitions/guid"
-          },
-          "title": {
-            "type": "string"
-          },
-          "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
-            "type": "string"
-          },
-          "links": {
-            "type": "object",
-            "patternProperties": {
-              "^[a-z_]+$": {
-                "$ref": "#/definitions/frontend_links"
-              }
-            }
           }
         }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
       }
     },
     "base_path_less_frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "document_type": {
-            "type": "string"
-          },
-          "schema_name": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
           "api_path": {
             "$ref": "#/definitions/absolute_path"
@@ -449,25 +472,93 @@
             "type": "string",
             "format": "uri"
           },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "public_updated_at": {
-            "type": "string"
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
+          "document_type": {
             "type": "string"
           },
           "locale": {
             "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
           }
         }
       }
@@ -479,64 +570,58 @@
         "body": {
           "$ref": "#/definitions/body_html_and_govspeak"
         },
-        "external_related_links": {
-          "$ref": "#/definitions/external_related_links"
-        },
         "change_history": {
           "$ref": "#/definitions/change_history"
+        },
+        "external_related_links": {
+          "$ref": "#/definitions/external_related_links"
         }
       }
     },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -547,20 +632,437 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "base_path",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
+            "type": "string"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "country": {
+            "$ref": "#/definitions/country"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "details": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "links": {
+            "type": "object",
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links"
+              }
+            }
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -577,212 +1079,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -841,98 +1153,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -941,10 +1286,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -952,6 +1293,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -974,79 +1319,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1058,13 +1532,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1072,61 +1540,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1134,418 +1565,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1555,9 +1579,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/answer/notification/schema.json
+++ b/dist/formats/answer/notification/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "content_id",
@@ -17,12 +16,25 @@
     "title",
     "update_type"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -34,60 +46,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -252,60 +212,9 @@
         "written_statement"
       ]
     },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "answer"
-      ]
-    },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
-    },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
     "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "govuk_request_id": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
     },
     "expanded_links": {
       "type": "object",
@@ -314,112 +223,206 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "govuk_request_id": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "answer"
+      ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
-    "frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "base_path",
-          "locale"
-        ],
-        "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
-          },
-          "document_type": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
             "type": "string"
-          },
-          "schema_name": {
-            "type": "string"
-          },
-          "public_updated_at": {
-            "type": "string"
-          },
-          "content_id": {
-            "$ref": "#/definitions/guid"
-          },
-          "title": {
-            "type": "string"
-          },
-          "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
-            "type": "string"
-          },
-          "links": {
-            "type": "object",
-            "patternProperties": {
-              "^[a-z_]+$": {
-                "$ref": "#/definitions/frontend_links"
-              }
-            }
           }
         }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
       }
     },
     "base_path_less_frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "document_type": {
-            "type": "string"
-          },
-          "schema_name": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
           "api_path": {
             "$ref": "#/definitions/absolute_path"
@@ -429,25 +432,93 @@
             "type": "string",
             "format": "uri"
           },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "public_updated_at": {
-            "type": "string"
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
+          "document_type": {
             "type": "string"
           },
           "locale": {
             "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
           }
         }
       }
@@ -459,64 +530,58 @@
         "body": {
           "$ref": "#/definitions/body_html_and_govspeak"
         },
-        "external_related_links": {
-          "$ref": "#/definitions/external_related_links"
-        },
         "change_history": {
           "$ref": "#/definitions/change_history"
+        },
+        "external_related_links": {
+          "$ref": "#/definitions/external_related_links"
         }
       }
     },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -527,20 +592,437 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "base_path",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
+            "type": "string"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "country": {
+            "$ref": "#/definitions/country"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "details": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "links": {
+            "type": "object",
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links"
+              }
+            }
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -557,212 +1039,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -821,98 +1113,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -921,10 +1246,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -932,6 +1253,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -954,79 +1279,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1038,13 +1492,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1052,61 +1500,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1114,418 +1525,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1535,9 +1539,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/answer/publisher_v2/links.json
+++ b/dist/formats/answer/publisher_v2/links.json
@@ -3,25 +3,10 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "previous_version": {
-      "type": "string"
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/guid_list"
-        },
         "mainstream_browse_pages": {
           "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/guid_list"
@@ -30,8 +15,12 @@
           "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/guid_list"
         },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
@@ -51,38 +40,50 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/guid_list"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
         }
       }
+    },
+    "previous_version": {
+      "type": "string"
     }
   },
   "definitions": {
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
     "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
       "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
     "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
         {
           "type": "string"
@@ -90,22 +91,158 @@
         {
           "type": "null"
         }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+      ]
     },
-    "external_related_links": {
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -116,20 +253,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -146,212 +616,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -410,98 +690,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -510,10 +823,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -521,6 +830,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -543,79 +856,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -627,13 +1069,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -641,61 +1077,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -703,418 +1102,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1124,9 +1116,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/answer/publisher_v2/schema.json
+++ b/dist/formats/answer/publisher_v2/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "title",
     "details",
@@ -13,12 +12,22 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "description": {
       "anyOf": [
@@ -30,84 +39,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "access_limited": {
-      "$ref": "#/definitions/access_limited"
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "change_note": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "previous_version": {
-      "type": "string"
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "links": {
-      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string",
@@ -272,14 +205,224 @@
         "written_statement"
       ]
     },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "answer"
       ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,
@@ -292,65 +435,50 @@
         }
       }
     },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policy_areas": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -361,20 +489,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -391,212 +852,31 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
         }
       }
     },
-    "redirect_route": {
+    "links": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
       "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
         }
       }
     },
@@ -655,98 +935,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -755,10 +1068,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -766,6 +1075,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -788,79 +1101,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -872,13 +1314,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -886,61 +1322,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -948,418 +1347,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1369,9 +1361,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/case_study/frontend/schema.json
+++ b/dist/formats/case_study/frontend/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "links",
@@ -12,12 +11,25 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -29,128 +41,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "related_policies": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "world_locations": {
-          "$ref": "#/definitions/base_path_less_frontend_links"
-        },
-        "worldwide_organisations": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_pages": {
-          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "meets_user_needs": {
-          "description": "The user needs this piece of content meets.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "organisations": {
-          "description": "All organisations linked to this content item. This should include lead organisations.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "parent": {
-          "description": "The parent content item.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policy_areas": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "primary_publishing_organisation": {
-          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "available_translations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "children": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policies": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "document_collections": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "child_taxons": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -315,67 +207,657 @@
         "written_statement"
       ]
     },
+    "email_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "available_translations": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "policies": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policy_areas": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "primary_publishing_organisation": {
+          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "related_policies": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "world_locations": {
+          "$ref": "#/definitions/base_path_less_frontend_links"
+        },
+        "worldwide_organisations": {
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "case_study"
       ]
     },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    "title": {
+      "type": "string"
     },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
-    "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
     },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "base_path_less_frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "required": [
+        "body",
+        "first_public_at"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "archive_notice": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "archived_at": {
+              "format": "date-time"
+            },
+            "explanation": {
+              "type": "string"
+            }
+          }
+        },
+        "body": {
+          "$ref": "#/definitions/body"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "emphasised_organisations": {
+          "$ref": "#/definitions/emphasised_organisations"
+        },
+        "first_public_at": {
+          "$ref": "#/definitions/first_public_at"
+        },
+        "format_display_type": {
+          "type": "string",
+          "enum": [
+            "case_study"
+          ]
+        },
+        "image": {
+          "$ref": "#/definitions/image"
+        },
+        "tags": {
+          "$ref": "#/definitions/tags"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "required": [
+        "title",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
     "frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "base_path",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
-          "document_type": {
-            "type": "string"
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
           },
-          "schema_name": {
-            "type": "string"
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
           },
-          "public_updated_at": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
             "type": "string"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
-            "type": "string"
+          "country": {
+            "$ref": "#/definitions/country"
           },
           "description": {
             "anyOf": [
@@ -387,36 +869,11 @@
               }
             ]
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "details": {
+            "type": "object",
+            "additionalProperties": true
           },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
+          "document_type": {
             "type": "string"
           },
           "links": {
@@ -426,160 +883,205 @@
                 "$ref": "#/definitions/frontend_links"
               }
             }
-          }
-        }
-      }
-    },
-    "base_path_less_frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "locale"
-        ],
-        "properties": {
-          "document_type": {
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
             "type": "string"
           },
           "schema_name": {
             "type": "string"
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
+          "title": {
+            "type": "string"
           },
           "web_url": {
             "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
             "type": "string",
             "format": "uri"
           },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
           },
-          "public_updated_at": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
             "type": "string"
           },
-          "content_id": {
-            "$ref": "#/definitions/guid"
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
           },
           "title": {
             "type": "string"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
           }
         }
       }
     },
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "body",
-        "first_public_at"
-      ],
-      "properties": {
-        "body": {
-          "$ref": "#/definitions/body"
-        },
-        "image": {
-          "$ref": "#/definitions/image"
-        },
-        "format_display_type": {
-          "type": "string",
-          "enum": [
-            "case_study"
-          ]
-        },
-        "first_public_at": {
-          "$ref": "#/definitions/first_public_at"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        },
-        "tags": {
-          "$ref": "#/definitions/tags"
-        },
-        "archive_notice": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "explanation": {
-              "type": "string"
-            },
-            "archived_at": {
-              "format": "date-time"
-            }
-          }
-        },
-        "emphasised_organisations": {
-          "$ref": "#/definitions/emphasised_organisations"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
       }
     },
-    "external_link": {
+    "image": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
+        "alt_text": {
           "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "url": {
           "type": "string",
@@ -590,17 +1092,17 @@
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -617,212 +1119,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -881,98 +1193,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -981,10 +1326,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -992,6 +1333,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -1014,79 +1359,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1098,13 +1572,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1112,61 +1580,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1174,418 +1605,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1595,9 +1619,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/case_study/notification/schema.json
+++ b/dist/formats/case_study/notification/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "content_id",
@@ -17,12 +16,25 @@
     "title",
     "update_type"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -34,60 +46,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -252,60 +212,9 @@
         "written_statement"
       ]
     },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "case_study"
-      ]
-    },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
-    },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
     "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "govuk_request_id": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
     },
     "expanded_links": {
       "type": "object",
@@ -314,39 +223,592 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "govuk_request_id": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "case_study"
+      ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "base_path_less_frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "required": [
+        "body",
+        "first_public_at"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "archive_notice": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "archived_at": {
+              "format": "date-time"
+            },
+            "explanation": {
+              "type": "string"
+            }
+          }
+        },
+        "body": {
+          "$ref": "#/definitions/body"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "emphasised_organisations": {
+          "$ref": "#/definitions/emphasised_organisations"
+        },
+        "first_public_at": {
+          "$ref": "#/definitions/first_public_at"
+        },
+        "format_display_type": {
+          "type": "string",
+          "enum": [
+            "case_study"
+          ]
+        },
+        "image": {
+          "$ref": "#/definitions/image"
+        },
+        "tags": {
+          "$ref": "#/definitions/tags"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "required": [
+        "title",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
     "frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "base_path",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
-          "document_type": {
-            "type": "string"
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
           },
-          "schema_name": {
-            "type": "string"
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
           },
-          "public_updated_at": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
             "type": "string"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
-            "type": "string"
+          "country": {
+            "$ref": "#/definitions/country"
           },
           "description": {
             "anyOf": [
@@ -358,36 +820,11 @@
               }
             ]
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "details": {
+            "type": "object",
+            "additionalProperties": true
           },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
+          "document_type": {
             "type": "string"
           },
           "links": {
@@ -397,160 +834,205 @@
                 "$ref": "#/definitions/frontend_links"
               }
             }
-          }
-        }
-      }
-    },
-    "base_path_less_frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "locale"
-        ],
-        "properties": {
-          "document_type": {
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
             "type": "string"
           },
           "schema_name": {
             "type": "string"
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
+          "title": {
+            "type": "string"
           },
           "web_url": {
             "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
             "type": "string",
             "format": "uri"
           },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
           },
-          "public_updated_at": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
             "type": "string"
           },
-          "content_id": {
-            "$ref": "#/definitions/guid"
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
           },
           "title": {
             "type": "string"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
           }
         }
       }
     },
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "body",
-        "first_public_at"
-      ],
-      "properties": {
-        "body": {
-          "$ref": "#/definitions/body"
-        },
-        "image": {
-          "$ref": "#/definitions/image"
-        },
-        "format_display_type": {
-          "type": "string",
-          "enum": [
-            "case_study"
-          ]
-        },
-        "first_public_at": {
-          "$ref": "#/definitions/first_public_at"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        },
-        "tags": {
-          "$ref": "#/definitions/tags"
-        },
-        "archive_notice": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "explanation": {
-              "type": "string"
-            },
-            "archived_at": {
-              "format": "date-time"
-            }
-          }
-        },
-        "emphasised_organisations": {
-          "$ref": "#/definitions/emphasised_organisations"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
       }
     },
-    "external_link": {
+    "image": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
+        "alt_text": {
           "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "url": {
           "type": "string",
@@ -561,17 +1043,17 @@
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -588,212 +1070,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -852,98 +1144,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -952,10 +1277,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -963,6 +1284,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -985,79 +1310,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1069,13 +1523,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1083,61 +1531,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1145,418 +1556,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1566,9 +1570,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/case_study/publisher_v2/links.json
+++ b/dist/formats/case_study/publisher_v2/links.json
@@ -3,34 +3,10 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "previous_version": {
-      "type": "string"
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "related_policies": {
-          "$ref": "#/definitions/guid_list"
-        },
-        "world_locations": {
-          "$ref": "#/definitions/guid_list"
-        },
-        "worldwide_organisations": {
-          "$ref": "#/definitions/guid_list"
-        },
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/guid_list"
-        },
         "mainstream_browse_pages": {
           "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/guid_list"
@@ -39,8 +15,12 @@
           "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/guid_list"
         },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
@@ -60,38 +40,59 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "related_policies": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/guid_list"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "world_locations": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "worldwide_organisations": {
+          "$ref": "#/definitions/guid_list"
         }
       }
+    },
+    "previous_version": {
+      "type": "string"
     }
   },
   "definitions": {
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
     "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
       "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
     "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
         {
           "type": "string"
@@ -99,22 +100,158 @@
         {
           "type": "null"
         }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+      ]
     },
-    "external_related_links": {
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -125,20 +262,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -155,212 +625,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -419,98 +699,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -519,10 +832,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -530,6 +839,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -552,79 +865,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -636,13 +1078,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -650,61 +1086,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -712,418 +1111,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1133,9 +1125,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/case_study/publisher_v2/schema.json
+++ b/dist/formats/case_study/publisher_v2/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "title",
     "details",
@@ -13,12 +12,22 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "description": {
       "anyOf": [
@@ -30,84 +39,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "access_limited": {
-      "$ref": "#/definitions/access_limited"
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "change_note": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "previous_version": {
-      "type": "string"
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "links": {
-      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string",
@@ -272,96 +205,109 @@
         "written_statement"
       ]
     },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "case_study"
       ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "body",
-        "first_public_at"
-      ],
-      "properties": {
-        "body": {
-          "$ref": "#/definitions/body"
-        },
-        "image": {
-          "$ref": "#/definitions/image"
-        },
-        "format_display_type": {
-          "type": "string",
-          "enum": [
-            "case_study"
-          ]
-        },
-        "first_public_at": {
-          "$ref": "#/definitions/first_public_at"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        },
-        "tags": {
-          "$ref": "#/definitions/tags"
-        },
-        "archive_notice": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "explanation": {
-              "type": "string"
-            },
-            "archived_at": {
-              "format": "date-time"
-            }
-          }
-        },
-        "emphasised_organisations": {
-          "$ref": "#/definitions/emphasised_organisations"
-        }
-      }
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policy_areas": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
     },
     "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
       "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
     "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
         {
           "type": "string"
@@ -369,22 +315,204 @@
         {
           "type": "null"
         }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+      ]
     },
-    "external_related_links": {
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "required": [
+        "body",
+        "first_public_at"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "archive_notice": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "archived_at": {
+              "format": "date-time"
+            },
+            "explanation": {
+              "type": "string"
+            }
+          }
+        },
+        "body": {
+          "$ref": "#/definitions/body"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "emphasised_organisations": {
+          "$ref": "#/definitions/emphasised_organisations"
+        },
+        "first_public_at": {
+          "$ref": "#/definitions/first_public_at"
+        },
+        "format_display_type": {
+          "type": "string",
+          "enum": [
+            "case_study"
+          ]
+        },
+        "image": {
+          "$ref": "#/definitions/image"
+        },
+        "tags": {
+          "$ref": "#/definitions/tags"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -395,20 +523,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -425,212 +886,31 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
         }
       }
     },
-    "redirect_route": {
+    "links": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
       "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
         }
       }
     },
@@ -689,98 +969,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -789,10 +1102,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -800,6 +1109,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -822,79 +1135,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -906,13 +1348,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -920,61 +1356,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -982,418 +1381,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1403,9 +1395,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/coming_soon/frontend/schema.json
+++ b/dist/formats/coming_soon/frontend/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "links",
@@ -12,12 +11,25 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -29,119 +41,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_pages": {
-          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "meets_user_needs": {
-          "description": "The user needs this piece of content meets.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "organisations": {
-          "description": "All organisations linked to this content item. This should include lead organisations.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "parent": {
-          "description": "The parent content item.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policy_areas": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "primary_publishing_organisation": {
-          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "available_translations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "children": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policies": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "document_collections": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "child_taxons": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -306,67 +207,621 @@
         "written_statement"
       ]
     },
+    "email_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "available_translations": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "policies": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policy_areas": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "primary_publishing_organisation": {
+          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "coming_soon"
       ]
     },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    "title": {
+      "type": "string"
     },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
-    "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
     },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "base_path_less_frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "required": [
+        "publish_time"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "public_updated_at": {
+          "$ref": "#/definitions/public_updated_at"
+        },
+        "publish_time": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "required": [
+        "title",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
     "frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "base_path",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
-          "document_type": {
-            "type": "string"
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
           },
-          "schema_name": {
-            "type": "string"
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
           },
-          "public_updated_at": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
             "type": "string"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
-            "type": "string"
+          "country": {
+            "$ref": "#/definitions/country"
           },
           "description": {
             "anyOf": [
@@ -378,36 +833,11 @@
               }
             ]
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "details": {
+            "type": "object",
+            "additionalProperties": true
           },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
+          "document_type": {
             "type": "string"
           },
           "links": {
@@ -417,133 +847,205 @@
                 "$ref": "#/definitions/frontend_links"
               }
             }
-          }
-        }
-      }
-    },
-    "base_path_less_frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "locale"
-        ],
-        "properties": {
-          "document_type": {
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
             "type": "string"
           },
           "schema_name": {
             "type": "string"
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
+          "title": {
+            "type": "string"
           },
           "web_url": {
             "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
             "type": "string",
             "format": "uri"
           },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
           },
-          "public_updated_at": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
             "type": "string"
           },
-          "content_id": {
-            "$ref": "#/definitions/guid"
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
           },
           "title": {
             "type": "string"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
           }
         }
       }
     },
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "publish_time"
-      ],
-      "properties": {
-        "publish_time": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "public_updated_at": {
-          "$ref": "#/definitions/public_updated_at"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
       }
     },
-    "external_link": {
+    "image": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
+        "alt_text": {
           "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "url": {
           "type": "string",
@@ -554,17 +1056,17 @@
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -581,212 +1083,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -845,98 +1157,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -945,10 +1290,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -956,6 +1297,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -978,79 +1323,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1062,13 +1536,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1076,61 +1544,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1138,418 +1569,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1559,9 +1583,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/coming_soon/notification/schema.json
+++ b/dist/formats/coming_soon/notification/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "content_id",
@@ -17,12 +16,25 @@
     "title",
     "update_type"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -34,60 +46,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -252,60 +212,9 @@
         "written_statement"
       ]
     },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "coming_soon"
-      ]
-    },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
-    },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
     "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "govuk_request_id": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
     },
     "expanded_links": {
       "type": "object",
@@ -314,39 +223,565 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "govuk_request_id": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "coming_soon"
+      ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "base_path_less_frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "required": [
+        "publish_time"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "public_updated_at": {
+          "$ref": "#/definitions/public_updated_at"
+        },
+        "publish_time": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "required": [
+        "title",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
     "frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "base_path",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
-          "document_type": {
-            "type": "string"
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
           },
-          "schema_name": {
-            "type": "string"
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
           },
-          "public_updated_at": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
             "type": "string"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
-            "type": "string"
+          "country": {
+            "$ref": "#/definitions/country"
           },
           "description": {
             "anyOf": [
@@ -358,36 +793,11 @@
               }
             ]
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "details": {
+            "type": "object",
+            "additionalProperties": true
           },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
+          "document_type": {
             "type": "string"
           },
           "links": {
@@ -397,133 +807,205 @@
                 "$ref": "#/definitions/frontend_links"
               }
             }
-          }
-        }
-      }
-    },
-    "base_path_less_frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "locale"
-        ],
-        "properties": {
-          "document_type": {
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
             "type": "string"
           },
           "schema_name": {
             "type": "string"
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
+          "title": {
+            "type": "string"
           },
           "web_url": {
             "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
             "type": "string",
             "format": "uri"
           },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
           },
-          "public_updated_at": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
             "type": "string"
           },
-          "content_id": {
-            "$ref": "#/definitions/guid"
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
           },
           "title": {
             "type": "string"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
           }
         }
       }
     },
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "publish_time"
-      ],
-      "properties": {
-        "publish_time": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "public_updated_at": {
-          "$ref": "#/definitions/public_updated_at"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
       }
     },
-    "external_link": {
+    "image": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
+        "alt_text": {
           "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "url": {
           "type": "string",
@@ -534,17 +1016,17 @@
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -561,212 +1043,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -825,98 +1117,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -925,10 +1250,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -936,6 +1257,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -958,79 +1283,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1042,13 +1496,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1056,61 +1504,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1118,418 +1529,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1539,9 +1543,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/coming_soon/publisher_v2/links.json
+++ b/dist/formats/coming_soon/publisher_v2/links.json
@@ -3,25 +3,10 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "previous_version": {
-      "type": "string"
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/guid_list"
-        },
         "mainstream_browse_pages": {
           "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/guid_list"
@@ -30,8 +15,12 @@
           "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/guid_list"
         },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
@@ -51,38 +40,50 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/guid_list"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
         }
       }
+    },
+    "previous_version": {
+      "type": "string"
     }
   },
   "definitions": {
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
     "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
       "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
     "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
         {
           "type": "string"
@@ -90,22 +91,158 @@
         {
           "type": "null"
         }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+      ]
     },
-    "external_related_links": {
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -116,20 +253,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -146,212 +616,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -410,98 +690,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -510,10 +823,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -521,6 +830,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -543,79 +856,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -627,13 +1069,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -641,61 +1077,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -703,418 +1102,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1124,9 +1116,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/coming_soon/publisher_v2/schema.json
+++ b/dist/formats/coming_soon/publisher_v2/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "title",
     "details",
@@ -13,12 +12,22 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "description": {
       "anyOf": [
@@ -30,84 +39,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "access_limited": {
-      "$ref": "#/definitions/access_limited"
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "change_note": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "previous_version": {
-      "type": "string"
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "links": {
-      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string",
@@ -272,66 +205,109 @@
         "written_statement"
       ]
     },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "coming_soon"
       ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "publish_time"
-      ],
-      "properties": {
-        "publish_time": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "public_updated_at": {
-          "$ref": "#/definitions/public_updated_at"
-        }
-      }
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policy_areas": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
     },
     "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
       "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
     "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
         {
           "type": "string"
@@ -339,22 +315,174 @@
         {
           "type": "null"
         }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+      ]
     },
-    "external_related_links": {
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "required": [
+        "publish_time"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "public_updated_at": {
+          "$ref": "#/definitions/public_updated_at"
+        },
+        "publish_time": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -365,20 +493,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -395,212 +856,31 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
         }
       }
     },
-    "redirect_route": {
+    "links": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
       "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
         }
       }
     },
@@ -659,98 +939,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -759,10 +1072,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -770,6 +1079,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -792,79 +1105,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -876,13 +1318,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -890,61 +1326,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -952,418 +1351,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1373,9 +1365,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/completed_transaction/frontend/schema.json
+++ b/dist/formats/completed_transaction/frontend/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "links",
@@ -12,12 +11,25 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -29,119 +41,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_pages": {
-          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "meets_user_needs": {
-          "description": "The user needs this piece of content meets.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "organisations": {
-          "description": "All organisations linked to this content item. This should include lead organisations.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "parent": {
-          "description": "The parent content item.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policy_areas": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "primary_publishing_organisation": {
-          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "available_translations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "children": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policies": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "document_collections": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "child_taxons": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -306,140 +207,262 @@
         "written_statement"
       ]
     },
+    "email_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "available_translations": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "policies": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policy_areas": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "primary_publishing_organisation": {
+          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "completed_transaction"
       ]
     },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    "title": {
+      "type": "string"
     },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
-    "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
     },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
-    "frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "base_path",
-          "locale"
-        ],
-        "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
-          },
-          "document_type": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
             "type": "string"
-          },
-          "schema_name": {
-            "type": "string"
-          },
-          "public_updated_at": {
-            "type": "string"
-          },
-          "content_id": {
-            "$ref": "#/definitions/guid"
-          },
-          "title": {
-            "type": "string"
-          },
-          "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
-            "type": "string"
-          },
-          "links": {
-            "type": "object",
-            "patternProperties": {
-              "^[a-z_]+$": {
-                "$ref": "#/definitions/frontend_links"
-              }
-            }
           }
         }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
       }
     },
     "base_path_less_frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "document_type": {
-            "type": "string"
-          },
-          "schema_name": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
           "api_path": {
             "$ref": "#/definitions/absolute_path"
@@ -449,25 +472,93 @@
             "type": "string",
             "format": "uri"
           },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "public_updated_at": {
-            "type": "string"
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
+          "document_type": {
             "type": "string"
           },
           "locale": {
             "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
           }
         }
       }
@@ -476,16 +567,19 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
         "external_related_links": {
           "$ref": "#/definitions/external_related_links"
         },
         "promotion": {
           "type": "object",
-          "additionalProperties": false,
           "required": [
             "category",
             "url"
           ],
+          "additionalProperties": false,
           "properties": {
             "category": {
               "enum": [
@@ -498,62 +592,53 @@
               "format": "uri"
             }
           }
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
         }
       }
     },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -564,20 +649,437 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "base_path",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
+            "type": "string"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "country": {
+            "$ref": "#/definitions/country"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "details": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "links": {
+            "type": "object",
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links"
+              }
+            }
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -594,212 +1096,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -858,98 +1170,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -958,10 +1303,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -969,6 +1310,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -991,79 +1336,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1075,13 +1549,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1089,61 +1557,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1151,418 +1582,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1572,9 +1596,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/completed_transaction/notification/schema.json
+++ b/dist/formats/completed_transaction/notification/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "content_id",
@@ -17,12 +16,25 @@
     "title",
     "update_type"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -34,60 +46,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -252,60 +212,9 @@
         "written_statement"
       ]
     },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "completed_transaction"
-      ]
-    },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
-    },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
     "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "govuk_request_id": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
     },
     "expanded_links": {
       "type": "object",
@@ -314,112 +223,206 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "govuk_request_id": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "completed_transaction"
+      ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
-    "frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "base_path",
-          "locale"
-        ],
-        "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
-          },
-          "document_type": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
             "type": "string"
-          },
-          "schema_name": {
-            "type": "string"
-          },
-          "public_updated_at": {
-            "type": "string"
-          },
-          "content_id": {
-            "$ref": "#/definitions/guid"
-          },
-          "title": {
-            "type": "string"
-          },
-          "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
-            "type": "string"
-          },
-          "links": {
-            "type": "object",
-            "patternProperties": {
-              "^[a-z_]+$": {
-                "$ref": "#/definitions/frontend_links"
-              }
-            }
           }
         }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
       }
     },
     "base_path_less_frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "document_type": {
-            "type": "string"
-          },
-          "schema_name": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
           "api_path": {
             "$ref": "#/definitions/absolute_path"
@@ -429,25 +432,93 @@
             "type": "string",
             "format": "uri"
           },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "public_updated_at": {
-            "type": "string"
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
+          "document_type": {
             "type": "string"
           },
           "locale": {
             "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
           }
         }
       }
@@ -456,16 +527,19 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
         "external_related_links": {
           "$ref": "#/definitions/external_related_links"
         },
         "promotion": {
           "type": "object",
-          "additionalProperties": false,
           "required": [
             "category",
             "url"
           ],
+          "additionalProperties": false,
           "properties": {
             "category": {
               "enum": [
@@ -478,62 +552,53 @@
               "format": "uri"
             }
           }
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
         }
       }
     },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -544,20 +609,437 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "base_path",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
+            "type": "string"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "country": {
+            "$ref": "#/definitions/country"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "details": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "links": {
+            "type": "object",
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links"
+              }
+            }
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -574,212 +1056,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -838,98 +1130,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -938,10 +1263,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -949,6 +1270,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -971,79 +1296,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1055,13 +1509,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1069,61 +1517,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1131,418 +1542,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1552,9 +1556,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/completed_transaction/publisher_v2/links.json
+++ b/dist/formats/completed_transaction/publisher_v2/links.json
@@ -3,25 +3,10 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "previous_version": {
-      "type": "string"
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/guid_list"
-        },
         "mainstream_browse_pages": {
           "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/guid_list"
@@ -30,8 +15,12 @@
           "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/guid_list"
         },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
@@ -51,38 +40,50 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/guid_list"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
         }
       }
+    },
+    "previous_version": {
+      "type": "string"
     }
   },
   "definitions": {
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
     "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
       "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
     "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
         {
           "type": "string"
@@ -90,22 +91,158 @@
         {
           "type": "null"
         }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+      ]
     },
-    "external_related_links": {
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -116,20 +253,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -146,212 +616,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -410,98 +690,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -510,10 +823,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -521,6 +830,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -543,79 +856,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -627,13 +1069,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -641,61 +1077,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -703,418 +1102,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1124,9 +1116,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/completed_transaction/publisher_v2/schema.json
+++ b/dist/formats/completed_transaction/publisher_v2/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "title",
     "details",
@@ -13,12 +12,22 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "description": {
       "anyOf": [
@@ -30,84 +39,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "access_limited": {
-      "$ref": "#/definitions/access_limited"
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "change_note": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "previous_version": {
-      "type": "string"
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "links": {
-      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string",
@@ -272,14 +205,224 @@
         "written_statement"
       ]
     },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "completed_transaction"
       ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,
@@ -289,11 +432,11 @@
         },
         "promotion": {
           "type": "object",
-          "additionalProperties": false,
           "required": [
             "category",
             "url"
           ],
+          "additionalProperties": false,
           "properties": {
             "category": {
               "enum": [
@@ -309,65 +452,50 @@
         }
       }
     },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policy_areas": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -378,20 +506,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -408,212 +869,31 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
         }
       }
     },
-    "redirect_route": {
+    "links": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
       "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
         }
       }
     },
@@ -672,98 +952,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -772,10 +1085,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -783,6 +1092,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -805,79 +1118,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -889,13 +1331,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -903,61 +1339,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -965,418 +1364,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1386,9 +1378,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/consultation/frontend/schema.json
+++ b/dist/formats/consultation/frontend/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "links",
@@ -12,12 +11,25 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -29,136 +41,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "related_policies": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ministers": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "topical_events": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "roles": {
-          "description": "Used to power Email Alert Api subscriptions for Whitehall content",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "people": {
-          "description": "Used to power Email Alert Api subscriptions for Whitehall content",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_pages": {
-          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "meets_user_needs": {
-          "description": "The user needs this piece of content meets.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "organisations": {
-          "description": "All organisations linked to this content item. This should include lead organisations.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "parent": {
-          "description": "The parent content item.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policy_areas": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "primary_publishing_organisation": {
-          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "available_translations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "children": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policies": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "document_collections": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "child_taxons": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -323,67 +207,709 @@
         "written_statement"
       ]
     },
+    "email_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "available_translations": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ministers": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "people": {
+          "description": "Used to power Email Alert Api subscriptions for Whitehall content",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policies": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policy_areas": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "primary_publishing_organisation": {
+          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "related_policies": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "roles": {
+          "description": "Used to power Email Alert Api subscriptions for Whitehall content",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "topical_events": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "consultation"
       ]
     },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    "title": {
+      "type": "string"
     },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
-    "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
     },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "base_path_less_frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "required": [
+        "body",
+        "government",
+        "political"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "body": {
+          "$ref": "#/definitions/body"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "closing_date": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "documents": {
+          "$ref": "#/definitions/attachments_with_thumbnails"
+        },
+        "emphasised_organisations": {
+          "$ref": "#/definitions/emphasised_organisations"
+        },
+        "final_outcome_detail": {
+          "type": "string"
+        },
+        "final_outcome_documents": {
+          "$ref": "#/definitions/attachments_with_thumbnails"
+        },
+        "final_outcome_publication_date": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "first_public_at": {
+          "$ref": "#/definitions/first_public_at"
+        },
+        "government": {
+          "$ref": "#/definitions/government"
+        },
+        "held_on_another_website_url": {
+          "type": "string"
+        },
+        "image": {
+          "$ref": "#/definitions/image"
+        },
+        "national_applicability": {
+          "$ref": "#/definitions/national_applicability"
+        },
+        "opening_date": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "political": {
+          "$ref": "#/definitions/political"
+        },
+        "public_feedback_detail": {
+          "type": "string"
+        },
+        "public_feedback_documents": {
+          "$ref": "#/definitions/attachments_with_thumbnails"
+        },
+        "public_feedback_publication_date": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "tags": {
+          "$ref": "#/definitions/tags"
+        },
+        "ways_to_respond": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "attachment_url": {
+              "type": "string"
+            },
+            "email": {
+              "type": "string"
+            },
+            "link_url": {
+              "type": "string"
+            },
+            "postal_address": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "required": [
+        "title",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
     "frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "base_path",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
-          "document_type": {
-            "type": "string"
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
           },
-          "schema_name": {
-            "type": "string"
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
           },
-          "public_updated_at": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
             "type": "string"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
-            "type": "string"
+          "country": {
+            "$ref": "#/definitions/country"
           },
           "description": {
             "anyOf": [
@@ -395,36 +921,11 @@
               }
             ]
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "details": {
+            "type": "object",
+            "additionalProperties": true
           },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
+          "document_type": {
             "type": "string"
           },
           "links": {
@@ -434,204 +935,205 @@
                 "$ref": "#/definitions/frontend_links"
               }
             }
-          }
-        }
-      }
-    },
-    "base_path_less_frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "locale"
-        ],
-        "properties": {
-          "document_type": {
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
             "type": "string"
           },
           "schema_name": {
             "type": "string"
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
+          "title": {
+            "type": "string"
           },
           "web_url": {
             "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
             "type": "string",
             "format": "uri"
           },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
           },
-          "public_updated_at": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
             "type": "string"
           },
-          "content_id": {
-            "$ref": "#/definitions/guid"
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
           },
           "title": {
             "type": "string"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
           }
         }
       }
     },
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "body",
-        "government",
-        "political"
-      ],
-      "properties": {
-        "body": {
-          "$ref": "#/definitions/body"
-        },
-        "opening_date": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "closing_date": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "government": {
-          "$ref": "#/definitions/government"
-        },
-        "political": {
-          "$ref": "#/definitions/political"
-        },
-        "image": {
-          "$ref": "#/definitions/image"
-        },
-        "held_on_another_website_url": {
-          "type": "string"
-        },
-        "first_public_at": {
-          "$ref": "#/definitions/first_public_at"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        },
-        "national_applicability": {
-          "$ref": "#/definitions/national_applicability"
-        },
-        "emphasised_organisations": {
-          "$ref": "#/definitions/emphasised_organisations"
-        },
-        "documents": {
-          "$ref": "#/definitions/attachments_with_thumbnails"
-        },
-        "ways_to_respond": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "link_url": {
-              "type": "string"
-            },
-            "email": {
-              "type": "string"
-            },
-            "postal_address": {
-              "type": "string"
-            },
-            "attachment_url": {
-              "type": "string"
-            }
-          }
-        },
-        "public_feedback_publication_date": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "public_feedback_detail": {
-          "type": "string"
-        },
-        "public_feedback_documents": {
-          "$ref": "#/definitions/attachments_with_thumbnails"
-        },
-        "final_outcome_publication_date": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "final_outcome_detail": {
-          "type": "string"
-        },
-        "final_outcome_documents": {
-          "$ref": "#/definitions/attachments_with_thumbnails"
-        },
-        "tags": {
-          "$ref": "#/definitions/tags"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
       }
     },
-    "external_link": {
+    "image": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
+        "alt_text": {
           "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "url": {
           "type": "string",
@@ -642,17 +1144,17 @@
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -669,212 +1171,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -933,98 +1245,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -1033,10 +1378,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -1044,6 +1385,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -1066,79 +1411,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1150,13 +1624,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1164,61 +1632,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1226,418 +1657,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1647,9 +1671,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/consultation/notification/schema.json
+++ b/dist/formats/consultation/notification/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "content_id",
@@ -17,12 +16,25 @@
     "title",
     "update_type"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -34,60 +46,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -252,60 +212,9 @@
         "written_statement"
       ]
     },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "consultation"
-      ]
-    },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
-    },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
     "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "govuk_request_id": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
     },
     "expanded_links": {
       "type": "object",
@@ -314,39 +223,636 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "govuk_request_id": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "consultation"
+      ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "base_path_less_frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "required": [
+        "body",
+        "government",
+        "political"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "body": {
+          "$ref": "#/definitions/body"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "closing_date": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "documents": {
+          "$ref": "#/definitions/attachments_with_thumbnails"
+        },
+        "emphasised_organisations": {
+          "$ref": "#/definitions/emphasised_organisations"
+        },
+        "final_outcome_detail": {
+          "type": "string"
+        },
+        "final_outcome_documents": {
+          "$ref": "#/definitions/attachments_with_thumbnails"
+        },
+        "final_outcome_publication_date": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "first_public_at": {
+          "$ref": "#/definitions/first_public_at"
+        },
+        "government": {
+          "$ref": "#/definitions/government"
+        },
+        "held_on_another_website_url": {
+          "type": "string"
+        },
+        "image": {
+          "$ref": "#/definitions/image"
+        },
+        "national_applicability": {
+          "$ref": "#/definitions/national_applicability"
+        },
+        "opening_date": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "political": {
+          "$ref": "#/definitions/political"
+        },
+        "public_feedback_detail": {
+          "type": "string"
+        },
+        "public_feedback_documents": {
+          "$ref": "#/definitions/attachments_with_thumbnails"
+        },
+        "public_feedback_publication_date": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "tags": {
+          "$ref": "#/definitions/tags"
+        },
+        "ways_to_respond": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "attachment_url": {
+              "type": "string"
+            },
+            "email": {
+              "type": "string"
+            },
+            "link_url": {
+              "type": "string"
+            },
+            "postal_address": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "required": [
+        "title",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
     "frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "base_path",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
-          "document_type": {
-            "type": "string"
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
           },
-          "schema_name": {
-            "type": "string"
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
           },
-          "public_updated_at": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
             "type": "string"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
-            "type": "string"
+          "country": {
+            "$ref": "#/definitions/country"
           },
           "description": {
             "anyOf": [
@@ -358,36 +864,11 @@
               }
             ]
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "details": {
+            "type": "object",
+            "additionalProperties": true
           },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
+          "document_type": {
             "type": "string"
           },
           "links": {
@@ -397,204 +878,205 @@
                 "$ref": "#/definitions/frontend_links"
               }
             }
-          }
-        }
-      }
-    },
-    "base_path_less_frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "locale"
-        ],
-        "properties": {
-          "document_type": {
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
             "type": "string"
           },
           "schema_name": {
             "type": "string"
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
+          "title": {
+            "type": "string"
           },
           "web_url": {
             "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
             "type": "string",
             "format": "uri"
           },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
           },
-          "public_updated_at": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
             "type": "string"
           },
-          "content_id": {
-            "$ref": "#/definitions/guid"
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
           },
           "title": {
             "type": "string"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
           }
         }
       }
     },
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "body",
-        "government",
-        "political"
-      ],
-      "properties": {
-        "body": {
-          "$ref": "#/definitions/body"
-        },
-        "opening_date": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "closing_date": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "government": {
-          "$ref": "#/definitions/government"
-        },
-        "political": {
-          "$ref": "#/definitions/political"
-        },
-        "image": {
-          "$ref": "#/definitions/image"
-        },
-        "held_on_another_website_url": {
-          "type": "string"
-        },
-        "first_public_at": {
-          "$ref": "#/definitions/first_public_at"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        },
-        "national_applicability": {
-          "$ref": "#/definitions/national_applicability"
-        },
-        "emphasised_organisations": {
-          "$ref": "#/definitions/emphasised_organisations"
-        },
-        "documents": {
-          "$ref": "#/definitions/attachments_with_thumbnails"
-        },
-        "ways_to_respond": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "link_url": {
-              "type": "string"
-            },
-            "email": {
-              "type": "string"
-            },
-            "postal_address": {
-              "type": "string"
-            },
-            "attachment_url": {
-              "type": "string"
-            }
-          }
-        },
-        "public_feedback_publication_date": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "public_feedback_detail": {
-          "type": "string"
-        },
-        "public_feedback_documents": {
-          "$ref": "#/definitions/attachments_with_thumbnails"
-        },
-        "final_outcome_publication_date": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "final_outcome_detail": {
-          "type": "string"
-        },
-        "final_outcome_documents": {
-          "$ref": "#/definitions/attachments_with_thumbnails"
-        },
-        "tags": {
-          "$ref": "#/definitions/tags"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
       }
     },
-    "external_link": {
+    "image": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
+        "alt_text": {
           "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "url": {
           "type": "string",
@@ -605,17 +1087,17 @@
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -632,212 +1114,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -896,98 +1188,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -996,10 +1321,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -1007,6 +1328,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -1029,79 +1354,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1113,13 +1567,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1127,61 +1575,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1189,418 +1600,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1610,9 +1614,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/consultation/publisher_v2/links.json
+++ b/dist/formats/consultation/publisher_v2/links.json
@@ -3,42 +3,10 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "previous_version": {
-      "type": "string"
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "related_policies": {
-          "$ref": "#/definitions/guid_list"
-        },
-        "ministers": {
-          "$ref": "#/definitions/guid_list"
-        },
-        "topical_events": {
-          "$ref": "#/definitions/guid_list"
-        },
-        "roles": {
-          "$ref": "#/definitions/guid_list",
-          "description": "Used to power Email Alert Api subscriptions for Whitehall content"
-        },
-        "people": {
-          "$ref": "#/definitions/guid_list",
-          "description": "Used to power Email Alert Api subscriptions for Whitehall content"
-        },
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/guid_list"
-        },
         "mainstream_browse_pages": {
           "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/guid_list"
@@ -47,8 +15,15 @@
           "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/guid_list"
         },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+        "ministers": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
@@ -60,6 +35,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "people": {
+          "description": "Used to power Email Alert Api subscriptions for Whitehall content",
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"
@@ -68,38 +47,60 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "related_policies": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "roles": {
+          "description": "Used to power Email Alert Api subscriptions for Whitehall content",
+          "$ref": "#/definitions/guid_list"
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/guid_list"
+        },
+        "topical_events": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
         }
       }
+    },
+    "previous_version": {
+      "type": "string"
     }
   },
   "definitions": {
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
     "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
       "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
     "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
         {
           "type": "string"
@@ -107,22 +108,158 @@
         {
           "type": "null"
         }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+      ]
     },
-    "external_related_links": {
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -133,20 +270,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -163,212 +633,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -427,98 +707,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -527,10 +840,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -538,6 +847,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -560,79 +873,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -644,13 +1086,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -658,61 +1094,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -720,418 +1119,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1141,9 +1133,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/consultation/publisher_v2/schema.json
+++ b/dist/formats/consultation/publisher_v2/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "title",
     "details",
@@ -13,12 +12,22 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "description": {
       "anyOf": [
@@ -30,84 +39,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "access_limited": {
-      "$ref": "#/definitions/access_limited"
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "change_note": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "previous_version": {
-      "type": "string"
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "links": {
-      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string",
@@ -272,175 +205,109 @@
         "written_statement"
       ]
     },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "consultation"
       ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "body",
-        "government",
-        "political"
-      ],
-      "properties": {
-        "body": {
-          "$ref": "#/definitions/body"
-        },
-        "opening_date": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "closing_date": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "government": {
-          "$ref": "#/definitions/government"
-        },
-        "political": {
-          "$ref": "#/definitions/political"
-        },
-        "image": {
-          "$ref": "#/definitions/image"
-        },
-        "held_on_another_website_url": {
-          "type": "string"
-        },
-        "first_public_at": {
-          "$ref": "#/definitions/first_public_at"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        },
-        "national_applicability": {
-          "$ref": "#/definitions/national_applicability"
-        },
-        "emphasised_organisations": {
-          "$ref": "#/definitions/emphasised_organisations"
-        },
-        "documents": {
-          "$ref": "#/definitions/attachments_with_thumbnails"
-        },
-        "ways_to_respond": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "link_url": {
-              "type": "string"
-            },
-            "email": {
-              "type": "string"
-            },
-            "postal_address": {
-              "type": "string"
-            },
-            "attachment_url": {
-              "type": "string"
-            }
-          }
-        },
-        "public_feedback_publication_date": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "public_feedback_detail": {
-          "type": "string"
-        },
-        "public_feedback_documents": {
-          "$ref": "#/definitions/attachments_with_thumbnails"
-        },
-        "final_outcome_publication_date": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "final_outcome_detail": {
-          "type": "string"
-        },
-        "final_outcome_documents": {
-          "$ref": "#/definitions/attachments_with_thumbnails"
-        },
-        "tags": {
-          "$ref": "#/definitions/tags"
-        }
-      }
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "ministers": {
-          "$ref": "#/definitions/guid_list"
-        },
-        "organisations": {
-          "description": "All organisations linked to this content item. This should include lead organisations.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "parent": {
-          "description": "The parent content item.",
-          "maxItems": 1,
-          "$ref": "#/definitions/guid_list"
-        },
-        "people": {
-          "$ref": "#/definitions/guid_list",
-          "description": "Used to power Email Alert Api subscriptions for Whitehall content"
-        },
-        "primary_publishing_organisation": {
-          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
-          "$ref": "#/definitions/guid_list",
-          "maxItems": 1
-        },
-        "related_policies": {
-          "$ref": "#/definitions/guid_list"
-        },
-        "roles": {
-          "$ref": "#/definitions/guid_list",
-          "description": "Used to power Email Alert Api subscriptions for Whitehall content"
-        },
-        "topical_events": {
-          "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "policy_areas": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
     },
     "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
       "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
     "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
         {
           "type": "string"
@@ -448,22 +315,248 @@
         {
           "type": "null"
         }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+      ]
     },
-    "external_related_links": {
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "required": [
+        "body",
+        "government",
+        "political"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "body": {
+          "$ref": "#/definitions/body"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "closing_date": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "documents": {
+          "$ref": "#/definitions/attachments_with_thumbnails"
+        },
+        "emphasised_organisations": {
+          "$ref": "#/definitions/emphasised_organisations"
+        },
+        "final_outcome_detail": {
+          "type": "string"
+        },
+        "final_outcome_documents": {
+          "$ref": "#/definitions/attachments_with_thumbnails"
+        },
+        "final_outcome_publication_date": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "first_public_at": {
+          "$ref": "#/definitions/first_public_at"
+        },
+        "government": {
+          "$ref": "#/definitions/government"
+        },
+        "held_on_another_website_url": {
+          "type": "string"
+        },
+        "image": {
+          "$ref": "#/definitions/image"
+        },
+        "national_applicability": {
+          "$ref": "#/definitions/national_applicability"
+        },
+        "opening_date": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "political": {
+          "$ref": "#/definitions/political"
+        },
+        "public_feedback_detail": {
+          "type": "string"
+        },
+        "public_feedback_documents": {
+          "$ref": "#/definitions/attachments_with_thumbnails"
+        },
+        "public_feedback_publication_date": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "tags": {
+          "$ref": "#/definitions/tags"
+        },
+        "ways_to_respond": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "attachment_url": {
+              "type": "string"
+            },
+            "email": {
+              "type": "string"
+            },
+            "link_url": {
+              "type": "string"
+            },
+            "postal_address": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -474,20 +567,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -504,212 +930,66 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
         }
       }
     },
-    "redirect_route": {
+    "links": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
       "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
+        "ministers": {
+          "$ref": "#/definitions/guid_list"
         },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
         },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
         },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
+        "people": {
+          "description": "Used to power Email Alert Api subscriptions for Whitehall content",
+          "$ref": "#/definitions/guid_list"
+        },
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "primary_publishing_organisation": {
+          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
+        },
+        "related_policies": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "roles": {
+          "description": "Used to power Email Alert Api subscriptions for Whitehall content",
+          "$ref": "#/definitions/guid_list"
+        },
+        "topical_events": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
         }
       }
     },
@@ -768,98 +1048,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -868,10 +1181,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -879,6 +1188,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -901,79 +1214,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -985,13 +1427,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -999,61 +1435,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1061,418 +1460,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1482,9 +1474,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/contact/frontend/schema.json
+++ b/dist/formats/contact/frontend/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "links",
@@ -12,12 +11,25 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -29,122 +41,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "related": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_pages": {
-          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "meets_user_needs": {
-          "description": "The user needs this piece of content meets.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "organisations": {
-          "description": "All organisations linked to this content item. This should include lead organisations.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "parent": {
-          "description": "The parent content item.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policy_areas": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "primary_publishing_organisation": {
-          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "available_translations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "children": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policies": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "document_collections": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "child_taxons": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -309,140 +207,265 @@
         "written_statement"
       ]
     },
+    "email_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "available_translations": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "policies": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policy_areas": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "primary_publishing_organisation": {
+          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "related": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "contact"
       ]
     },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    "title": {
+      "type": "string"
     },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
-    "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
     },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
-    "frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "base_path",
-          "locale"
-        ],
-        "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
-          },
-          "document_type": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
             "type": "string"
-          },
-          "schema_name": {
-            "type": "string"
-          },
-          "public_updated_at": {
-            "type": "string"
-          },
-          "content_id": {
-            "$ref": "#/definitions/guid"
-          },
-          "title": {
-            "type": "string"
-          },
-          "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
-            "type": "string"
-          },
-          "links": {
-            "type": "object",
-            "patternProperties": {
-              "^[a-z_]+$": {
-                "$ref": "#/definitions/frontend_links"
-              }
-            }
           }
         }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
       }
     },
     "base_path_less_frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "document_type": {
-            "type": "string"
-          },
-          "schema_name": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
           "api_path": {
             "$ref": "#/definitions/absolute_path"
@@ -452,70 +475,106 @@
             "type": "string",
             "format": "uri"
           },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "public_updated_at": {
-            "type": "string"
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
+          "document_type": {
             "type": "string"
           },
           "locale": {
             "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
           }
         }
       }
     },
     "details": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title"
       ],
+      "additionalProperties": false,
       "properties": {
-        "slug": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "type": "string"
-        },
-        "quick_links": {
-          "type": "array",
-          "maxItems": 3,
-          "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "required": [
-              "title",
-              "url"
-            ],
-            "properties": {
-              "title": {
-                "type": "string"
-              },
-              "url": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "query_response_time": {
-          "type": [
-            "string",
-            "boolean"
-          ]
+        "change_history": {
+          "$ref": "#/definitions/change_history"
         },
         "contact_form_links": {
           "type": "array",
@@ -523,17 +582,51 @@
             "type": "object",
             "additionalProperties": false,
             "properties": {
-              "title": {
+              "description": {
                 "type": "string"
               },
               "link": {
                 "type": "string"
               },
-              "description": {
+              "title": {
                 "type": "string"
               }
             }
           }
+        },
+        "contact_type": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "email_addresses": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "title",
+              "email"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "email": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "feature_on_homepage": {
+          "type": "boolean"
+        },
+        "language": {
+          "type": "string"
         },
         "more_info_contact_form": {
           "anyOf": [
@@ -545,35 +638,27 @@
             }
           ]
         },
-        "contact_type": {
-          "type": "string"
-        },
-        "feature_on_homepage": {
-          "type": "boolean"
-        },
-        "email_addresses": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "required": [
-              "title",
-              "email"
-            ],
-            "properties": {
-              "title": {
-                "type": "string"
-              },
-              "email": {
-                "type": "string"
-              },
-              "description": {
-                "type": "string"
-              }
-            }
-          }
-        },
         "more_info_email_address": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "more_info_phone_number": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "more_info_post_address": {
           "anyOf": [
             {
               "type": "string"
@@ -587,153 +672,153 @@
           "type": "array",
           "items": {
             "type": "object",
-            "additionalProperties": false,
             "required": [
               "title",
               "number"
             ],
+            "additionalProperties": false,
             "properties": {
-              "title": {
-                "type": "string"
-              },
-              "number": {
-                "type": "string"
-              },
-              "textphone": {
-                "type": "string"
-              },
-              "international_phone": {
-                "type": "string"
-              },
-              "fax": {
+              "best_time_to_call": {
                 "type": "string"
               },
               "description": {
                 "type": "string"
               },
+              "fax": {
+                "type": "string"
+              },
+              "international_phone": {
+                "type": "string"
+              },
+              "number": {
+                "type": "string"
+              },
               "open_hours": {
                 "type": "string"
               },
-              "best_time_to_call": {
+              "textphone": {
+                "type": "string"
+              },
+              "title": {
                 "type": "string"
               }
             }
           }
         },
-        "more_info_phone_number": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
         "post_addresses": {
           "type": "array",
           "items": {
             "type": "object",
-            "additionalProperties": false,
             "required": [
               "title",
               "street_address",
               "postal_code",
               "world_location"
             ],
+            "additionalProperties": false,
             "properties": {
-              "title": {
-                "type": "string"
-              },
-              "street_address": {
-                "type": "string"
-              },
-              "postal_code": {
-                "type": "string"
-              },
-              "world_location": {
+              "description": {
                 "type": "string"
               },
               "locality": {
                 "type": "string"
               },
+              "postal_code": {
+                "type": "string"
+              },
               "region": {
                 "type": "string"
               },
-              "description": {
+              "street_address": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              },
+              "world_location": {
                 "type": "string"
               }
             }
           }
         },
-        "more_info_post_address": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
+        "query_response_time": {
+          "type": [
+            "string",
+            "boolean"
           ]
         },
-        "language": {
-          "type": "string"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
+        "quick_links": {
           "type": "array",
           "items": {
-            "type": "string"
-          }
+            "type": "object",
+            "required": [
+              "title",
+              "url"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            }
+          },
+          "maxItems": 3
         },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        "slug": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -744,20 +829,437 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "base_path",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
+            "type": "string"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "country": {
+            "$ref": "#/definitions/country"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "details": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "links": {
+            "type": "object",
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links"
+              }
+            }
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -774,212 +1276,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -1038,98 +1350,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -1138,10 +1483,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -1149,6 +1490,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -1171,79 +1516,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1255,13 +1729,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1269,61 +1737,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1331,418 +1762,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1752,9 +1776,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/contact/notification/schema.json
+++ b/dist/formats/contact/notification/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "content_id",
@@ -17,12 +16,25 @@
     "title",
     "update_type"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -34,60 +46,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -252,60 +212,9 @@
         "written_statement"
       ]
     },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "contact"
-      ]
-    },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
-    },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
     "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "govuk_request_id": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
     },
     "expanded_links": {
       "type": "object",
@@ -314,112 +223,206 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "govuk_request_id": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "contact"
+      ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
-    "frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "base_path",
-          "locale"
-        ],
-        "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
-          },
-          "document_type": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
             "type": "string"
-          },
-          "schema_name": {
-            "type": "string"
-          },
-          "public_updated_at": {
-            "type": "string"
-          },
-          "content_id": {
-            "$ref": "#/definitions/guid"
-          },
-          "title": {
-            "type": "string"
-          },
-          "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
-            "type": "string"
-          },
-          "links": {
-            "type": "object",
-            "patternProperties": {
-              "^[a-z_]+$": {
-                "$ref": "#/definitions/frontend_links"
-              }
-            }
           }
         }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
       }
     },
     "base_path_less_frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "document_type": {
-            "type": "string"
-          },
-          "schema_name": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
           "api_path": {
             "$ref": "#/definitions/absolute_path"
@@ -429,70 +432,106 @@
             "type": "string",
             "format": "uri"
           },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "public_updated_at": {
-            "type": "string"
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
+          "document_type": {
             "type": "string"
           },
           "locale": {
             "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
           }
         }
       }
     },
     "details": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title"
       ],
+      "additionalProperties": false,
       "properties": {
-        "slug": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "type": "string"
-        },
-        "quick_links": {
-          "type": "array",
-          "maxItems": 3,
-          "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "required": [
-              "title",
-              "url"
-            ],
-            "properties": {
-              "title": {
-                "type": "string"
-              },
-              "url": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "query_response_time": {
-          "type": [
-            "string",
-            "boolean"
-          ]
+        "change_history": {
+          "$ref": "#/definitions/change_history"
         },
         "contact_form_links": {
           "type": "array",
@@ -500,17 +539,51 @@
             "type": "object",
             "additionalProperties": false,
             "properties": {
-              "title": {
+              "description": {
                 "type": "string"
               },
               "link": {
                 "type": "string"
               },
-              "description": {
+              "title": {
                 "type": "string"
               }
             }
           }
+        },
+        "contact_type": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "email_addresses": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "title",
+              "email"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "email": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "feature_on_homepage": {
+          "type": "boolean"
+        },
+        "language": {
+          "type": "string"
         },
         "more_info_contact_form": {
           "anyOf": [
@@ -522,35 +595,27 @@
             }
           ]
         },
-        "contact_type": {
-          "type": "string"
-        },
-        "feature_on_homepage": {
-          "type": "boolean"
-        },
-        "email_addresses": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "required": [
-              "title",
-              "email"
-            ],
-            "properties": {
-              "title": {
-                "type": "string"
-              },
-              "email": {
-                "type": "string"
-              },
-              "description": {
-                "type": "string"
-              }
-            }
-          }
-        },
         "more_info_email_address": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "more_info_phone_number": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "more_info_post_address": {
           "anyOf": [
             {
               "type": "string"
@@ -564,153 +629,153 @@
           "type": "array",
           "items": {
             "type": "object",
-            "additionalProperties": false,
             "required": [
               "title",
               "number"
             ],
+            "additionalProperties": false,
             "properties": {
-              "title": {
-                "type": "string"
-              },
-              "number": {
-                "type": "string"
-              },
-              "textphone": {
-                "type": "string"
-              },
-              "international_phone": {
-                "type": "string"
-              },
-              "fax": {
+              "best_time_to_call": {
                 "type": "string"
               },
               "description": {
                 "type": "string"
               },
+              "fax": {
+                "type": "string"
+              },
+              "international_phone": {
+                "type": "string"
+              },
+              "number": {
+                "type": "string"
+              },
               "open_hours": {
                 "type": "string"
               },
-              "best_time_to_call": {
+              "textphone": {
+                "type": "string"
+              },
+              "title": {
                 "type": "string"
               }
             }
           }
         },
-        "more_info_phone_number": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
         "post_addresses": {
           "type": "array",
           "items": {
             "type": "object",
-            "additionalProperties": false,
             "required": [
               "title",
               "street_address",
               "postal_code",
               "world_location"
             ],
+            "additionalProperties": false,
             "properties": {
-              "title": {
-                "type": "string"
-              },
-              "street_address": {
-                "type": "string"
-              },
-              "postal_code": {
-                "type": "string"
-              },
-              "world_location": {
+              "description": {
                 "type": "string"
               },
               "locality": {
                 "type": "string"
               },
+              "postal_code": {
+                "type": "string"
+              },
               "region": {
                 "type": "string"
               },
-              "description": {
+              "street_address": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              },
+              "world_location": {
                 "type": "string"
               }
             }
           }
         },
-        "more_info_post_address": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
+        "query_response_time": {
+          "type": [
+            "string",
+            "boolean"
           ]
         },
-        "language": {
-          "type": "string"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
+        "quick_links": {
           "type": "array",
           "items": {
-            "type": "string"
-          }
+            "type": "object",
+            "required": [
+              "title",
+              "url"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            }
+          },
+          "maxItems": 3
         },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        "slug": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -721,20 +786,437 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "base_path",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
+            "type": "string"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "country": {
+            "$ref": "#/definitions/country"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "details": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "links": {
+            "type": "object",
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links"
+              }
+            }
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -751,212 +1233,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -1015,98 +1307,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -1115,10 +1440,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -1126,6 +1447,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -1148,79 +1473,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1232,13 +1686,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1246,61 +1694,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1308,418 +1719,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1729,9 +1733,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/contact/publisher_v2/links.json
+++ b/dist/formats/contact/publisher_v2/links.json
@@ -3,28 +3,10 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "previous_version": {
-      "type": "string"
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "related": {
-          "$ref": "#/definitions/guid_list"
-        },
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/guid_list"
-        },
         "mainstream_browse_pages": {
           "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/guid_list"
@@ -33,8 +15,12 @@
           "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/guid_list"
         },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
@@ -54,38 +40,53 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "related": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/guid_list"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
         }
       }
+    },
+    "previous_version": {
+      "type": "string"
     }
   },
   "definitions": {
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
     "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
       "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
     "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
         {
           "type": "string"
@@ -93,22 +94,158 @@
         {
           "type": "null"
         }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+      ]
     },
-    "external_related_links": {
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -119,20 +256,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -149,212 +619,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -413,98 +693,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -513,10 +826,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -524,6 +833,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -546,79 +859,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -630,13 +1072,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -644,61 +1080,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -706,418 +1105,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1127,9 +1119,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/contact/publisher_v2/schema.json
+++ b/dist/formats/contact/publisher_v2/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "title",
     "details",
@@ -10,12 +9,22 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "description": {
       "anyOf": [
@@ -27,84 +36,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "access_limited": {
-      "$ref": "#/definitions/access_limited"
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "change_note": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "previous_version": {
-      "type": "string"
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "links": {
-      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string",
@@ -269,73 +202,282 @@
         "written_statement"
       ]
     },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "contact"
       ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
-    "details": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "title"
-      ],
       "properties": {
-        "slug": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
           "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
         },
         "title": {
           "type": "string"
         },
-        "description": {
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
           "type": "string"
         },
-        "quick_links": {
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
           "type": "array",
-          "maxItems": 3,
           "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "required": [
-              "title",
-              "url"
-            ],
-            "properties": {
-              "title": {
-                "type": "string"
-              },
-              "url": {
-                "type": "string"
-              }
-            }
+            "type": "string"
           }
-        },
-        "query_response_time": {
-          "type": [
-            "string",
-            "boolean"
-          ]
-        },
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "required": [
+        "title"
+      ],
+      "additionalProperties": false,
+      "properties": {
         "contact_form_links": {
           "type": "array",
           "items": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
-              "title": {
+              "description": {
                 "type": "string"
               },
               "link": {
                 "type": "string"
               },
-              "description": {
+              "title": {
                 "type": "string"
               }
             }
           }
+        },
+        "contact_type": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "email_addresses": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "title",
+              "email"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "email": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "feature_on_homepage": {
+          "type": "boolean"
+        },
+        "language": {
+          "type": "string"
         },
         "more_info_contact_form": {
           "anyOf": [
@@ -347,35 +489,27 @@
             }
           ]
         },
-        "contact_type": {
-          "type": "string"
-        },
-        "feature_on_homepage": {
-          "type": "boolean"
-        },
-        "email_addresses": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "required": [
-              "title",
-              "email"
-            ],
-            "properties": {
-              "title": {
-                "type": "string"
-              },
-              "email": {
-                "type": "string"
-              },
-              "description": {
-                "type": "string"
-              }
-            }
-          }
-        },
         "more_info_email_address": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "more_info_phone_number": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "more_info_post_address": {
           "anyOf": [
             {
               "type": "string"
@@ -389,159 +523,153 @@
           "type": "array",
           "items": {
             "type": "object",
-            "additionalProperties": false,
             "required": [
               "title",
               "number"
             ],
+            "additionalProperties": false,
             "properties": {
-              "title": {
-                "type": "string"
-              },
-              "number": {
-                "type": "string"
-              },
-              "textphone": {
-                "type": "string"
-              },
-              "international_phone": {
-                "type": "string"
-              },
-              "fax": {
+              "best_time_to_call": {
                 "type": "string"
               },
               "description": {
                 "type": "string"
               },
+              "fax": {
+                "type": "string"
+              },
+              "international_phone": {
+                "type": "string"
+              },
+              "number": {
+                "type": "string"
+              },
               "open_hours": {
                 "type": "string"
               },
-              "best_time_to_call": {
+              "textphone": {
+                "type": "string"
+              },
+              "title": {
                 "type": "string"
               }
             }
           }
         },
-        "more_info_phone_number": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
         "post_addresses": {
           "type": "array",
           "items": {
             "type": "object",
-            "additionalProperties": false,
             "required": [
               "title",
               "street_address",
               "postal_code",
               "world_location"
             ],
+            "additionalProperties": false,
             "properties": {
-              "title": {
-                "type": "string"
-              },
-              "street_address": {
-                "type": "string"
-              },
-              "postal_code": {
-                "type": "string"
-              },
-              "world_location": {
+              "description": {
                 "type": "string"
               },
               "locality": {
                 "type": "string"
               },
+              "postal_code": {
+                "type": "string"
+              },
               "region": {
                 "type": "string"
               },
-              "description": {
+              "street_address": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              },
+              "world_location": {
                 "type": "string"
               }
             }
           }
         },
-        "more_info_post_address": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
+        "query_response_time": {
+          "type": [
+            "string",
+            "boolean"
           ]
         },
-        "language": {
-          "type": "string"
-        }
-      }
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policy_areas": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
+        "quick_links": {
           "type": "array",
           "items": {
-            "type": "string"
-          }
+            "type": "object",
+            "required": [
+              "title",
+              "url"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            }
+          },
+          "maxItems": 3
         },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        "slug": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -552,20 +680,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -582,212 +1043,31 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
         }
       }
     },
-    "redirect_route": {
+    "links": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
       "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
         }
       }
     },
@@ -846,98 +1126,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -946,10 +1259,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -957,6 +1266,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -979,79 +1292,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1063,13 +1505,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1077,61 +1513,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1139,418 +1538,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1560,9 +1552,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/corporate_information_page/frontend/schema.json
+++ b/dist/formats/corporate_information_page/frontend/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "links",
@@ -12,12 +11,25 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -29,122 +41,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "corporate_information_pages": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_pages": {
-          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "meets_user_needs": {
-          "description": "The user needs this piece of content meets.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "organisations": {
-          "description": "All organisations linked to this content item. This should include lead organisations.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "parent": {
-          "description": "The parent content item.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policy_areas": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "primary_publishing_organisation": {
-          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "available_translations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "children": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policies": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "document_collections": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "child_taxons": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -309,67 +207,632 @@
         "written_statement"
       ]
     },
+    "email_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "available_translations": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "corporate_information_pages": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "policies": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policy_areas": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "primary_publishing_organisation": {
+          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "corporate_information_page"
       ]
     },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    "title": {
+      "type": "string"
     },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
-    "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
     },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "base_path_less_frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "required": [
+        "body",
+        "organisation"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "body": {
+          "$ref": "#/definitions/body"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "corporate_information_groups": {
+          "description": "Groups of corporate information to display on about pages",
+          "$ref": "#/definitions/grouped_lists_of_links"
+        },
+        "organisation": {
+          "description": "A single organisation that is the subject of this corporate information page",
+          "$ref": "#/definitions/guid"
+        },
+        "tags": {
+          "$ref": "#/definitions/tags"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "required": [
+        "title",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
     "frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "base_path",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
-          "document_type": {
-            "type": "string"
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
           },
-          "schema_name": {
-            "type": "string"
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
           },
-          "public_updated_at": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
             "type": "string"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
-            "type": "string"
+          "country": {
+            "$ref": "#/definitions/country"
           },
           "description": {
             "anyOf": [
@@ -381,36 +844,11 @@
               }
             ]
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "details": {
+            "type": "object",
+            "additionalProperties": true
           },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
+          "document_type": {
             "type": "string"
           },
           "links": {
@@ -420,141 +858,205 @@
                 "$ref": "#/definitions/frontend_links"
               }
             }
-          }
-        }
-      }
-    },
-    "base_path_less_frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "locale"
-        ],
-        "properties": {
-          "document_type": {
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
             "type": "string"
           },
           "schema_name": {
             "type": "string"
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
+          "title": {
+            "type": "string"
           },
           "web_url": {
             "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
             "type": "string",
             "format": "uri"
           },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
           },
-          "public_updated_at": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
             "type": "string"
           },
-          "content_id": {
-            "$ref": "#/definitions/guid"
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
           },
           "title": {
             "type": "string"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
           }
         }
       }
     },
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "body",
-        "organisation"
-      ],
-      "properties": {
-        "body": {
-          "$ref": "#/definitions/body"
-        },
-        "organisation": {
-          "description": "A single organisation that is the subject of this corporate information page",
-          "$ref": "#/definitions/guid"
-        },
-        "tags": {
-          "$ref": "#/definitions/tags"
-        },
-        "corporate_information_groups": {
-          "description": "Groups of corporate information to display on about pages",
-          "$ref": "#/definitions/grouped_lists_of_links"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
       }
     },
-    "external_link": {
+    "image": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
+        "alt_text": {
           "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "url": {
           "type": "string",
@@ -565,17 +1067,17 @@
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -592,212 +1094,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -856,98 +1168,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -956,10 +1301,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -967,6 +1308,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -989,79 +1334,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1073,13 +1547,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1087,61 +1555,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1149,418 +1580,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1570,9 +1594,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/corporate_information_page/notification/schema.json
+++ b/dist/formats/corporate_information_page/notification/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "content_id",
@@ -17,12 +16,25 @@
     "title",
     "update_type"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -34,60 +46,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -252,60 +212,9 @@
         "written_statement"
       ]
     },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "corporate_information_page"
-      ]
-    },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
-    },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
     "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "govuk_request_id": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
     },
     "expanded_links": {
       "type": "object",
@@ -314,39 +223,573 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "govuk_request_id": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "corporate_information_page"
+      ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "base_path_less_frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "required": [
+        "body",
+        "organisation"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "body": {
+          "$ref": "#/definitions/body"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "corporate_information_groups": {
+          "description": "Groups of corporate information to display on about pages",
+          "$ref": "#/definitions/grouped_lists_of_links"
+        },
+        "organisation": {
+          "description": "A single organisation that is the subject of this corporate information page",
+          "$ref": "#/definitions/guid"
+        },
+        "tags": {
+          "$ref": "#/definitions/tags"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "required": [
+        "title",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
     "frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "base_path",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
-          "document_type": {
-            "type": "string"
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
           },
-          "schema_name": {
-            "type": "string"
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
           },
-          "public_updated_at": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
             "type": "string"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
-            "type": "string"
+          "country": {
+            "$ref": "#/definitions/country"
           },
           "description": {
             "anyOf": [
@@ -358,36 +801,11 @@
               }
             ]
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "details": {
+            "type": "object",
+            "additionalProperties": true
           },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
+          "document_type": {
             "type": "string"
           },
           "links": {
@@ -397,141 +815,205 @@
                 "$ref": "#/definitions/frontend_links"
               }
             }
-          }
-        }
-      }
-    },
-    "base_path_less_frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "locale"
-        ],
-        "properties": {
-          "document_type": {
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
             "type": "string"
           },
           "schema_name": {
             "type": "string"
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
+          "title": {
+            "type": "string"
           },
           "web_url": {
             "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
             "type": "string",
             "format": "uri"
           },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
           },
-          "public_updated_at": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
             "type": "string"
           },
-          "content_id": {
-            "$ref": "#/definitions/guid"
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
           },
           "title": {
             "type": "string"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
           }
         }
       }
     },
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "body",
-        "organisation"
-      ],
-      "properties": {
-        "body": {
-          "$ref": "#/definitions/body"
-        },
-        "organisation": {
-          "description": "A single organisation that is the subject of this corporate information page",
-          "$ref": "#/definitions/guid"
-        },
-        "tags": {
-          "$ref": "#/definitions/tags"
-        },
-        "corporate_information_groups": {
-          "description": "Groups of corporate information to display on about pages",
-          "$ref": "#/definitions/grouped_lists_of_links"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
       }
     },
-    "external_link": {
+    "image": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
+        "alt_text": {
           "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "url": {
           "type": "string",
@@ -542,17 +1024,17 @@
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -569,212 +1051,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -833,98 +1125,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -933,10 +1258,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -944,6 +1265,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -966,79 +1291,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1050,13 +1504,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1064,61 +1512,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1126,418 +1537,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1547,9 +1551,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/corporate_information_page/publisher_v2/links.json
+++ b/dist/formats/corporate_information_page/publisher_v2/links.json
@@ -3,26 +3,11 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "previous_version": {
-      "type": "string"
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
         "corporate_information_pages": {
-          "$ref": "#/definitions/guid_list"
-        },
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/guid_list"
         },
         "mainstream_browse_pages": {
@@ -33,8 +18,12 @@
           "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/guid_list"
         },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
@@ -54,38 +43,50 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/guid_list"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
         }
       }
+    },
+    "previous_version": {
+      "type": "string"
     }
   },
   "definitions": {
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
     "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
       "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
     "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
         {
           "type": "string"
@@ -93,22 +94,158 @@
         {
           "type": "null"
         }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+      ]
     },
-    "external_related_links": {
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -119,20 +256,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -149,212 +619,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -413,98 +693,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -513,10 +826,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -524,6 +833,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -546,79 +859,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -630,13 +1072,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -644,61 +1080,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -706,418 +1105,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1127,9 +1119,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/corporate_information_page/publisher_v2/schema.json
+++ b/dist/formats/corporate_information_page/publisher_v2/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "title",
     "details",
@@ -13,12 +12,22 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "description": {
       "anyOf": [
@@ -30,84 +39,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "access_limited": {
-      "$ref": "#/definitions/access_limited"
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "change_note": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "previous_version": {
-      "type": "string"
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "links": {
-      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string",
@@ -272,91 +205,109 @@
         "written_statement"
       ]
     },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "corporate_information_page"
       ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "body",
-        "organisation"
-      ],
-      "properties": {
-        "body": {
-          "$ref": "#/definitions/body"
-        },
-        "organisation": {
-          "description": "A single organisation that is the subject of this corporate information page",
-          "$ref": "#/definitions/guid"
-        },
-        "tags": {
-          "$ref": "#/definitions/tags"
-        },
-        "corporate_information_groups": {
-          "description": "Groups of corporate information to display on about pages",
-          "$ref": "#/definitions/grouped_lists_of_links"
-        }
-      }
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "corporate_information_pages": {
-          "$ref": "#/definitions/guid_list"
-        },
-        "organisations": {
-          "description": "All organisations linked to this content item. This should include lead organisations.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "parent": {
-          "description": "The parent content item.",
-          "maxItems": 1,
-          "$ref": "#/definitions/guid_list"
-        },
-        "primary_publishing_organisation": {
-          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
-          "$ref": "#/definitions/guid_list",
-          "maxItems": 1
-        },
-        "policy_areas": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
     },
     "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
       "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
     "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
         {
           "type": "string"
@@ -364,22 +315,182 @@
         {
           "type": "null"
         }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+      ]
     },
-    "external_related_links": {
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "required": [
+        "body",
+        "organisation"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "body": {
+          "$ref": "#/definitions/body"
+        },
+        "corporate_information_groups": {
+          "description": "Groups of corporate information to display on about pages",
+          "$ref": "#/definitions/grouped_lists_of_links"
+        },
+        "organisation": {
+          "description": "A single organisation that is the subject of this corporate information page",
+          "$ref": "#/definitions/guid"
+        },
+        "tags": {
+          "$ref": "#/definitions/tags"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -390,20 +501,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -420,212 +864,48 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
         }
       }
     },
-    "redirect_route": {
+    "links": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
       "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
+        "corporate_information_pages": {
+          "$ref": "#/definitions/guid_list"
         },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
         },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
         },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "primary_publishing_organisation": {
+          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
         }
       }
     },
@@ -684,98 +964,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -784,10 +1097,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -795,6 +1104,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -817,79 +1130,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -901,13 +1343,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -915,61 +1351,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -977,418 +1376,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1398,9 +1390,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/detailed_guide/frontend/schema.json
+++ b/dist/formats/detailed_guide/frontend/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "links",
@@ -12,12 +11,25 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -29,128 +41,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "related_guides": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "related_policies": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "related_mainstream_content": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_pages": {
-          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "meets_user_needs": {
-          "description": "The user needs this piece of content meets.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "organisations": {
-          "description": "All organisations linked to this content item. This should include lead organisations.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "parent": {
-          "description": "The parent content item.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policy_areas": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "primary_publishing_organisation": {
-          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "available_translations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "children": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policies": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "document_collections": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "child_taxons": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -315,67 +207,666 @@
         "written_statement"
       ]
     },
+    "email_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "available_translations": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "policies": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policy_areas": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "primary_publishing_organisation": {
+          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "related_guides": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "related_mainstream_content": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "related_policies": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "detailed_guide"
       ]
     },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    "title": {
+      "type": "string"
     },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
-    "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
     },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "base_path_less_frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "required": [
+        "body",
+        "first_public_at",
+        "government",
+        "political"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alternative_nothern_ireland_url": {
+          "type": "string"
+        },
+        "alternative_scotland_url": {
+          "type": "string"
+        },
+        "alternative_wales_url": {
+          "type": "string"
+        },
+        "body": {
+          "$ref": "#/definitions/body"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "emphasised_organisations": {
+          "$ref": "#/definitions/emphasised_organisations"
+        },
+        "first_public_at": {
+          "$ref": "#/definitions/first_public_at"
+        },
+        "government": {
+          "$ref": "#/definitions/government"
+        },
+        "image": {
+          "$ref": "#/definitions/image"
+        },
+        "national_applicability": {
+          "$ref": "#/definitions/national_applicability"
+        },
+        "political": {
+          "$ref": "#/definitions/political"
+        },
+        "related_mainstream_content": {
+          "description": "The ordered list of related and additional mainstream content item IDs. Use in conjunction with the (unordered) `related_mainstream_content` link.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/guid"
+          }
+        },
+        "tags": {
+          "$ref": "#/definitions/tags"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "required": [
+        "title",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
     "frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "base_path",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
-          "document_type": {
-            "type": "string"
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
           },
-          "schema_name": {
-            "type": "string"
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
           },
-          "public_updated_at": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
             "type": "string"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
-            "type": "string"
+          "country": {
+            "$ref": "#/definitions/country"
           },
           "description": {
             "anyOf": [
@@ -387,36 +878,11 @@
               }
             ]
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "details": {
+            "type": "object",
+            "additionalProperties": true
           },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
+          "document_type": {
             "type": "string"
           },
           "links": {
@@ -426,169 +892,205 @@
                 "$ref": "#/definitions/frontend_links"
               }
             }
-          }
-        }
-      }
-    },
-    "base_path_less_frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "locale"
-        ],
-        "properties": {
-          "document_type": {
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
             "type": "string"
           },
           "schema_name": {
             "type": "string"
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
+          "title": {
+            "type": "string"
           },
           "web_url": {
             "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
             "type": "string",
             "format": "uri"
           },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
           },
-          "public_updated_at": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
             "type": "string"
           },
-          "content_id": {
-            "$ref": "#/definitions/guid"
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
           },
           "title": {
             "type": "string"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
           }
         }
       }
     },
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "body",
-        "first_public_at",
-        "government",
-        "political"
-      ],
-      "properties": {
-        "body": {
-          "$ref": "#/definitions/body"
-        },
-        "related_mainstream_content": {
-          "description": "The ordered list of related and additional mainstream content item IDs. Use in conjunction with the (unordered) `related_mainstream_content` link.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/guid"
-          }
-        },
-        "first_public_at": {
-          "$ref": "#/definitions/first_public_at"
-        },
-        "image": {
-          "$ref": "#/definitions/image"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        },
-        "alternative_scotland_url": {
-          "type": "string"
-        },
-        "alternative_wales_url": {
-          "type": "string"
-        },
-        "alternative_nothern_ireland_url": {
-          "type": "string"
-        },
-        "tags": {
-          "$ref": "#/definitions/tags"
-        },
-        "government": {
-          "$ref": "#/definitions/government"
-        },
-        "political": {
-          "$ref": "#/definitions/political"
-        },
-        "emphasised_organisations": {
-          "$ref": "#/definitions/emphasised_organisations"
-        },
-        "national_applicability": {
-          "$ref": "#/definitions/national_applicability"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
       }
     },
-    "external_link": {
+    "image": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
+        "alt_text": {
           "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "url": {
           "type": "string",
@@ -599,17 +1101,17 @@
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -626,212 +1128,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -890,98 +1202,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -990,10 +1335,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -1001,6 +1342,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -1023,79 +1368,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1107,13 +1581,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1121,61 +1589,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1183,418 +1614,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1604,9 +1628,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/detailed_guide/notification/schema.json
+++ b/dist/formats/detailed_guide/notification/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "content_id",
@@ -17,12 +16,25 @@
     "title",
     "update_type"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -34,60 +46,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -252,60 +212,9 @@
         "written_statement"
       ]
     },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "detailed_guide"
-      ]
-    },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
-    },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
     "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "govuk_request_id": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
     },
     "expanded_links": {
       "type": "object",
@@ -314,39 +223,601 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "govuk_request_id": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "detailed_guide"
+      ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "base_path_less_frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "required": [
+        "body",
+        "first_public_at",
+        "government",
+        "political"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alternative_nothern_ireland_url": {
+          "type": "string"
+        },
+        "alternative_scotland_url": {
+          "type": "string"
+        },
+        "alternative_wales_url": {
+          "type": "string"
+        },
+        "body": {
+          "$ref": "#/definitions/body"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "emphasised_organisations": {
+          "$ref": "#/definitions/emphasised_organisations"
+        },
+        "first_public_at": {
+          "$ref": "#/definitions/first_public_at"
+        },
+        "government": {
+          "$ref": "#/definitions/government"
+        },
+        "image": {
+          "$ref": "#/definitions/image"
+        },
+        "national_applicability": {
+          "$ref": "#/definitions/national_applicability"
+        },
+        "political": {
+          "$ref": "#/definitions/political"
+        },
+        "related_mainstream_content": {
+          "description": "The ordered list of related and additional mainstream content item IDs. Use in conjunction with the (unordered) `related_mainstream_content` link.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/guid"
+          }
+        },
+        "tags": {
+          "$ref": "#/definitions/tags"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "required": [
+        "title",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
     "frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "base_path",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
-          "document_type": {
-            "type": "string"
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
           },
-          "schema_name": {
-            "type": "string"
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
           },
-          "public_updated_at": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
             "type": "string"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
-            "type": "string"
+          "country": {
+            "$ref": "#/definitions/country"
           },
           "description": {
             "anyOf": [
@@ -358,36 +829,11 @@
               }
             ]
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "details": {
+            "type": "object",
+            "additionalProperties": true
           },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
+          "document_type": {
             "type": "string"
           },
           "links": {
@@ -397,169 +843,205 @@
                 "$ref": "#/definitions/frontend_links"
               }
             }
-          }
-        }
-      }
-    },
-    "base_path_less_frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "locale"
-        ],
-        "properties": {
-          "document_type": {
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
             "type": "string"
           },
           "schema_name": {
             "type": "string"
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
+          "title": {
+            "type": "string"
           },
           "web_url": {
             "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
             "type": "string",
             "format": "uri"
           },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
           },
-          "public_updated_at": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
             "type": "string"
           },
-          "content_id": {
-            "$ref": "#/definitions/guid"
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
           },
           "title": {
             "type": "string"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
           }
         }
       }
     },
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "body",
-        "first_public_at",
-        "government",
-        "political"
-      ],
-      "properties": {
-        "body": {
-          "$ref": "#/definitions/body"
-        },
-        "related_mainstream_content": {
-          "description": "The ordered list of related and additional mainstream content item IDs. Use in conjunction with the (unordered) `related_mainstream_content` link.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/guid"
-          }
-        },
-        "first_public_at": {
-          "$ref": "#/definitions/first_public_at"
-        },
-        "image": {
-          "$ref": "#/definitions/image"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        },
-        "alternative_scotland_url": {
-          "type": "string"
-        },
-        "alternative_wales_url": {
-          "type": "string"
-        },
-        "alternative_nothern_ireland_url": {
-          "type": "string"
-        },
-        "tags": {
-          "$ref": "#/definitions/tags"
-        },
-        "government": {
-          "$ref": "#/definitions/government"
-        },
-        "political": {
-          "$ref": "#/definitions/political"
-        },
-        "emphasised_organisations": {
-          "$ref": "#/definitions/emphasised_organisations"
-        },
-        "national_applicability": {
-          "$ref": "#/definitions/national_applicability"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
       }
     },
-    "external_link": {
+    "image": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
+        "alt_text": {
           "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "url": {
           "type": "string",
@@ -570,17 +1052,17 @@
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -597,212 +1079,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -861,98 +1153,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -961,10 +1286,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -972,6 +1293,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -994,79 +1319,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1078,13 +1532,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1092,61 +1540,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1154,418 +1565,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1575,9 +1579,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/detailed_guide/publisher_v2/links.json
+++ b/dist/formats/detailed_guide/publisher_v2/links.json
@@ -3,34 +3,10 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "previous_version": {
-      "type": "string"
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "related_guides": {
-          "$ref": "#/definitions/guid_list"
-        },
-        "related_policies": {
-          "$ref": "#/definitions/guid_list"
-        },
-        "related_mainstream_content": {
-          "$ref": "#/definitions/guid_list"
-        },
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/guid_list"
-        },
         "mainstream_browse_pages": {
           "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/guid_list"
@@ -39,8 +15,12 @@
           "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/guid_list"
         },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
@@ -60,38 +40,59 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "related_guides": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "related_mainstream_content": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "related_policies": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/guid_list"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
         }
       }
+    },
+    "previous_version": {
+      "type": "string"
     }
   },
   "definitions": {
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
     "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
       "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
     "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
         {
           "type": "string"
@@ -99,22 +100,158 @@
         {
           "type": "null"
         }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+      ]
     },
-    "external_related_links": {
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -125,20 +262,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -155,212 +625,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -419,98 +699,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -519,10 +832,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -530,6 +839,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -552,79 +865,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -636,13 +1078,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -650,61 +1086,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -712,418 +1111,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1133,9 +1125,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/detailed_guide/publisher_v2/schema.json
+++ b/dist/formats/detailed_guide/publisher_v2/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "title",
     "details",
@@ -13,12 +12,22 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "description": {
       "anyOf": [
@@ -30,84 +39,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "access_limited": {
-      "$ref": "#/definitions/access_limited"
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "change_note": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "previous_version": {
-      "type": "string"
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "links": {
-      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string",
@@ -272,26 +205,266 @@
         "written_statement"
       ]
     },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "detailed_guide"
       ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
-    "details": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
       "type": "object",
       "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
       "required": [
         "body",
         "first_public_at",
         "government",
         "political"
       ],
+      "additionalProperties": false,
       "properties": {
+        "alternative_nothern_ireland_url": {
+          "type": "string"
+        },
+        "alternative_scotland_url": {
+          "type": "string"
+        },
+        "alternative_wales_url": {
+          "type": "string"
+        },
         "body": {
           "$ref": "#/definitions/body"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "emphasised_organisations": {
+          "$ref": "#/definitions/emphasised_organisations"
+        },
+        "first_public_at": {
+          "$ref": "#/definitions/first_public_at"
+        },
+        "government": {
+          "$ref": "#/definitions/government"
+        },
+        "image": {
+          "$ref": "#/definitions/image"
+        },
+        "national_applicability": {
+          "$ref": "#/definitions/national_applicability"
+        },
+        "political": {
+          "$ref": "#/definitions/political"
         },
         "related_mainstream_content": {
           "description": "The ordered list of related and additional mainstream content item IDs. Use in conjunction with the (unordered) `related_mainstream_content` link.",
@@ -300,100 +473,55 @@
             "$ref": "#/definitions/guid"
           }
         },
-        "first_public_at": {
-          "$ref": "#/definitions/first_public_at"
-        },
-        "image": {
-          "$ref": "#/definitions/image"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        },
-        "alternative_scotland_url": {
-          "type": "string"
-        },
-        "alternative_wales_url": {
-          "type": "string"
-        },
-        "alternative_nothern_ireland_url": {
-          "type": "string"
-        },
         "tags": {
           "$ref": "#/definitions/tags"
-        },
-        "government": {
-          "$ref": "#/definitions/government"
-        },
-        "political": {
-          "$ref": "#/definitions/political"
-        },
-        "emphasised_organisations": {
-          "$ref": "#/definitions/emphasised_organisations"
-        },
-        "national_applicability": {
-          "$ref": "#/definitions/national_applicability"
         }
       }
     },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policy_areas": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -404,20 +532,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -434,212 +895,31 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
         }
       }
     },
-    "redirect_route": {
+    "links": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
       "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
         }
       }
     },
@@ -698,98 +978,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -798,10 +1111,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -809,6 +1118,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -831,79 +1144,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -915,13 +1357,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -929,61 +1365,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -991,418 +1390,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1412,9 +1404,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/document_collection/frontend/schema.json
+++ b/dist/formats/document_collection/frontend/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "links",
@@ -12,12 +11,25 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -29,124 +41,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "documents": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "topical_events": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "related_policies": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_pages": {
-          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "meets_user_needs": {
-          "description": "The user needs this piece of content meets.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "topics": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "organisations": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "parent": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policy_areas": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "primary_publishing_organisation": {
-          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "available_translations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "children": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policies": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "document_collections": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "child_taxons": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -311,67 +207,668 @@
         "written_statement"
       ]
     },
+    "email_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "available_translations": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "documents": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "organisations": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "parent": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policies": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policy_areas": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "primary_publishing_organisation": {
+          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "related_policies": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "topical_events": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "topics": {
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "document_collection"
       ]
     },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    "title": {
+      "type": "string"
     },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
-    "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
     },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "base_path_less_frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "required": [
+        "first_public_at",
+        "collection_groups",
+        "government",
+        "political"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "body": {
+          "$ref": "#/definitions/body"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "collection_groups": {
+          "description": "The ordered list of collection groups",
+          "type": "array",
+          "items": {
+            "description": "Collection group",
+            "type": "object",
+            "required": [
+              "title",
+              "documents"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "body": {
+                "$ref": "#/definitions/body"
+              },
+              "documents": {
+                "description": "An ordered list of documents in this collection group",
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/guid"
+                }
+              },
+              "title": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "emphasised_organisations": {
+          "$ref": "#/definitions/emphasised_organisations"
+        },
+        "first_public_at": {
+          "$ref": "#/definitions/first_public_at"
+        },
+        "government": {
+          "$ref": "#/definitions/government"
+        },
+        "political": {
+          "$ref": "#/definitions/political"
+        },
+        "tags": {
+          "$ref": "#/definitions/tags"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "required": [
+        "title",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
     "frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "base_path",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
-          "document_type": {
-            "type": "string"
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
           },
-          "schema_name": {
-            "type": "string"
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
           },
-          "public_updated_at": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
             "type": "string"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
-            "type": "string"
+          "country": {
+            "$ref": "#/definitions/country"
           },
           "description": {
             "anyOf": [
@@ -383,36 +880,11 @@
               }
             ]
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "details": {
+            "type": "object",
+            "additionalProperties": true
           },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
+          "document_type": {
             "type": "string"
           },
           "links": {
@@ -422,175 +894,205 @@
                 "$ref": "#/definitions/frontend_links"
               }
             }
-          }
-        }
-      }
-    },
-    "base_path_less_frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "locale"
-        ],
-        "properties": {
-          "document_type": {
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
             "type": "string"
           },
           "schema_name": {
             "type": "string"
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
+          "title": {
+            "type": "string"
           },
           "web_url": {
             "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
             "type": "string",
             "format": "uri"
           },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
           },
-          "public_updated_at": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
             "type": "string"
           },
-          "content_id": {
-            "$ref": "#/definitions/guid"
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
           },
           "title": {
             "type": "string"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
           }
         }
       }
     },
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "first_public_at",
-        "collection_groups",
-        "government",
-        "political"
-      ],
-      "properties": {
-        "body": {
-          "$ref": "#/definitions/body"
-        },
-        "collection_groups": {
-          "description": "The ordered list of collection groups",
-          "type": "array",
-          "items": {
-            "description": "Collection group",
-            "type": "object",
-            "additionalProperties": false,
-            "required": [
-              "title",
-              "documents"
-            ],
-            "properties": {
-              "title": {
-                "type": "string"
-              },
-              "body": {
-                "$ref": "#/definitions/body"
-              },
-              "documents": {
-                "description": "An ordered list of documents in this collection group",
-                "type": "array",
-                "items": {
-                  "$ref": "#/definitions/guid"
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
                 }
               }
             }
-          }
-        },
-        "first_public_at": {
-          "$ref": "#/definitions/first_public_at"
-        },
-        "tags": {
-          "$ref": "#/definitions/tags"
-        },
-        "government": {
-          "$ref": "#/definitions/government"
-        },
-        "political": {
-          "$ref": "#/definitions/political"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        },
-        "emphasised_organisations": {
-          "$ref": "#/definitions/emphasised_organisations"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
+          },
+          "title": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/external_link"
-      }
-    },
-    "external_link": {
+    "image": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
+        "alt_text": {
           "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "url": {
           "type": "string",
@@ -601,17 +1103,17 @@
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -628,212 +1130,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -892,98 +1204,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -992,10 +1337,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -1003,6 +1344,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -1025,79 +1370,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1109,13 +1583,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1123,61 +1591,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1185,418 +1616,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1606,9 +1630,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/document_collection/notification/schema.json
+++ b/dist/formats/document_collection/notification/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "content_id",
@@ -17,12 +16,25 @@
     "title",
     "update_type"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -34,60 +46,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -252,60 +212,9 @@
         "written_statement"
       ]
     },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "document_collection"
-      ]
-    },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
-    },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
     "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "govuk_request_id": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
     },
     "expanded_links": {
       "type": "object",
@@ -314,39 +223,607 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "govuk_request_id": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "document_collection"
+      ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "base_path_less_frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "required": [
+        "first_public_at",
+        "collection_groups",
+        "government",
+        "political"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "body": {
+          "$ref": "#/definitions/body"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "collection_groups": {
+          "description": "The ordered list of collection groups",
+          "type": "array",
+          "items": {
+            "description": "Collection group",
+            "type": "object",
+            "required": [
+              "title",
+              "documents"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "body": {
+                "$ref": "#/definitions/body"
+              },
+              "documents": {
+                "description": "An ordered list of documents in this collection group",
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/guid"
+                }
+              },
+              "title": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "emphasised_organisations": {
+          "$ref": "#/definitions/emphasised_organisations"
+        },
+        "first_public_at": {
+          "$ref": "#/definitions/first_public_at"
+        },
+        "government": {
+          "$ref": "#/definitions/government"
+        },
+        "political": {
+          "$ref": "#/definitions/political"
+        },
+        "tags": {
+          "$ref": "#/definitions/tags"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "required": [
+        "title",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
     "frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "base_path",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
-          "document_type": {
-            "type": "string"
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
           },
-          "schema_name": {
-            "type": "string"
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
           },
-          "public_updated_at": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
             "type": "string"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
-            "type": "string"
+          "country": {
+            "$ref": "#/definitions/country"
           },
           "description": {
             "anyOf": [
@@ -358,36 +835,11 @@
               }
             ]
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "details": {
+            "type": "object",
+            "additionalProperties": true
           },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
+          "document_type": {
             "type": "string"
           },
           "links": {
@@ -397,175 +849,205 @@
                 "$ref": "#/definitions/frontend_links"
               }
             }
-          }
-        }
-      }
-    },
-    "base_path_less_frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "locale"
-        ],
-        "properties": {
-          "document_type": {
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
             "type": "string"
           },
           "schema_name": {
             "type": "string"
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
+          "title": {
+            "type": "string"
           },
           "web_url": {
             "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
             "type": "string",
             "format": "uri"
           },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
           },
-          "public_updated_at": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
             "type": "string"
           },
-          "content_id": {
-            "$ref": "#/definitions/guid"
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
           },
           "title": {
             "type": "string"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
           }
         }
       }
     },
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "first_public_at",
-        "collection_groups",
-        "government",
-        "political"
-      ],
-      "properties": {
-        "body": {
-          "$ref": "#/definitions/body"
-        },
-        "collection_groups": {
-          "description": "The ordered list of collection groups",
-          "type": "array",
-          "items": {
-            "description": "Collection group",
-            "type": "object",
-            "additionalProperties": false,
-            "required": [
-              "title",
-              "documents"
-            ],
-            "properties": {
-              "title": {
-                "type": "string"
-              },
-              "body": {
-                "$ref": "#/definitions/body"
-              },
-              "documents": {
-                "description": "An ordered list of documents in this collection group",
-                "type": "array",
-                "items": {
-                  "$ref": "#/definitions/guid"
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
                 }
               }
             }
-          }
-        },
-        "first_public_at": {
-          "$ref": "#/definitions/first_public_at"
-        },
-        "tags": {
-          "$ref": "#/definitions/tags"
-        },
-        "government": {
-          "$ref": "#/definitions/government"
-        },
-        "political": {
-          "$ref": "#/definitions/political"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        },
-        "emphasised_organisations": {
-          "$ref": "#/definitions/emphasised_organisations"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
+          },
+          "title": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/external_link"
-      }
-    },
-    "external_link": {
+    "image": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
+        "alt_text": {
           "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "url": {
           "type": "string",
@@ -576,17 +1058,17 @@
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -603,212 +1085,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -867,98 +1159,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -967,10 +1292,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -978,6 +1299,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -1000,79 +1325,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1084,13 +1538,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1098,61 +1546,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1160,418 +1571,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1581,9 +1585,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/document_collection/publisher_v2/links.json
+++ b/dist/formats/document_collection/publisher_v2/links.json
@@ -3,33 +3,12 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "previous_version": {
-      "type": "string"
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
         "documents": {
           "description": "An unordered list of all documents in this collection",
-          "$ref": "#/definitions/guid_list"
-        },
-        "topical_events": {
-          "$ref": "#/definitions/guid_list"
-        },
-        "related_policies": {
-          "$ref": "#/definitions/guid_list"
-        },
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/guid_list"
         },
         "mainstream_browse_pages": {
@@ -40,8 +19,12 @@
           "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/guid_list"
         },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
@@ -61,38 +44,56 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "related_policies": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/guid_list"
+        },
+        "topical_events": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
         }
       }
+    },
+    "previous_version": {
+      "type": "string"
     }
   },
   "definitions": {
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
     "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
       "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
     "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
         {
           "type": "string"
@@ -100,22 +101,158 @@
         {
           "type": "null"
         }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+      ]
     },
-    "external_related_links": {
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -126,20 +263,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -156,212 +626,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -420,98 +700,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -520,10 +833,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -531,6 +840,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -553,79 +866,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -637,13 +1079,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -651,61 +1087,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -713,418 +1112,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1134,9 +1126,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/document_collection/publisher_v2/schema.json
+++ b/dist/formats/document_collection/publisher_v2/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "title",
     "details",
@@ -13,12 +12,22 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "description": {
       "anyOf": [
@@ -30,84 +39,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "access_limited": {
-      "$ref": "#/definitions/access_limited"
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "change_note": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "previous_version": {
-      "type": "string"
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "links": {
-      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string",
@@ -272,26 +205,239 @@
         "written_statement"
       ]
     },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "document_collection"
       ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
-    "details": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
       "type": "object",
       "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
       "required": [
         "first_public_at",
         "collection_groups",
         "government",
         "political"
       ],
+      "additionalProperties": false,
       "properties": {
         "body": {
           "$ref": "#/definitions/body"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
         },
         "collection_groups": {
           "description": "The ordered list of collection groups",
@@ -299,15 +445,12 @@
           "items": {
             "description": "Collection group",
             "type": "object",
-            "additionalProperties": false,
             "required": [
               "title",
               "documents"
             ],
+            "additionalProperties": false,
             "properties": {
-              "title": {
-                "type": "string"
-              },
               "body": {
                 "$ref": "#/definitions/body"
               },
@@ -317,15 +460,18 @@
                 "items": {
                   "$ref": "#/definitions/guid"
                 }
+              },
+              "title": {
+                "type": "string"
               }
             }
           }
         },
+        "emphasised_organisations": {
+          "$ref": "#/definitions/emphasised_organisations"
+        },
         "first_public_at": {
           "$ref": "#/definitions/first_public_at"
-        },
-        "tags": {
-          "$ref": "#/definitions/tags"
         },
         "government": {
           "$ref": "#/definitions/government"
@@ -333,96 +479,55 @@
         "political": {
           "$ref": "#/definitions/political"
         },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        },
-        "emphasised_organisations": {
-          "$ref": "#/definitions/emphasised_organisations"
+        "tags": {
+          "$ref": "#/definitions/tags"
         }
       }
     },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "documents": {
-          "$ref": "#/definitions/guid_list"
-        },
-        "organisations": {
-          "$ref": "#/definitions/guid_list"
-        },
-        "parent": {
-          "$ref": "#/definitions/guid_list"
-        },
-        "primary_publishing_organisation": {
-          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
-          "$ref": "#/definitions/guid_list",
-          "maxItems": 1
-        },
-        "related_policies": {
-          "$ref": "#/definitions/guid_list"
-        },
-        "topical_events": {
-          "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "$ref": "#/definitions/guid_list"
-        },
-        "policy_areas": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -433,20 +538,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -463,212 +901,54 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
         }
       }
     },
-    "redirect_route": {
+    "links": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
       "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
+        "documents": {
+          "$ref": "#/definitions/guid_list"
         },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
+        "organisations": {
+          "$ref": "#/definitions/guid_list"
         },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
+        "parent": {
+          "$ref": "#/definitions/guid_list"
         },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "primary_publishing_organisation": {
+          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
+        },
+        "related_policies": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "topical_events": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "topics": {
+          "$ref": "#/definitions/guid_list"
         }
       }
     },
@@ -727,98 +1007,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -827,10 +1140,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -838,6 +1147,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -860,79 +1173,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -944,13 +1386,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -958,61 +1394,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1020,418 +1419,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1441,9 +1433,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/email_alert_signup/frontend/schema.json
+++ b/dist/formats/email_alert_signup/frontend/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "links",
@@ -12,12 +11,25 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -29,119 +41,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_pages": {
-          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "meets_user_needs": {
-          "description": "The user needs this piece of content meets.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "organisations": {
-          "description": "All organisations linked to this content item. This should include lead organisations.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "parent": {
-          "description": "The parent content item.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policy_areas": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "primary_publishing_organisation": {
-          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "available_translations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "children": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policies": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "document_collections": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "child_taxons": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -306,67 +207,657 @@
         "written_statement"
       ]
     },
+    "email_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "available_translations": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "policies": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policy_areas": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "primary_publishing_organisation": {
+          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "email_alert_signup"
       ]
     },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    "title": {
+      "type": "string"
     },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
-    "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
     },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "base_path_less_frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "required": [
+        "subscriber_list",
+        "summary"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "breadcrumbs": {
+          "$ref": "#/definitions/email_alert_signup_breadcrumbs"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "email_alert_type": {
+          "type": "string",
+          "enum": [
+            "topics",
+            "policies",
+            "countries"
+          ]
+        },
+        "govdelivery_title": {
+          "type": "string"
+        },
+        "subscriber_list": {
+          "description": "The attributes used to match subscriber lists in email-alert-api",
+          "type": "object",
+          "minProperties": 1,
+          "properties": {
+            "document_type": {
+              "description": "The document_type used to match subscribers lists",
+              "type": "string"
+            },
+            "links": {
+              "description": "The links used to match subscribers lists",
+              "type": "object",
+              "additionalProperties": false,
+              "maxProperties": 1,
+              "patternProperties": {
+                "^[a-z_]+$": {
+                  "type": "array"
+                }
+              }
+            },
+            "tags": {
+              "$ref": "#/definitions/tags"
+            }
+          }
+        },
+        "summary": {
+          "$ref": "#/definitions/email_alert_signup_summary"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "required": [
+        "title",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
     "frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "base_path",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
-          "document_type": {
-            "type": "string"
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
           },
-          "schema_name": {
-            "type": "string"
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
           },
-          "public_updated_at": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
             "type": "string"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
-            "type": "string"
+          "country": {
+            "$ref": "#/definitions/country"
           },
           "description": {
             "anyOf": [
@@ -378,36 +869,11 @@
               }
             ]
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "details": {
+            "type": "object",
+            "additionalProperties": true
           },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
+          "document_type": {
             "type": "string"
           },
           "links": {
@@ -417,169 +883,205 @@
                 "$ref": "#/definitions/frontend_links"
               }
             }
-          }
-        }
-      }
-    },
-    "base_path_less_frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "locale"
-        ],
-        "properties": {
-          "document_type": {
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
             "type": "string"
           },
           "schema_name": {
             "type": "string"
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
+          "title": {
+            "type": "string"
           },
           "web_url": {
             "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
             "type": "string",
             "format": "uri"
           },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
           },
-          "public_updated_at": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
             "type": "string"
           },
-          "content_id": {
-            "$ref": "#/definitions/guid"
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
           },
           "title": {
             "type": "string"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
           }
         }
       }
     },
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "subscriber_list",
-        "summary"
-      ],
-      "properties": {
-        "subscriber_list": {
-          "type": "object",
-          "description": "The attributes used to match subscriber lists in email-alert-api",
-          "minProperties": 1,
-          "properties": {
-            "tags": {
-              "$ref": "#/definitions/tags"
-            },
-            "links": {
-              "type": "object",
-              "description": "The links used to match subscribers lists",
-              "additionalProperties": false,
-              "maxProperties": 1,
-              "patternProperties": {
-                "^[a-z_]+$": {
-                  "type": "array"
-                }
-              }
-            },
-            "document_type": {
-              "type": "string",
-              "description": "The document_type used to match subscribers lists"
-            }
-          }
-        },
-        "email_alert_type": {
-          "type": "string",
-          "enum": [
-            "topics",
-            "policies",
-            "countries"
-          ]
-        },
-        "summary": {
-          "$ref": "#/definitions/email_alert_signup_summary"
-        },
-        "breadcrumbs": {
-          "$ref": "#/definitions/email_alert_signup_breadcrumbs"
-        },
-        "govdelivery_title": {
-          "type": "string"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
       }
     },
-    "external_link": {
+    "image": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
+        "alt_text": {
           "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "url": {
           "type": "string",
@@ -590,17 +1092,17 @@
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -617,212 +1119,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -881,98 +1193,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -981,10 +1326,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -992,6 +1333,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -1014,79 +1359,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1098,13 +1572,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1112,61 +1580,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1174,418 +1605,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1595,9 +1619,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/email_alert_signup/notification/schema.json
+++ b/dist/formats/email_alert_signup/notification/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "content_id",
@@ -17,12 +16,25 @@
     "title",
     "update_type"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -34,60 +46,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -252,60 +212,9 @@
         "written_statement"
       ]
     },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "email_alert_signup"
-      ]
-    },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
-    },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
     "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "govuk_request_id": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
     },
     "expanded_links": {
       "type": "object",
@@ -314,39 +223,601 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "govuk_request_id": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "email_alert_signup"
+      ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "base_path_less_frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "required": [
+        "subscriber_list",
+        "summary"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "breadcrumbs": {
+          "$ref": "#/definitions/email_alert_signup_breadcrumbs"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "email_alert_type": {
+          "type": "string",
+          "enum": [
+            "topics",
+            "policies",
+            "countries"
+          ]
+        },
+        "govdelivery_title": {
+          "type": "string"
+        },
+        "subscriber_list": {
+          "description": "The attributes used to match subscriber lists in email-alert-api",
+          "type": "object",
+          "minProperties": 1,
+          "properties": {
+            "document_type": {
+              "description": "The document_type used to match subscribers lists",
+              "type": "string"
+            },
+            "links": {
+              "description": "The links used to match subscribers lists",
+              "type": "object",
+              "additionalProperties": false,
+              "maxProperties": 1,
+              "patternProperties": {
+                "^[a-z_]+$": {
+                  "type": "array"
+                }
+              }
+            },
+            "tags": {
+              "$ref": "#/definitions/tags"
+            }
+          }
+        },
+        "summary": {
+          "$ref": "#/definitions/email_alert_signup_summary"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "required": [
+        "title",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
     "frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "base_path",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
-          "document_type": {
-            "type": "string"
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
           },
-          "schema_name": {
-            "type": "string"
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
           },
-          "public_updated_at": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
             "type": "string"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
-            "type": "string"
+          "country": {
+            "$ref": "#/definitions/country"
           },
           "description": {
             "anyOf": [
@@ -358,36 +829,11 @@
               }
             ]
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "details": {
+            "type": "object",
+            "additionalProperties": true
           },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
+          "document_type": {
             "type": "string"
           },
           "links": {
@@ -397,169 +843,205 @@
                 "$ref": "#/definitions/frontend_links"
               }
             }
-          }
-        }
-      }
-    },
-    "base_path_less_frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "locale"
-        ],
-        "properties": {
-          "document_type": {
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
             "type": "string"
           },
           "schema_name": {
             "type": "string"
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
+          "title": {
+            "type": "string"
           },
           "web_url": {
             "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
             "type": "string",
             "format": "uri"
           },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
           },
-          "public_updated_at": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
             "type": "string"
           },
-          "content_id": {
-            "$ref": "#/definitions/guid"
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
           },
           "title": {
             "type": "string"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
           }
         }
       }
     },
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "subscriber_list",
-        "summary"
-      ],
-      "properties": {
-        "subscriber_list": {
-          "type": "object",
-          "description": "The attributes used to match subscriber lists in email-alert-api",
-          "minProperties": 1,
-          "properties": {
-            "tags": {
-              "$ref": "#/definitions/tags"
-            },
-            "links": {
-              "type": "object",
-              "description": "The links used to match subscribers lists",
-              "additionalProperties": false,
-              "maxProperties": 1,
-              "patternProperties": {
-                "^[a-z_]+$": {
-                  "type": "array"
-                }
-              }
-            },
-            "document_type": {
-              "type": "string",
-              "description": "The document_type used to match subscribers lists"
-            }
-          }
-        },
-        "email_alert_type": {
-          "type": "string",
-          "enum": [
-            "topics",
-            "policies",
-            "countries"
-          ]
-        },
-        "summary": {
-          "$ref": "#/definitions/email_alert_signup_summary"
-        },
-        "breadcrumbs": {
-          "$ref": "#/definitions/email_alert_signup_breadcrumbs"
-        },
-        "govdelivery_title": {
-          "type": "string"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
       }
     },
-    "external_link": {
+    "image": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
+        "alt_text": {
           "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "url": {
           "type": "string",
@@ -570,17 +1052,17 @@
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -597,212 +1079,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -861,98 +1153,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -961,10 +1286,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -972,6 +1293,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -994,79 +1319,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1078,13 +1532,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1092,61 +1540,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1154,418 +1565,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1575,9 +1579,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/email_alert_signup/publisher_v2/links.json
+++ b/dist/formats/email_alert_signup/publisher_v2/links.json
@@ -3,25 +3,10 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "previous_version": {
-      "type": "string"
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/guid_list"
-        },
         "mainstream_browse_pages": {
           "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/guid_list"
@@ -30,8 +15,12 @@
           "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/guid_list"
         },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
@@ -51,38 +40,50 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/guid_list"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
         }
       }
+    },
+    "previous_version": {
+      "type": "string"
     }
   },
   "definitions": {
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
     "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
       "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
     "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
         {
           "type": "string"
@@ -90,22 +91,158 @@
         {
           "type": "null"
         }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+      ]
     },
-    "external_related_links": {
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -116,20 +253,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -146,212 +616,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -410,98 +690,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -510,10 +823,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -521,6 +830,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -543,79 +856,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -627,13 +1069,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -641,61 +1077,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -703,418 +1102,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1124,9 +1116,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/email_alert_signup/publisher_v2/schema.json
+++ b/dist/formats/email_alert_signup/publisher_v2/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "title",
     "details",
@@ -13,12 +12,22 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "description": {
       "anyOf": [
@@ -30,84 +39,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "access_limited": {
-      "$ref": "#/definitions/access_limited"
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "change_note": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "previous_version": {
-      "type": "string"
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "links": {
-      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string",
@@ -272,46 +205,234 @@
         "written_statement"
       ]
     },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "email_alert_signup"
       ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
-    "details": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
       "type": "object",
       "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
       "required": [
         "subscriber_list",
         "summary"
       ],
+      "additionalProperties": false,
       "properties": {
-        "subscriber_list": {
-          "type": "object",
-          "description": "The attributes used to match subscriber lists in email-alert-api",
-          "minProperties": 1,
-          "properties": {
-            "tags": {
-              "$ref": "#/definitions/tags"
-            },
-            "links": {
-              "type": "object",
-              "description": "The links used to match subscribers lists",
-              "additionalProperties": false,
-              "maxProperties": 1,
-              "patternProperties": {
-                "^[a-z_]+$": {
-                  "type": "array"
-                }
-              }
-            },
-            "document_type": {
-              "type": "string",
-              "description": "The document_type used to match subscribers lists"
-            }
-          }
+        "breadcrumbs": {
+          "$ref": "#/definitions/email_alert_signup_breadcrumbs"
         },
         "email_alert_type": {
           "type": "string",
@@ -321,76 +442,83 @@
             "countries"
           ]
         },
-        "summary": {
-          "$ref": "#/definitions/email_alert_signup_summary"
-        },
-        "breadcrumbs": {
-          "$ref": "#/definitions/email_alert_signup_breadcrumbs"
-        },
         "govdelivery_title": {
           "type": "string"
-        }
-      }
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policy_areas": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
+        },
+        "subscriber_list": {
+          "description": "The attributes used to match subscriber lists in email-alert-api",
+          "type": "object",
+          "minProperties": 1,
+          "properties": {
+            "document_type": {
+              "description": "The document_type used to match subscribers lists",
+              "type": "string"
+            },
+            "links": {
+              "description": "The links used to match subscribers lists",
+              "type": "object",
+              "additionalProperties": false,
+              "maxProperties": 1,
+              "patternProperties": {
+                "^[a-z_]+$": {
+                  "type": "array"
+                }
+              }
+            },
+            "tags": {
+              "$ref": "#/definitions/tags"
+            }
           }
         },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        "summary": {
+          "$ref": "#/definitions/email_alert_signup_summary"
         }
       }
     },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -401,20 +529,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -431,212 +892,31 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
         }
       }
     },
-    "redirect_route": {
+    "links": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
       "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
         }
       }
     },
@@ -695,98 +975,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -795,10 +1108,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -806,6 +1115,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -828,79 +1141,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -912,13 +1354,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -926,61 +1362,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -988,418 +1387,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1409,9 +1401,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/fatality_notice/frontend/schema.json
+++ b/dist/formats/fatality_notice/frontend/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "links",
@@ -12,12 +11,25 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -29,134 +41,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "field_of_operation": {
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ministers": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "roles": {
-          "description": "Used to power Email Alert Api subscriptions for Whitehall content",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "people": {
-          "description": "Used to power Email Alert Api subscriptions for Whitehall content",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_pages": {
-          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "meets_user_needs": {
-          "description": "The user needs this piece of content meets.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "organisations": {
-          "description": "All organisations linked to this content item. This should include lead organisations.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "parent": {
-          "description": "The parent content item.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policy_areas": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "primary_publishing_organisation": {
-          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "available_translations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "children": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policies": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "document_collections": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "child_taxons": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -321,67 +207,641 @@
         "written_statement"
       ]
     },
+    "email_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "available_translations": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "field_of_operation": {
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ministers": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "people": {
+          "description": "Used to power Email Alert Api subscriptions for Whitehall content",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policies": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policy_areas": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "primary_publishing_organisation": {
+          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "roles": {
+          "description": "Used to power Email Alert Api subscriptions for Whitehall content",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "fatality_notice"
       ]
     },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    "title": {
+      "type": "string"
     },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
-    "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
     },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "base_path_less_frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "required": [
+        "body",
+        "first_public_at",
+        "change_history",
+        "emphasised_organisations"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "body": {
+          "$ref": "#/definitions/body"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "emphasised_organisations": {
+          "$ref": "#/definitions/emphasised_organisations"
+        },
+        "first_public_at": {
+          "$ref": "#/definitions/first_public_at"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "required": [
+        "title",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
     "frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "base_path",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
-          "document_type": {
-            "type": "string"
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
           },
-          "schema_name": {
-            "type": "string"
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
           },
-          "public_updated_at": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
             "type": "string"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
-            "type": "string"
+          "country": {
+            "$ref": "#/definitions/country"
           },
           "description": {
             "anyOf": [
@@ -393,36 +853,11 @@
               }
             ]
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "details": {
+            "type": "object",
+            "additionalProperties": true
           },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
+          "document_type": {
             "type": "string"
           },
           "links": {
@@ -432,138 +867,205 @@
                 "$ref": "#/definitions/frontend_links"
               }
             }
-          }
-        }
-      }
-    },
-    "base_path_less_frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "locale"
-        ],
-        "properties": {
-          "document_type": {
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
             "type": "string"
           },
           "schema_name": {
             "type": "string"
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
+          "title": {
+            "type": "string"
           },
           "web_url": {
             "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
             "type": "string",
             "format": "uri"
           },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
           },
-          "public_updated_at": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
             "type": "string"
           },
-          "content_id": {
-            "$ref": "#/definitions/guid"
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
           },
           "title": {
             "type": "string"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
           }
         }
       }
     },
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "body",
-        "first_public_at",
-        "change_history",
-        "emphasised_organisations"
-      ],
-      "properties": {
-        "body": {
-          "$ref": "#/definitions/body"
-        },
-        "first_public_at": {
-          "$ref": "#/definitions/first_public_at"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        },
-        "emphasised_organisations": {
-          "$ref": "#/definitions/emphasised_organisations"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
       }
     },
-    "external_link": {
+    "image": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
+        "alt_text": {
           "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "url": {
           "type": "string",
@@ -574,17 +1076,17 @@
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -601,212 +1103,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -865,98 +1177,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -965,10 +1310,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -976,6 +1317,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -998,79 +1343,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1082,13 +1556,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1096,61 +1564,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1158,418 +1589,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1579,9 +1603,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/fatality_notice/notification/schema.json
+++ b/dist/formats/fatality_notice/notification/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "content_id",
@@ -17,12 +16,25 @@
     "title",
     "update_type"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -34,60 +46,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -252,60 +212,9 @@
         "written_statement"
       ]
     },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "fatality_notice"
-      ]
-    },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
-    },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
     "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "govuk_request_id": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
     },
     "expanded_links": {
       "type": "object",
@@ -314,39 +223,570 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "govuk_request_id": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "fatality_notice"
+      ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "base_path_less_frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "required": [
+        "body",
+        "first_public_at",
+        "change_history",
+        "emphasised_organisations"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "body": {
+          "$ref": "#/definitions/body"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "emphasised_organisations": {
+          "$ref": "#/definitions/emphasised_organisations"
+        },
+        "first_public_at": {
+          "$ref": "#/definitions/first_public_at"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "required": [
+        "title",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
     "frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "base_path",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
-          "document_type": {
-            "type": "string"
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
           },
-          "schema_name": {
-            "type": "string"
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
           },
-          "public_updated_at": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
             "type": "string"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
-            "type": "string"
+          "country": {
+            "$ref": "#/definitions/country"
           },
           "description": {
             "anyOf": [
@@ -358,36 +798,11 @@
               }
             ]
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "details": {
+            "type": "object",
+            "additionalProperties": true
           },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
+          "document_type": {
             "type": "string"
           },
           "links": {
@@ -397,138 +812,205 @@
                 "$ref": "#/definitions/frontend_links"
               }
             }
-          }
-        }
-      }
-    },
-    "base_path_less_frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "locale"
-        ],
-        "properties": {
-          "document_type": {
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
             "type": "string"
           },
           "schema_name": {
             "type": "string"
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
+          "title": {
+            "type": "string"
           },
           "web_url": {
             "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
             "type": "string",
             "format": "uri"
           },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
           },
-          "public_updated_at": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
             "type": "string"
           },
-          "content_id": {
-            "$ref": "#/definitions/guid"
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
           },
           "title": {
             "type": "string"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
           }
         }
       }
     },
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "body",
-        "first_public_at",
-        "change_history",
-        "emphasised_organisations"
-      ],
-      "properties": {
-        "body": {
-          "$ref": "#/definitions/body"
-        },
-        "first_public_at": {
-          "$ref": "#/definitions/first_public_at"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        },
-        "emphasised_organisations": {
-          "$ref": "#/definitions/emphasised_organisations"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
       }
     },
-    "external_link": {
+    "image": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
+        "alt_text": {
           "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "url": {
           "type": "string",
@@ -539,17 +1021,17 @@
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -566,212 +1048,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -830,98 +1122,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -930,10 +1255,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -941,6 +1262,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -963,79 +1288,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1047,13 +1501,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1061,61 +1509,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1123,418 +1534,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1544,9 +1548,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/fatality_notice/publisher_v2/links.json
+++ b/dist/formats/fatality_notice/publisher_v2/links.json
@@ -3,9 +3,6 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "previous_version": {
-      "type": "string"
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
@@ -15,29 +12,6 @@
           "maxItems": 1,
           "minItems": 1
         },
-        "ministers": {
-          "$ref": "#/definitions/guid_list"
-        },
-        "roles": {
-          "$ref": "#/definitions/guid_list",
-          "description": "Used to power Email Alert Api subscriptions for Whitehall content"
-        },
-        "people": {
-          "$ref": "#/definitions/guid_list",
-          "description": "Used to power Email Alert Api subscriptions for Whitehall content"
-        },
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/guid_list"
-        },
         "mainstream_browse_pages": {
           "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/guid_list"
@@ -46,8 +20,15 @@
           "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/guid_list"
         },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+        "ministers": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
@@ -59,6 +40,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "people": {
+          "description": "Used to power Email Alert Api subscriptions for Whitehall content",
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"
@@ -67,38 +52,54 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "roles": {
+          "description": "Used to power Email Alert Api subscriptions for Whitehall content",
+          "$ref": "#/definitions/guid_list"
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/guid_list"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
         }
       }
+    },
+    "previous_version": {
+      "type": "string"
     }
   },
   "definitions": {
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
     "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
       "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
     "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
         {
           "type": "string"
@@ -106,22 +107,158 @@
         {
           "type": "null"
         }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+      ]
     },
-    "external_related_links": {
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -132,20 +269,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -162,212 +632,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -426,98 +706,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -526,10 +839,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -537,6 +846,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -559,79 +872,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -643,13 +1085,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -657,61 +1093,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -719,418 +1118,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1140,9 +1132,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/fatality_notice/publisher_v2/schema.json
+++ b/dist/formats/fatality_notice/publisher_v2/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "title",
     "details",
@@ -13,12 +12,22 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "description": {
       "anyOf": [
@@ -30,84 +39,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "access_limited": {
-      "$ref": "#/definitions/access_limited"
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "change_note": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "previous_version": {
-      "type": "string"
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "links": {
-      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string",
@@ -272,35 +205,681 @@
         "written_statement"
       ]
     },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "fatality_notice"
       ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
-    "details": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
       "type": "object",
       "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
       "required": [
         "body",
         "first_public_at",
         "change_history",
         "emphasised_organisations"
       ],
+      "additionalProperties": false,
       "properties": {
         "body": {
           "$ref": "#/definitions/body"
-        },
-        "first_public_at": {
-          "$ref": "#/definitions/first_public_at"
         },
         "change_history": {
           "$ref": "#/definitions/change_history"
         },
         "emphasised_organisations": {
           "$ref": "#/definitions/emphasised_organisations"
+        },
+        "first_public_at": {
+          "$ref": "#/definitions/first_public_at"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "required": [
+        "title",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "required": [
+        "title",
+        "path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
+    },
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
+      "type": "object",
+      "required": [
+        "label",
+        "value"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "A human readable label",
+          "type": "string"
+        },
+        "value": {
+          "description": "A value to use for form controls",
+          "type": "string"
         }
       }
     },
@@ -321,8 +900,11 @@
           "$ref": "#/definitions/guid_list"
         },
         "people": {
-          "$ref": "#/definitions/guid_list",
-          "description": "Used to power Email Alert Api subscriptions for Whitehall content"
+          "description": "Used to power Email Alert Api subscriptions for Whitehall content",
+          "$ref": "#/definitions/guid_list"
+        },
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
         },
         "primary_publishing_organisation": {
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
@@ -330,310 +912,8 @@
           "maxItems": 1
         },
         "roles": {
-          "$ref": "#/definitions/guid_list",
-          "description": "Used to power Email Alert Api subscriptions for Whitehall content"
-        },
-        "policy_areas": {
+          "description": "Used to power Email Alert Api subscriptions for Whitehall content",
           "$ref": "#/definitions/guid_list"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/external_link"
-      }
-    },
-    "external_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "title",
-        "url"
-      ],
-      "properties": {
-        "title": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        }
-      }
-    },
-    "internal_link_without_guid": {
-      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "title",
-        "path"
-      ],
-      "properties": {
-        "title": {
-          "type": "string"
-        },
-        "path": {
-          "$ref": "#/definitions/absolute_fullpath"
-        }
-      }
-    },
-    "internal_or_external_link": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/external_link"
-        },
-        {
-          "$ref": "#/definitions/internal_link_without_guid"
-        },
-        {
-          "$ref": "#/definitions/guid"
-        }
-      ]
-    },
-    "government": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "title",
-        "slug",
-        "current"
-      ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url"
-      ],
-      "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
-          "type": "string"
-        },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
-          "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -692,98 +972,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -792,10 +1105,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -803,6 +1112,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -825,79 +1138,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -909,13 +1351,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -923,61 +1359,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -985,418 +1384,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1406,9 +1398,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/finder/frontend/schema.json
+++ b/dist/formats/finder/frontend/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "links",
@@ -12,12 +11,25 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -29,125 +41,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "related": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "email_alert_signup": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "available_translations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_pages": {
-          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "meets_user_needs": {
-          "description": "The user needs this piece of content meets.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "organisations": {
-          "description": "All organisations linked to this content item. This should include lead organisations.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "parent": {
-          "description": "The parent content item.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policy_areas": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "primary_publishing_organisation": {
-          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "children": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policies": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "document_collections": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "child_taxons": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -312,140 +207,268 @@
         "written_statement"
       ]
     },
+    "email_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "available_translations": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "email_alert_signup": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "policies": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policy_areas": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "primary_publishing_organisation": {
+          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "related": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "finder"
       ]
     },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    "title": {
+      "type": "string"
     },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
-    "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
     },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
-    "frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "base_path",
-          "locale"
-        ],
-        "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
-          },
-          "document_type": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
             "type": "string"
-          },
-          "schema_name": {
-            "type": "string"
-          },
-          "public_updated_at": {
-            "type": "string"
-          },
-          "content_id": {
-            "$ref": "#/definitions/guid"
-          },
-          "title": {
-            "type": "string"
-          },
-          "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
-            "type": "string"
-          },
-          "links": {
-            "type": "object",
-            "patternProperties": {
-              "^[a-z_]+$": {
-                "$ref": "#/definitions/frontend_links"
-              }
-            }
           }
         }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
       }
     },
     "base_path_less_frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "document_type": {
-            "type": "string"
-          },
-          "schema_name": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
           "api_path": {
             "$ref": "#/definitions/absolute_path"
@@ -455,36 +478,104 @@
             "type": "string",
             "format": "uri"
           },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "public_updated_at": {
-            "type": "string"
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
+          "document_type": {
             "type": "string"
           },
           "locale": {
             "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
           }
         }
       }
     },
     "details": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "document_noun",
         "facets"
       ],
+      "additionalProperties": false,
       "properties": {
         "beta": {
           "$ref": "#/definitions/finder_beta"
@@ -499,91 +590,85 @@
             }
           ]
         },
-        "document_noun": {
-          "$ref": "#/definitions/finder_document_noun"
+        "change_history": {
+          "$ref": "#/definitions/change_history"
         },
         "default_documents_per_page": {
           "$ref": "#/definitions/finder_default_documents_per_page"
         },
-        "logo_path": {
-          "type": "string"
-        },
         "default_order": {
           "$ref": "#/definitions/finder_default_order"
         },
-        "filter": {
-          "$ref": "#/definitions/finder_filter"
-        },
-        "reject": {
-          "$ref": "#/definitions/finder_reject_filter"
+        "document_noun": {
+          "$ref": "#/definitions/finder_document_noun"
         },
         "facets": {
           "$ref": "#/definitions/finder_facets"
         },
+        "filter": {
+          "$ref": "#/definitions/finder_filter"
+        },
         "format_name": {
           "type": "string"
+        },
+        "logo_path": {
+          "type": "string"
+        },
+        "reject": {
+          "$ref": "#/definitions/finder_reject_filter"
         },
         "show_summaries": {
           "$ref": "#/definitions/finder_show_summaries"
         },
         "summary": {
           "$ref": "#/definitions/finder_summary"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
         }
       }
     },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -594,20 +679,437 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "base_path",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
+            "type": "string"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "country": {
+            "$ref": "#/definitions/country"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "details": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "links": {
+            "type": "object",
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links"
+              }
+            }
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -624,212 +1126,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -888,98 +1200,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -988,10 +1333,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -999,6 +1340,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -1021,79 +1366,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1105,13 +1579,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1119,61 +1587,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1181,418 +1612,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1602,9 +1626,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/finder/notification/schema.json
+++ b/dist/formats/finder/notification/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "content_id",
@@ -17,12 +16,25 @@
     "title",
     "update_type"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -34,60 +46,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -252,60 +212,9 @@
         "written_statement"
       ]
     },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "finder"
-      ]
-    },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
-    },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
     "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "govuk_request_id": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
     },
     "expanded_links": {
       "type": "object",
@@ -314,112 +223,206 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "govuk_request_id": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "finder"
+      ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
-    "frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "base_path",
-          "locale"
-        ],
-        "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
-          },
-          "document_type": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
             "type": "string"
-          },
-          "schema_name": {
-            "type": "string"
-          },
-          "public_updated_at": {
-            "type": "string"
-          },
-          "content_id": {
-            "$ref": "#/definitions/guid"
-          },
-          "title": {
-            "type": "string"
-          },
-          "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
-            "type": "string"
-          },
-          "links": {
-            "type": "object",
-            "patternProperties": {
-              "^[a-z_]+$": {
-                "$ref": "#/definitions/frontend_links"
-              }
-            }
           }
         }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
       }
     },
     "base_path_less_frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "document_type": {
-            "type": "string"
-          },
-          "schema_name": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
           "api_path": {
             "$ref": "#/definitions/absolute_path"
@@ -429,36 +432,104 @@
             "type": "string",
             "format": "uri"
           },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "public_updated_at": {
-            "type": "string"
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
+          "document_type": {
             "type": "string"
           },
           "locale": {
             "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
           }
         }
       }
     },
     "details": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "document_noun",
         "facets"
       ],
+      "additionalProperties": false,
       "properties": {
         "beta": {
           "$ref": "#/definitions/finder_beta"
@@ -473,91 +544,85 @@
             }
           ]
         },
-        "document_noun": {
-          "$ref": "#/definitions/finder_document_noun"
+        "change_history": {
+          "$ref": "#/definitions/change_history"
         },
         "default_documents_per_page": {
           "$ref": "#/definitions/finder_default_documents_per_page"
         },
-        "logo_path": {
-          "type": "string"
-        },
         "default_order": {
           "$ref": "#/definitions/finder_default_order"
         },
-        "filter": {
-          "$ref": "#/definitions/finder_filter"
-        },
-        "reject": {
-          "$ref": "#/definitions/finder_reject_filter"
+        "document_noun": {
+          "$ref": "#/definitions/finder_document_noun"
         },
         "facets": {
           "$ref": "#/definitions/finder_facets"
         },
+        "filter": {
+          "$ref": "#/definitions/finder_filter"
+        },
         "format_name": {
           "type": "string"
+        },
+        "logo_path": {
+          "type": "string"
+        },
+        "reject": {
+          "$ref": "#/definitions/finder_reject_filter"
         },
         "show_summaries": {
           "$ref": "#/definitions/finder_show_summaries"
         },
         "summary": {
           "$ref": "#/definitions/finder_summary"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
         }
       }
     },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -568,20 +633,437 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "base_path",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
+            "type": "string"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "country": {
+            "$ref": "#/definitions/country"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "details": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "links": {
+            "type": "object",
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links"
+              }
+            }
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -598,212 +1080,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -862,98 +1154,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -962,10 +1287,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -973,6 +1294,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -995,79 +1320,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1079,13 +1533,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1093,61 +1541,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1155,418 +1566,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1576,9 +1580,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/finder/publisher_v2/links.json
+++ b/dist/formats/finder/publisher_v2/links.json
@@ -3,32 +3,14 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "previous_version": {
-      "type": "string"
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "related": {
-          "$ref": "#/definitions/guid_list"
-        },
-        "email_alert_signup": {
-          "$ref": "#/definitions/guid_list"
-        },
         "available_translations": {
           "$ref": "#/definitions/guid_list"
         },
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
+        "email_alert_signup": {
           "$ref": "#/definitions/guid_list"
         },
         "mainstream_browse_pages": {
@@ -39,8 +21,12 @@
           "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/guid_list"
         },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
@@ -60,38 +46,53 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "related": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/guid_list"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
         }
       }
+    },
+    "previous_version": {
+      "type": "string"
     }
   },
   "definitions": {
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
     "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
       "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
     "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
         {
           "type": "string"
@@ -99,22 +100,158 @@
         {
           "type": "null"
         }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+      ]
     },
-    "external_related_links": {
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -125,20 +262,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -155,212 +625,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -419,98 +699,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -519,10 +832,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -530,6 +839,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -552,79 +865,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -636,13 +1078,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -650,61 +1086,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -712,418 +1111,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1133,9 +1125,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/finder/publisher_v2/schema.json
+++ b/dist/formats/finder/publisher_v2/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "title",
     "details",
@@ -13,12 +12,22 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "description": {
       "anyOf": [
@@ -30,84 +39,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "access_limited": {
-      "$ref": "#/definitions/access_limited"
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "change_note": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "previous_version": {
-      "type": "string"
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "links": {
-      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string",
@@ -272,21 +205,231 @@
         "written_statement"
       ]
     },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "finder"
       ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
-    "details": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
       "type": "object",
       "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
       "required": [
         "document_noun",
         "facets"
       ],
+      "additionalProperties": false,
       "properties": {
         "beta": {
           "$ref": "#/definitions/finder_beta"
@@ -301,29 +444,29 @@
             }
           ]
         },
-        "document_noun": {
-          "$ref": "#/definitions/finder_document_noun"
-        },
         "default_documents_per_page": {
           "$ref": "#/definitions/finder_default_documents_per_page"
-        },
-        "logo_path": {
-          "type": "string"
         },
         "default_order": {
           "$ref": "#/definitions/finder_default_order"
         },
-        "filter": {
-          "$ref": "#/definitions/finder_filter"
-        },
-        "reject": {
-          "$ref": "#/definitions/finder_reject_filter"
+        "document_noun": {
+          "$ref": "#/definitions/finder_document_noun"
         },
         "facets": {
           "$ref": "#/definitions/finder_facets"
         },
+        "filter": {
+          "$ref": "#/definitions/finder_filter"
+        },
         "format_name": {
           "type": "string"
+        },
+        "logo_path": {
+          "type": "string"
+        },
+        "reject": {
+          "$ref": "#/definitions/finder_reject_filter"
         },
         "show_summaries": {
           "$ref": "#/definitions/finder_show_summaries"
@@ -333,65 +476,50 @@
         }
       }
     },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policy_areas": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -402,20 +530,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -432,212 +893,31 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
         }
       }
     },
-    "redirect_route": {
+    "links": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
       "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
         }
       }
     },
@@ -696,98 +976,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -796,10 +1109,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -807,6 +1116,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -829,79 +1142,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -913,13 +1355,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -927,61 +1363,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -989,418 +1388,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1410,9 +1402,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/finder_email_signup/frontend/schema.json
+++ b/dist/formats/finder_email_signup/frontend/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "links",
@@ -12,12 +11,25 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -29,122 +41,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "related": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "organisations": {
-          "description": "All organisations linked to this content item. This should include lead organisations.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_pages": {
-          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "meets_user_needs": {
-          "description": "The user needs this piece of content meets.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "parent": {
-          "description": "The parent content item.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policy_areas": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "primary_publishing_organisation": {
-          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "available_translations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "children": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policies": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "document_collections": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "child_taxons": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -309,140 +207,265 @@
         "written_statement"
       ]
     },
+    "email_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "available_translations": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "policies": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policy_areas": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "primary_publishing_organisation": {
+          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "related": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "finder_email_signup"
       ]
     },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    "title": {
+      "type": "string"
     },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
-    "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
     },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
-    "frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "base_path",
-          "locale"
-        ],
-        "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
-          },
-          "document_type": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
             "type": "string"
-          },
-          "schema_name": {
-            "type": "string"
-          },
-          "public_updated_at": {
-            "type": "string"
-          },
-          "content_id": {
-            "$ref": "#/definitions/guid"
-          },
-          "title": {
-            "type": "string"
-          },
-          "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
-            "type": "string"
-          },
-          "links": {
-            "type": "object",
-            "patternProperties": {
-              "^[a-z_]+$": {
-                "$ref": "#/definitions/frontend_links"
-              }
-            }
           }
         }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
       }
     },
     "base_path_less_frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "document_type": {
-            "type": "string"
-          },
-          "schema_name": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
           "api_path": {
             "$ref": "#/definitions/absolute_path"
@@ -452,66 +475,111 @@
             "type": "string",
             "format": "uri"
           },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "public_updated_at": {
-            "type": "string"
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
+          "document_type": {
             "type": "string"
           },
           "locale": {
             "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
           }
         }
       }
     },
     "details": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "email_signup_choice",
         "email_filter_by",
         "subscription_list_title_prefix"
       ],
+      "additionalProperties": false,
       "properties": {
         "beta": {
           "$ref": "#/definitions/finder_beta"
         },
-        "email_signup_choice": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "required": [
-              "key",
-              "radio_button_name",
-              "topic_name",
-              "prechecked"
-            ],
-            "properties": {
-              "key": {
-                "type": "string"
-              },
-              "radio_button_name": {
-                "type": "string"
-              },
-              "topic_name": {
-                "type": "string"
-              },
-              "prechecked": {
-                "type": "boolean"
-              }
-            }
-          }
+        "change_history": {
+          "$ref": "#/definitions/change_history"
         },
         "email_filter_by": {
           "oneOf": [
@@ -544,18 +612,44 @@
             }
           ]
         },
+        "email_signup_choice": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "key",
+              "radio_button_name",
+              "topic_name",
+              "prechecked"
+            ],
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "prechecked": {
+                "type": "boolean"
+              },
+              "radio_button_name": {
+                "type": "string"
+              },
+              "topic_name": {
+                "type": "string"
+              }
+            }
+          }
+        },
         "subscription_list_title_prefix": {
           "oneOf": [
             {
               "type": "object",
               "properties": {
+                "many": {
+                  "type": "string"
+                },
                 "plural": {
                   "type": "string"
                 },
                 "singular": {
-                  "type": "string"
-                },
-                "many": {
                   "type": "string"
                 }
               }
@@ -564,62 +658,53 @@
               "type": "string"
             }
           ]
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
         }
       }
     },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -630,20 +715,437 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "base_path",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
+            "type": "string"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "country": {
+            "$ref": "#/definitions/country"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "details": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "links": {
+            "type": "object",
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links"
+              }
+            }
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -660,212 +1162,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -924,98 +1236,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -1024,10 +1369,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -1035,6 +1376,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -1057,79 +1402,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1141,13 +1615,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1155,61 +1623,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1217,418 +1648,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1638,9 +1662,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/finder_email_signup/notification/schema.json
+++ b/dist/formats/finder_email_signup/notification/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "content_id",
@@ -17,12 +16,25 @@
     "title",
     "update_type"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -34,60 +46,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -252,60 +212,9 @@
         "written_statement"
       ]
     },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "finder_email_signup"
-      ]
-    },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
-    },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
     "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "govuk_request_id": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
     },
     "expanded_links": {
       "type": "object",
@@ -314,112 +223,206 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "govuk_request_id": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "finder_email_signup"
+      ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
-    "frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "base_path",
-          "locale"
-        ],
-        "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
-          },
-          "document_type": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
             "type": "string"
-          },
-          "schema_name": {
-            "type": "string"
-          },
-          "public_updated_at": {
-            "type": "string"
-          },
-          "content_id": {
-            "$ref": "#/definitions/guid"
-          },
-          "title": {
-            "type": "string"
-          },
-          "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
-            "type": "string"
-          },
-          "links": {
-            "type": "object",
-            "patternProperties": {
-              "^[a-z_]+$": {
-                "$ref": "#/definitions/frontend_links"
-              }
-            }
           }
         }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
       }
     },
     "base_path_less_frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "document_type": {
-            "type": "string"
-          },
-          "schema_name": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
           "api_path": {
             "$ref": "#/definitions/absolute_path"
@@ -429,66 +432,111 @@
             "type": "string",
             "format": "uri"
           },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "public_updated_at": {
-            "type": "string"
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
+          "document_type": {
             "type": "string"
           },
           "locale": {
             "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
           }
         }
       }
     },
     "details": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "email_signup_choice",
         "email_filter_by",
         "subscription_list_title_prefix"
       ],
+      "additionalProperties": false,
       "properties": {
         "beta": {
           "$ref": "#/definitions/finder_beta"
         },
-        "email_signup_choice": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "required": [
-              "key",
-              "radio_button_name",
-              "topic_name",
-              "prechecked"
-            ],
-            "properties": {
-              "key": {
-                "type": "string"
-              },
-              "radio_button_name": {
-                "type": "string"
-              },
-              "topic_name": {
-                "type": "string"
-              },
-              "prechecked": {
-                "type": "boolean"
-              }
-            }
-          }
+        "change_history": {
+          "$ref": "#/definitions/change_history"
         },
         "email_filter_by": {
           "oneOf": [
@@ -521,18 +569,44 @@
             }
           ]
         },
+        "email_signup_choice": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "key",
+              "radio_button_name",
+              "topic_name",
+              "prechecked"
+            ],
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "prechecked": {
+                "type": "boolean"
+              },
+              "radio_button_name": {
+                "type": "string"
+              },
+              "topic_name": {
+                "type": "string"
+              }
+            }
+          }
+        },
         "subscription_list_title_prefix": {
           "oneOf": [
             {
               "type": "object",
               "properties": {
+                "many": {
+                  "type": "string"
+                },
                 "plural": {
                   "type": "string"
                 },
                 "singular": {
-                  "type": "string"
-                },
-                "many": {
                   "type": "string"
                 }
               }
@@ -541,62 +615,53 @@
               "type": "string"
             }
           ]
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
         }
       }
     },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -607,20 +672,437 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "base_path",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
+            "type": "string"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "country": {
+            "$ref": "#/definitions/country"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "details": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "links": {
+            "type": "object",
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links"
+              }
+            }
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -637,212 +1119,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -901,98 +1193,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -1001,10 +1326,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -1012,6 +1333,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -1034,79 +1359,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1118,13 +1572,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1132,61 +1580,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1194,418 +1605,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1615,9 +1619,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/finder_email_signup/publisher_v2/links.json
+++ b/dist/formats/finder_email_signup/publisher_v2/links.json
@@ -3,22 +3,16 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "previous_version": {
-      "type": "string"
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "related": {
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         },
-        "organisations": {
-          "description": "All organisations linked to this content item. This should include lead organisations.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
+        "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/guid_list"
         },
         "ordered_related_items": {
@@ -29,16 +23,8 @@
           "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/guid_list"
         },
-        "mainstream_browse_pages": {
-          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "meets_user_needs": {
-          "description": "The user needs this piece of content meets.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {
@@ -54,38 +40,53 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "related": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/guid_list"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
         }
       }
+    },
+    "previous_version": {
+      "type": "string"
     }
   },
   "definitions": {
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
     "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
       "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
     "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
         {
           "type": "string"
@@ -93,22 +94,158 @@
         {
           "type": "null"
         }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+      ]
     },
-    "external_related_links": {
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -119,20 +256,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -149,212 +619,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -413,98 +693,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -513,10 +826,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -524,6 +833,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -546,79 +859,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -630,13 +1072,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -644,61 +1080,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -706,418 +1105,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1127,9 +1119,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/finder_email_signup/publisher_v2/schema.json
+++ b/dist/formats/finder_email_signup/publisher_v2/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "title",
     "details",
@@ -13,12 +12,22 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "description": {
       "anyOf": [
@@ -30,84 +39,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "access_limited": {
-      "$ref": "#/definitions/access_limited"
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "change_note": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "previous_version": {
-      "type": "string"
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "links": {
-      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string",
@@ -272,51 +205,235 @@
         "written_statement"
       ]
     },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "finder_email_signup"
       ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
-    "details": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
       "type": "object",
       "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
       "required": [
         "email_signup_choice",
         "email_filter_by",
         "subscription_list_title_prefix"
       ],
+      "additionalProperties": false,
       "properties": {
         "beta": {
           "$ref": "#/definitions/finder_beta"
-        },
-        "email_signup_choice": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "required": [
-              "key",
-              "radio_button_name",
-              "topic_name",
-              "prechecked"
-            ],
-            "properties": {
-              "key": {
-                "type": "string"
-              },
-              "radio_button_name": {
-                "type": "string"
-              },
-              "topic_name": {
-                "type": "string"
-              },
-              "prechecked": {
-                "type": "boolean"
-              }
-            }
-          }
         },
         "email_filter_by": {
           "oneOf": [
@@ -349,18 +466,44 @@
             }
           ]
         },
+        "email_signup_choice": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "key",
+              "radio_button_name",
+              "topic_name",
+              "prechecked"
+            ],
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "prechecked": {
+                "type": "boolean"
+              },
+              "radio_button_name": {
+                "type": "string"
+              },
+              "topic_name": {
+                "type": "string"
+              }
+            }
+          }
+        },
         "subscription_list_title_prefix": {
           "oneOf": [
             {
               "type": "object",
               "properties": {
+                "many": {
+                  "type": "string"
+                },
                 "plural": {
                   "type": "string"
                 },
                 "singular": {
-                  "type": "string"
-                },
-                "many": {
                   "type": "string"
                 }
               }
@@ -372,65 +515,50 @@
         }
       }
     },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policy_areas": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -441,20 +569,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -471,212 +932,31 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
         }
       }
     },
-    "redirect_route": {
+    "links": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
       "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
         }
       }
     },
@@ -735,98 +1015,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -835,10 +1148,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -846,6 +1155,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -868,79 +1181,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -952,13 +1394,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -966,61 +1402,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1028,418 +1427,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1449,9 +1441,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/generic/frontend/schema.json
+++ b/dist/formats/generic/frontend/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "links",
@@ -12,12 +11,25 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -29,119 +41,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_pages": {
-          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "meets_user_needs": {
-          "description": "The user needs this piece of content meets.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "organisations": {
-          "description": "All organisations linked to this content item. This should include lead organisations.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "parent": {
-          "description": "The parent content item.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policy_areas": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "primary_publishing_organisation": {
-          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "available_translations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "children": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policies": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "document_collections": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "child_taxons": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -306,140 +207,262 @@
         "written_statement"
       ]
     },
+    "email_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "available_translations": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "policies": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policy_areas": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "primary_publishing_organisation": {
+          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "generic"
       ]
     },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    "title": {
+      "type": "string"
     },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
-    "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
     },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
-    "frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "base_path",
-          "locale"
-        ],
-        "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
-          },
-          "document_type": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
             "type": "string"
-          },
-          "schema_name": {
-            "type": "string"
-          },
-          "public_updated_at": {
-            "type": "string"
-          },
-          "content_id": {
-            "$ref": "#/definitions/guid"
-          },
-          "title": {
-            "type": "string"
-          },
-          "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
-            "type": "string"
-          },
-          "links": {
-            "type": "object",
-            "patternProperties": {
-              "^[a-z_]+$": {
-                "$ref": "#/definitions/frontend_links"
-              }
-            }
           }
         }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
       }
     },
     "base_path_less_frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "document_type": {
-            "type": "string"
-          },
-          "schema_name": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
           "api_path": {
             "$ref": "#/definitions/absolute_path"
@@ -449,25 +472,93 @@
             "type": "string",
             "format": "uri"
           },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "public_updated_at": {
-            "type": "string"
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
+          "document_type": {
             "type": "string"
           },
           "locale": {
             "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
           }
         }
       }
@@ -481,56 +572,50 @@
         }
       }
     },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
     },
-    "external_related_links": {
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -541,20 +626,437 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "base_path",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
+            "type": "string"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "country": {
+            "$ref": "#/definitions/country"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "details": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "links": {
+            "type": "object",
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links"
+              }
+            }
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -571,212 +1073,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -835,98 +1147,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -935,10 +1280,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -946,6 +1287,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -968,79 +1313,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1052,13 +1526,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1066,61 +1534,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1128,418 +1559,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1549,9 +1573,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/generic/notification/schema.json
+++ b/dist/formats/generic/notification/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "content_id",
@@ -17,12 +16,25 @@
     "title",
     "update_type"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -34,60 +46,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -252,60 +212,9 @@
         "written_statement"
       ]
     },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "generic"
-      ]
-    },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
-    },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
     "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "govuk_request_id": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
     },
     "expanded_links": {
       "type": "object",
@@ -314,112 +223,206 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "govuk_request_id": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "generic"
+      ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
-    "frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "base_path",
-          "locale"
-        ],
-        "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
-          },
-          "document_type": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
             "type": "string"
-          },
-          "schema_name": {
-            "type": "string"
-          },
-          "public_updated_at": {
-            "type": "string"
-          },
-          "content_id": {
-            "$ref": "#/definitions/guid"
-          },
-          "title": {
-            "type": "string"
-          },
-          "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
-            "type": "string"
-          },
-          "links": {
-            "type": "object",
-            "patternProperties": {
-              "^[a-z_]+$": {
-                "$ref": "#/definitions/frontend_links"
-              }
-            }
           }
         }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
       }
     },
     "base_path_less_frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "document_type": {
-            "type": "string"
-          },
-          "schema_name": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
           "api_path": {
             "$ref": "#/definitions/absolute_path"
@@ -429,25 +432,93 @@
             "type": "string",
             "format": "uri"
           },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "public_updated_at": {
-            "type": "string"
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
+          "document_type": {
             "type": "string"
           },
           "locale": {
             "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
           }
         }
       }
@@ -461,56 +532,50 @@
         }
       }
     },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
     },
-    "external_related_links": {
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -521,20 +586,437 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "base_path",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
+            "type": "string"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "country": {
+            "$ref": "#/definitions/country"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "details": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "links": {
+            "type": "object",
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links"
+              }
+            }
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -551,212 +1033,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -815,98 +1107,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -915,10 +1240,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -926,6 +1247,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -948,79 +1273,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1032,13 +1486,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1046,61 +1494,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1108,418 +1519,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1529,9 +1533,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/generic/publisher_v2/links.json
+++ b/dist/formats/generic/publisher_v2/links.json
@@ -3,25 +3,10 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "previous_version": {
-      "type": "string"
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/guid_list"
-        },
         "mainstream_browse_pages": {
           "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/guid_list"
@@ -30,8 +15,12 @@
           "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/guid_list"
         },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
@@ -51,38 +40,50 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/guid_list"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
         }
       }
+    },
+    "previous_version": {
+      "type": "string"
     }
   },
   "definitions": {
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
     "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
       "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
     "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
         {
           "type": "string"
@@ -90,22 +91,158 @@
         {
           "type": "null"
         }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+      ]
     },
-    "external_related_links": {
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -116,20 +253,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -146,212 +616,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -410,98 +690,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -510,10 +823,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -521,6 +830,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -543,79 +856,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -627,13 +1069,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -641,61 +1077,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -703,418 +1102,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1124,9 +1116,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/generic/publisher_v2/schema.json
+++ b/dist/formats/generic/publisher_v2/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "title",
     "details",
@@ -13,12 +12,22 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "description": {
       "anyOf": [
@@ -30,84 +39,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "access_limited": {
-      "$ref": "#/definitions/access_limited"
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "change_note": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "previous_version": {
-      "type": "string"
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "links": {
-      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string",
@@ -272,56 +205,109 @@
         "written_statement"
       ]
     },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "generic"
       ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-      }
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policy_areas": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
     },
     "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
       "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
     "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
         {
           "type": "string"
@@ -329,22 +315,164 @@
         {
           "type": "null"
         }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+      ]
     },
-    "external_related_links": {
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -355,20 +483,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -385,212 +846,31 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
         }
       }
     },
-    "redirect_route": {
+    "links": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
       "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
         }
       }
     },
@@ -649,98 +929,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -749,10 +1062,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -760,6 +1069,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -782,79 +1095,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -866,13 +1308,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -880,61 +1316,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -942,418 +1341,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1363,9 +1355,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/generic_with_external_related_links/frontend/schema.json
+++ b/dist/formats/generic_with_external_related_links/frontend/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "links",
@@ -12,12 +11,25 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -29,119 +41,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_pages": {
-          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "meets_user_needs": {
-          "description": "The user needs this piece of content meets.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "organisations": {
-          "description": "All organisations linked to this content item. This should include lead organisations.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "parent": {
-          "description": "The parent content item.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policy_areas": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "primary_publishing_organisation": {
-          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "available_translations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "children": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policies": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "document_collections": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "child_taxons": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -306,67 +207,614 @@
         "written_statement"
       ]
     },
+    "email_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "available_translations": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "policies": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policy_areas": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "primary_publishing_organisation": {
+          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "generic_with_external_related_links"
       ]
     },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    "title": {
+      "type": "string"
     },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
-    "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
     },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "base_path_less_frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "external_related_links": {
+          "$ref": "#/definitions/external_related_links"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "required": [
+        "title",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
     "frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "base_path",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
-          "document_type": {
-            "type": "string"
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
           },
-          "schema_name": {
-            "type": "string"
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
           },
-          "public_updated_at": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
             "type": "string"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
-            "type": "string"
+          "country": {
+            "$ref": "#/definitions/country"
           },
           "description": {
             "anyOf": [
@@ -378,36 +826,11 @@
               }
             ]
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "details": {
+            "type": "object",
+            "additionalProperties": true
           },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
+          "document_type": {
             "type": "string"
           },
           "links": {
@@ -417,126 +840,205 @@
                 "$ref": "#/definitions/frontend_links"
               }
             }
-          }
-        }
-      }
-    },
-    "base_path_less_frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "locale"
-        ],
-        "properties": {
-          "document_type": {
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
             "type": "string"
           },
           "schema_name": {
             "type": "string"
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
+          "title": {
+            "type": "string"
           },
           "web_url": {
             "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
             "type": "string",
             "format": "uri"
           },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
           },
-          "public_updated_at": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
             "type": "string"
           },
-          "content_id": {
-            "$ref": "#/definitions/guid"
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
           },
           "title": {
             "type": "string"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
           }
         }
       }
     },
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "external_related_links": {
-          "$ref": "#/definitions/external_related_links"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
       }
     },
-    "external_link": {
+    "image": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
+        "alt_text": {
           "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "url": {
           "type": "string",
@@ -547,17 +1049,17 @@
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -574,212 +1076,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -838,98 +1150,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -938,10 +1283,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -949,6 +1290,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -971,79 +1316,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1055,13 +1529,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1069,61 +1537,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1131,418 +1562,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1552,9 +1576,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/generic_with_external_related_links/notification/schema.json
+++ b/dist/formats/generic_with_external_related_links/notification/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "content_id",
@@ -17,12 +16,25 @@
     "title",
     "update_type"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -34,60 +46,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -252,60 +212,9 @@
         "written_statement"
       ]
     },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "generic_with_external_related_links"
-      ]
-    },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
-    },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
     "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "govuk_request_id": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
     },
     "expanded_links": {
       "type": "object",
@@ -314,39 +223,558 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "govuk_request_id": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "generic_with_external_related_links"
+      ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "base_path_less_frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "external_related_links": {
+          "$ref": "#/definitions/external_related_links"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "required": [
+        "title",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
     "frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "base_path",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
-          "document_type": {
-            "type": "string"
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
           },
-          "schema_name": {
-            "type": "string"
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
           },
-          "public_updated_at": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
             "type": "string"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
-            "type": "string"
+          "country": {
+            "$ref": "#/definitions/country"
           },
           "description": {
             "anyOf": [
@@ -358,36 +786,11 @@
               }
             ]
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "details": {
+            "type": "object",
+            "additionalProperties": true
           },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
+          "document_type": {
             "type": "string"
           },
           "links": {
@@ -397,126 +800,205 @@
                 "$ref": "#/definitions/frontend_links"
               }
             }
-          }
-        }
-      }
-    },
-    "base_path_less_frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "locale"
-        ],
-        "properties": {
-          "document_type": {
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
             "type": "string"
           },
           "schema_name": {
             "type": "string"
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
+          "title": {
+            "type": "string"
           },
           "web_url": {
             "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
             "type": "string",
             "format": "uri"
           },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
           },
-          "public_updated_at": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
             "type": "string"
           },
-          "content_id": {
-            "$ref": "#/definitions/guid"
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
           },
           "title": {
             "type": "string"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
           }
         }
       }
     },
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "external_related_links": {
-          "$ref": "#/definitions/external_related_links"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
       }
     },
-    "external_link": {
+    "image": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
+        "alt_text": {
           "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "url": {
           "type": "string",
@@ -527,17 +1009,17 @@
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -554,212 +1036,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -818,98 +1110,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -918,10 +1243,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -929,6 +1250,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -951,79 +1276,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1035,13 +1489,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1049,61 +1497,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1111,418 +1522,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1532,9 +1536,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/generic_with_external_related_links/publisher_v2/links.json
+++ b/dist/formats/generic_with_external_related_links/publisher_v2/links.json
@@ -3,25 +3,10 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "previous_version": {
-      "type": "string"
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/guid_list"
-        },
         "mainstream_browse_pages": {
           "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/guid_list"
@@ -30,8 +15,12 @@
           "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/guid_list"
         },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
@@ -51,38 +40,50 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/guid_list"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
         }
       }
+    },
+    "previous_version": {
+      "type": "string"
     }
   },
   "definitions": {
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
     "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
       "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
     "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
         {
           "type": "string"
@@ -90,22 +91,158 @@
         {
           "type": "null"
         }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+      ]
     },
-    "external_related_links": {
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -116,20 +253,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -146,212 +616,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -410,98 +690,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -510,10 +823,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -521,6 +830,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -543,79 +856,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -627,13 +1069,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -641,61 +1077,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -703,418 +1102,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1124,9 +1116,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
+++ b/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "title",
     "details",
@@ -13,12 +12,22 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "description": {
       "anyOf": [
@@ -30,84 +39,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "access_limited": {
-      "$ref": "#/definitions/access_limited"
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "change_note": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "previous_version": {
-      "type": "string"
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "links": {
-      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string",
@@ -272,14 +205,224 @@
         "written_statement"
       ]
     },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "generic_with_external_related_links"
       ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,
@@ -289,65 +432,50 @@
         }
       }
     },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policy_areas": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -358,20 +486,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -388,212 +849,31 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
         }
       }
     },
-    "redirect_route": {
+    "links": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
       "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
         }
       }
     },
@@ -652,98 +932,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -752,10 +1065,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -763,6 +1072,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -785,79 +1098,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -869,13 +1311,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -883,61 +1319,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -945,418 +1344,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1366,9 +1358,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/guide/frontend/schema.json
+++ b/dist/formats/guide/frontend/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "links",
@@ -12,12 +11,25 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -29,119 +41,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_pages": {
-          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "meets_user_needs": {
-          "description": "The user needs this piece of content meets.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "organisations": {
-          "description": "All organisations linked to this content item. This should include lead organisations.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "parent": {
-          "description": "The parent content item.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policy_areas": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "primary_publishing_organisation": {
-          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "available_translations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "children": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policies": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "document_collections": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "child_taxons": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -306,67 +207,618 @@
         "written_statement"
       ]
     },
+    "email_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "available_translations": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "policies": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policy_areas": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "primary_publishing_organisation": {
+          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "guide"
       ]
     },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    "title": {
+      "type": "string"
     },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
-    "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
     },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "base_path_less_frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "external_related_links": {
+          "$ref": "#/definitions/external_related_links"
+        },
+        "parts": {
+          "description": "List of guide parts",
+          "$ref": "#/definitions/parts"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "required": [
+        "title",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
     "frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "base_path",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
-          "document_type": {
-            "type": "string"
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
           },
-          "schema_name": {
-            "type": "string"
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
           },
-          "public_updated_at": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
             "type": "string"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
-            "type": "string"
+          "country": {
+            "$ref": "#/definitions/country"
           },
           "description": {
             "anyOf": [
@@ -378,36 +830,11 @@
               }
             ]
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "details": {
+            "type": "object",
+            "additionalProperties": true
           },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
+          "document_type": {
             "type": "string"
           },
           "links": {
@@ -417,130 +844,205 @@
                 "$ref": "#/definitions/frontend_links"
               }
             }
-          }
-        }
-      }
-    },
-    "base_path_less_frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "locale"
-        ],
-        "properties": {
-          "document_type": {
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
             "type": "string"
           },
           "schema_name": {
             "type": "string"
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
+          "title": {
+            "type": "string"
           },
           "web_url": {
             "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
             "type": "string",
             "format": "uri"
           },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
           },
-          "public_updated_at": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
             "type": "string"
           },
-          "content_id": {
-            "$ref": "#/definitions/guid"
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
           },
           "title": {
             "type": "string"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
           }
         }
       }
     },
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "parts": {
-          "description": "List of guide parts",
-          "$ref": "#/definitions/parts"
-        },
-        "external_related_links": {
-          "$ref": "#/definitions/external_related_links"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
       }
     },
-    "external_link": {
+    "image": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
+        "alt_text": {
           "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "url": {
           "type": "string",
@@ -551,17 +1053,17 @@
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -578,212 +1080,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -842,98 +1154,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -942,10 +1287,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -953,6 +1294,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -975,79 +1320,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1059,13 +1533,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1073,61 +1541,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1135,418 +1566,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1556,9 +1580,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/guide/notification/schema.json
+++ b/dist/formats/guide/notification/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "content_id",
@@ -17,12 +16,25 @@
     "title",
     "update_type"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -34,60 +46,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -252,60 +212,9 @@
         "written_statement"
       ]
     },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "guide"
-      ]
-    },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
-    },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
     "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "govuk_request_id": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
     },
     "expanded_links": {
       "type": "object",
@@ -314,39 +223,562 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "govuk_request_id": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "guide"
+      ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "base_path_less_frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "external_related_links": {
+          "$ref": "#/definitions/external_related_links"
+        },
+        "parts": {
+          "description": "List of guide parts",
+          "$ref": "#/definitions/parts"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "required": [
+        "title",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
     "frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "base_path",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
-          "document_type": {
-            "type": "string"
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
           },
-          "schema_name": {
-            "type": "string"
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
           },
-          "public_updated_at": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
             "type": "string"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
-            "type": "string"
+          "country": {
+            "$ref": "#/definitions/country"
           },
           "description": {
             "anyOf": [
@@ -358,36 +790,11 @@
               }
             ]
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "details": {
+            "type": "object",
+            "additionalProperties": true
           },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
+          "document_type": {
             "type": "string"
           },
           "links": {
@@ -397,130 +804,205 @@
                 "$ref": "#/definitions/frontend_links"
               }
             }
-          }
-        }
-      }
-    },
-    "base_path_less_frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "locale"
-        ],
-        "properties": {
-          "document_type": {
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
             "type": "string"
           },
           "schema_name": {
             "type": "string"
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
+          "title": {
+            "type": "string"
           },
           "web_url": {
             "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
             "type": "string",
             "format": "uri"
           },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
           },
-          "public_updated_at": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
             "type": "string"
           },
-          "content_id": {
-            "$ref": "#/definitions/guid"
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
           },
           "title": {
             "type": "string"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
           }
         }
       }
     },
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "parts": {
-          "description": "List of guide parts",
-          "$ref": "#/definitions/parts"
-        },
-        "external_related_links": {
-          "$ref": "#/definitions/external_related_links"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
       }
     },
-    "external_link": {
+    "image": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
+        "alt_text": {
           "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "url": {
           "type": "string",
@@ -531,17 +1013,17 @@
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -558,212 +1040,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -822,98 +1114,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -922,10 +1247,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -933,6 +1254,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -955,79 +1280,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1039,13 +1493,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1053,61 +1501,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1115,418 +1526,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1536,9 +1540,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/guide/publisher_v2/links.json
+++ b/dist/formats/guide/publisher_v2/links.json
@@ -3,25 +3,10 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "previous_version": {
-      "type": "string"
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/guid_list"
-        },
         "mainstream_browse_pages": {
           "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/guid_list"
@@ -30,8 +15,12 @@
           "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/guid_list"
         },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
@@ -51,38 +40,50 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/guid_list"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
         }
       }
+    },
+    "previous_version": {
+      "type": "string"
     }
   },
   "definitions": {
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
     "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
       "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
     "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
         {
           "type": "string"
@@ -90,22 +91,158 @@
         {
           "type": "null"
         }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+      ]
     },
-    "external_related_links": {
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -116,20 +253,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -146,212 +616,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -410,98 +690,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -510,10 +823,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -521,6 +830,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -543,79 +856,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -627,13 +1069,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -641,61 +1077,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -703,418 +1102,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1124,9 +1116,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/guide/publisher_v2/schema.json
+++ b/dist/formats/guide/publisher_v2/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "title",
     "details",
@@ -13,12 +12,22 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "description": {
       "anyOf": [
@@ -30,84 +39,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "access_limited": {
-      "$ref": "#/definitions/access_limited"
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "change_note": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "previous_version": {
-      "type": "string"
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "links": {
-      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string",
@@ -272,63 +205,109 @@
         "written_statement"
       ]
     },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "guide"
       ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "parts": {
-          "description": "List of guide parts",
-          "$ref": "#/definitions/parts"
-        },
-        "external_related_links": {
-          "$ref": "#/definitions/external_related_links"
-        }
-      }
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policy_areas": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
     },
     "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
       "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
     "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
         {
           "type": "string"
@@ -336,22 +315,171 @@
         {
           "type": "null"
         }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+      ]
     },
-    "external_related_links": {
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "external_related_links": {
+          "$ref": "#/definitions/external_related_links"
+        },
+        "parts": {
+          "description": "List of guide parts",
+          "$ref": "#/definitions/parts"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -362,20 +490,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -392,212 +853,31 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
         }
       }
     },
-    "redirect_route": {
+    "links": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
       "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
         }
       }
     },
@@ -656,98 +936,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -756,10 +1069,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -767,6 +1076,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -789,79 +1102,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -873,13 +1315,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -887,61 +1323,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -949,418 +1348,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1370,9 +1362,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/help_page/frontend/schema.json
+++ b/dist/formats/help_page/frontend/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "links",
@@ -12,12 +11,25 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -29,119 +41,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_pages": {
-          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "meets_user_needs": {
-          "description": "The user needs this piece of content meets.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "organisations": {
-          "description": "All organisations linked to this content item. This should include lead organisations.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "parent": {
-          "description": "The parent content item.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policy_areas": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "primary_publishing_organisation": {
-          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "available_translations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "children": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policies": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "document_collections": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "child_taxons": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -306,140 +207,262 @@
         "written_statement"
       ]
     },
+    "email_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "available_translations": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "policies": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policy_areas": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "primary_publishing_organisation": {
+          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "help_page"
       ]
     },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    "title": {
+      "type": "string"
     },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
-    "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
     },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
-    "frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "base_path",
-          "locale"
-        ],
-        "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
-          },
-          "document_type": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
             "type": "string"
-          },
-          "schema_name": {
-            "type": "string"
-          },
-          "public_updated_at": {
-            "type": "string"
-          },
-          "content_id": {
-            "$ref": "#/definitions/guid"
-          },
-          "title": {
-            "type": "string"
-          },
-          "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
-            "type": "string"
-          },
-          "links": {
-            "type": "object",
-            "patternProperties": {
-              "^[a-z_]+$": {
-                "$ref": "#/definitions/frontend_links"
-              }
-            }
           }
         }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
       }
     },
     "base_path_less_frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "document_type": {
-            "type": "string"
-          },
-          "schema_name": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
           "api_path": {
             "$ref": "#/definitions/absolute_path"
@@ -449,25 +472,93 @@
             "type": "string",
             "format": "uri"
           },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "public_updated_at": {
-            "type": "string"
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
+          "document_type": {
             "type": "string"
           },
           "locale": {
             "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
           }
         }
       }
@@ -479,64 +570,58 @@
         "body": {
           "$ref": "#/definitions/body_html_and_govspeak"
         },
-        "external_related_links": {
-          "$ref": "#/definitions/external_related_links"
-        },
         "change_history": {
           "$ref": "#/definitions/change_history"
+        },
+        "external_related_links": {
+          "$ref": "#/definitions/external_related_links"
         }
       }
     },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -547,20 +632,437 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "base_path",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
+            "type": "string"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "country": {
+            "$ref": "#/definitions/country"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "details": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "links": {
+            "type": "object",
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links"
+              }
+            }
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -577,212 +1079,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -841,98 +1153,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -941,10 +1286,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -952,6 +1293,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -974,79 +1319,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1058,13 +1532,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1072,61 +1540,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1134,418 +1565,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1555,9 +1579,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/help_page/notification/schema.json
+++ b/dist/formats/help_page/notification/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "content_id",
@@ -17,12 +16,25 @@
     "title",
     "update_type"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -34,60 +46,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -252,60 +212,9 @@
         "written_statement"
       ]
     },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "help_page"
-      ]
-    },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
-    },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
     "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "govuk_request_id": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
     },
     "expanded_links": {
       "type": "object",
@@ -314,112 +223,206 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "govuk_request_id": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "help_page"
+      ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
-    "frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "base_path",
-          "locale"
-        ],
-        "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
-          },
-          "document_type": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
             "type": "string"
-          },
-          "schema_name": {
-            "type": "string"
-          },
-          "public_updated_at": {
-            "type": "string"
-          },
-          "content_id": {
-            "$ref": "#/definitions/guid"
-          },
-          "title": {
-            "type": "string"
-          },
-          "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
-            "type": "string"
-          },
-          "links": {
-            "type": "object",
-            "patternProperties": {
-              "^[a-z_]+$": {
-                "$ref": "#/definitions/frontend_links"
-              }
-            }
           }
         }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
       }
     },
     "base_path_less_frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "document_type": {
-            "type": "string"
-          },
-          "schema_name": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
           "api_path": {
             "$ref": "#/definitions/absolute_path"
@@ -429,25 +432,93 @@
             "type": "string",
             "format": "uri"
           },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "public_updated_at": {
-            "type": "string"
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
+          "document_type": {
             "type": "string"
           },
           "locale": {
             "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
           }
         }
       }
@@ -459,64 +530,58 @@
         "body": {
           "$ref": "#/definitions/body_html_and_govspeak"
         },
-        "external_related_links": {
-          "$ref": "#/definitions/external_related_links"
-        },
         "change_history": {
           "$ref": "#/definitions/change_history"
+        },
+        "external_related_links": {
+          "$ref": "#/definitions/external_related_links"
         }
       }
     },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -527,20 +592,437 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "base_path",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
+            "type": "string"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "country": {
+            "$ref": "#/definitions/country"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "details": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "links": {
+            "type": "object",
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links"
+              }
+            }
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -557,212 +1039,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -821,98 +1113,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -921,10 +1246,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -932,6 +1253,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -954,79 +1279,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1038,13 +1492,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1052,61 +1500,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1114,418 +1525,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1535,9 +1539,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/help_page/publisher_v2/links.json
+++ b/dist/formats/help_page/publisher_v2/links.json
@@ -3,25 +3,10 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "previous_version": {
-      "type": "string"
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/guid_list"
-        },
         "mainstream_browse_pages": {
           "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/guid_list"
@@ -30,8 +15,12 @@
           "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/guid_list"
         },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
@@ -51,38 +40,50 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/guid_list"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
         }
       }
+    },
+    "previous_version": {
+      "type": "string"
     }
   },
   "definitions": {
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
     "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
       "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
     "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
         {
           "type": "string"
@@ -90,22 +91,158 @@
         {
           "type": "null"
         }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+      ]
     },
-    "external_related_links": {
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -116,20 +253,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -146,212 +616,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -410,98 +690,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -510,10 +823,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -521,6 +830,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -543,79 +856,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -627,13 +1069,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -641,61 +1077,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -703,418 +1102,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1124,9 +1116,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/help_page/publisher_v2/schema.json
+++ b/dist/formats/help_page/publisher_v2/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "title",
     "details",
@@ -13,12 +12,22 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "description": {
       "anyOf": [
@@ -30,84 +39,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "access_limited": {
-      "$ref": "#/definitions/access_limited"
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "change_note": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "previous_version": {
-      "type": "string"
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "links": {
-      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string",
@@ -272,14 +205,224 @@
         "written_statement"
       ]
     },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "help_page"
       ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,
@@ -292,65 +435,50 @@
         }
       }
     },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policy_areas": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -361,20 +489,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -391,212 +852,31 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
         }
       }
     },
-    "redirect_route": {
+    "links": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
       "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
         }
       }
     },
@@ -655,98 +935,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -755,10 +1068,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -766,6 +1075,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -788,79 +1101,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -872,13 +1314,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -886,61 +1322,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -948,418 +1347,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1369,9 +1361,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/hmrc_manual/frontend/schema.json
+++ b/dist/formats/hmrc_manual/frontend/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "links",
@@ -12,12 +11,25 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -29,119 +41,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_pages": {
-          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "meets_user_needs": {
-          "description": "The user needs this piece of content meets.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "organisations": {
-          "description": "All organisations linked to this content item. This should include lead organisations.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "parent": {
-          "description": "The parent content item.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policy_areas": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "primary_publishing_organisation": {
-          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "available_translations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "children": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policies": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "document_collections": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "child_taxons": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -306,67 +207,629 @@
         "written_statement"
       ]
     },
+    "email_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "available_translations": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "policies": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policy_areas": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "primary_publishing_organisation": {
+          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "hmrc_manual"
       ]
     },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    "title": {
+      "type": "string"
     },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
-    "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
     },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "base_path_less_frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "required": [
+        "child_section_groups"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "body": {
+          "$ref": "#/definitions/body"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "change_notes": {
+          "$ref": "#/definitions/hmrc_manual_change_notes"
+        },
+        "child_section_groups": {
+          "$ref": "#/definitions/hmrc_manual_child_section_groups"
+        },
+        "organisations": {
+          "$ref": "#/definitions/manual_organisations"
+        },
+        "tags": {
+          "$ref": "#/definitions/tags"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "required": [
+        "title",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
     "frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "base_path",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
-          "document_type": {
-            "type": "string"
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
           },
-          "schema_name": {
-            "type": "string"
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
           },
-          "public_updated_at": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
             "type": "string"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
-            "type": "string"
+          "country": {
+            "$ref": "#/definitions/country"
           },
           "description": {
             "anyOf": [
@@ -378,36 +841,11 @@
               }
             ]
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "details": {
+            "type": "object",
+            "additionalProperties": true
           },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
+          "document_type": {
             "type": "string"
           },
           "links": {
@@ -417,141 +855,205 @@
                 "$ref": "#/definitions/frontend_links"
               }
             }
-          }
-        }
-      }
-    },
-    "base_path_less_frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "locale"
-        ],
-        "properties": {
-          "document_type": {
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
             "type": "string"
           },
           "schema_name": {
             "type": "string"
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
+          "title": {
+            "type": "string"
           },
           "web_url": {
             "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
             "type": "string",
             "format": "uri"
           },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
           },
-          "public_updated_at": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
             "type": "string"
           },
-          "content_id": {
-            "$ref": "#/definitions/guid"
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
           },
           "title": {
             "type": "string"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
           }
         }
       }
     },
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "child_section_groups"
-      ],
-      "properties": {
-        "body": {
-          "$ref": "#/definitions/body"
-        },
-        "child_section_groups": {
-          "$ref": "#/definitions/hmrc_manual_child_section_groups"
-        },
-        "change_notes": {
-          "$ref": "#/definitions/hmrc_manual_change_notes"
-        },
-        "organisations": {
-          "$ref": "#/definitions/manual_organisations"
-        },
-        "tags": {
-          "$ref": "#/definitions/tags"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
       }
     },
-    "external_link": {
+    "image": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
+        "alt_text": {
           "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "url": {
           "type": "string",
@@ -562,17 +1064,17 @@
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -589,212 +1091,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -853,98 +1165,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -953,10 +1298,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -964,6 +1305,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -986,79 +1331,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1070,13 +1544,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1084,61 +1552,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1146,418 +1577,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1567,9 +1591,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/hmrc_manual/notification/schema.json
+++ b/dist/formats/hmrc_manual/notification/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "content_id",
@@ -17,12 +16,25 @@
     "title",
     "update_type"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -34,60 +46,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -252,60 +212,9 @@
         "written_statement"
       ]
     },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "hmrc_manual"
-      ]
-    },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
-    },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
     "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "govuk_request_id": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
     },
     "expanded_links": {
       "type": "object",
@@ -314,39 +223,573 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "govuk_request_id": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "hmrc_manual"
+      ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "base_path_less_frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "required": [
+        "child_section_groups"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "body": {
+          "$ref": "#/definitions/body"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "change_notes": {
+          "$ref": "#/definitions/hmrc_manual_change_notes"
+        },
+        "child_section_groups": {
+          "$ref": "#/definitions/hmrc_manual_child_section_groups"
+        },
+        "organisations": {
+          "$ref": "#/definitions/manual_organisations"
+        },
+        "tags": {
+          "$ref": "#/definitions/tags"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "required": [
+        "title",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
     "frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "base_path",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
-          "document_type": {
-            "type": "string"
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
           },
-          "schema_name": {
-            "type": "string"
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
           },
-          "public_updated_at": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
             "type": "string"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
-            "type": "string"
+          "country": {
+            "$ref": "#/definitions/country"
           },
           "description": {
             "anyOf": [
@@ -358,36 +801,11 @@
               }
             ]
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "details": {
+            "type": "object",
+            "additionalProperties": true
           },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
+          "document_type": {
             "type": "string"
           },
           "links": {
@@ -397,141 +815,205 @@
                 "$ref": "#/definitions/frontend_links"
               }
             }
-          }
-        }
-      }
-    },
-    "base_path_less_frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "locale"
-        ],
-        "properties": {
-          "document_type": {
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
             "type": "string"
           },
           "schema_name": {
             "type": "string"
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
+          "title": {
+            "type": "string"
           },
           "web_url": {
             "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
             "type": "string",
             "format": "uri"
           },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
           },
-          "public_updated_at": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
             "type": "string"
           },
-          "content_id": {
-            "$ref": "#/definitions/guid"
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
           },
           "title": {
             "type": "string"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
           }
         }
       }
     },
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "child_section_groups"
-      ],
-      "properties": {
-        "body": {
-          "$ref": "#/definitions/body"
-        },
-        "child_section_groups": {
-          "$ref": "#/definitions/hmrc_manual_child_section_groups"
-        },
-        "change_notes": {
-          "$ref": "#/definitions/hmrc_manual_change_notes"
-        },
-        "organisations": {
-          "$ref": "#/definitions/manual_organisations"
-        },
-        "tags": {
-          "$ref": "#/definitions/tags"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
       }
     },
-    "external_link": {
+    "image": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
+        "alt_text": {
           "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "url": {
           "type": "string",
@@ -542,17 +1024,17 @@
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -569,212 +1051,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -833,98 +1125,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -933,10 +1258,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -944,6 +1265,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -966,79 +1291,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1050,13 +1504,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1064,61 +1512,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1126,418 +1537,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1547,9 +1551,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/hmrc_manual/publisher_v2/links.json
+++ b/dist/formats/hmrc_manual/publisher_v2/links.json
@@ -3,25 +3,10 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "previous_version": {
-      "type": "string"
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/guid_list"
-        },
         "mainstream_browse_pages": {
           "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/guid_list"
@@ -30,8 +15,12 @@
           "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/guid_list"
         },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
@@ -51,38 +40,50 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/guid_list"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
         }
       }
+    },
+    "previous_version": {
+      "type": "string"
     }
   },
   "definitions": {
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
     "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
       "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
     "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
         {
           "type": "string"
@@ -90,22 +91,158 @@
         {
           "type": "null"
         }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+      ]
     },
-    "external_related_links": {
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -116,20 +253,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -146,212 +616,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -410,98 +690,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -510,10 +823,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -521,6 +830,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -543,79 +856,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -627,13 +1069,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -641,61 +1077,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -703,418 +1102,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1124,9 +1116,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/hmrc_manual/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual/publisher_v2/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "title",
     "details",
@@ -13,12 +12,22 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "description": {
       "anyOf": [
@@ -30,84 +39,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "access_limited": {
-      "$ref": "#/definitions/access_limited"
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "change_note": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "previous_version": {
-      "type": "string"
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "links": {
-      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string",
@@ -272,29 +205,239 @@
         "written_statement"
       ]
     },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "hmrc_manual"
       ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
-    "details": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
       "type": "object",
       "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
       "required": [
         "child_section_groups"
       ],
+      "additionalProperties": false,
       "properties": {
         "body": {
           "$ref": "#/definitions/body"
         },
-        "child_section_groups": {
-          "$ref": "#/definitions/hmrc_manual_child_section_groups"
-        },
         "change_notes": {
           "$ref": "#/definitions/hmrc_manual_change_notes"
+        },
+        "child_section_groups": {
+          "$ref": "#/definitions/hmrc_manual_child_section_groups"
         },
         "organisations": {
           "$ref": "#/definitions/manual_organisations"
@@ -304,65 +447,50 @@
         }
       }
     },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policy_areas": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -373,20 +501,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -403,212 +864,31 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
         }
       }
     },
-    "redirect_route": {
+    "links": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
       "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
         }
       }
     },
@@ -667,98 +947,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -767,10 +1080,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -778,6 +1087,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -800,79 +1113,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -884,13 +1326,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -898,61 +1334,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -960,418 +1359,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1381,9 +1373,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "links",
@@ -12,12 +11,25 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -29,119 +41,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_pages": {
-          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "meets_user_needs": {
-          "description": "The user needs this piece of content meets.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "organisations": {
-          "description": "All organisations linked to this content item. This should include lead organisations.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "parent": {
-          "description": "The parent content item.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policy_areas": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "primary_publishing_organisation": {
-          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "available_translations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "children": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policies": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "document_collections": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "child_taxons": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -306,67 +207,633 @@
         "written_statement"
       ]
     },
+    "email_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "available_translations": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "policies": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policy_areas": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "primary_publishing_organisation": {
+          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "hmrc_manual_section"
       ]
     },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    "title": {
+      "type": "string"
     },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
-    "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
     },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "base_path_less_frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "required": [
+        "section_id",
+        "manual"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "body": {
+          "$ref": "#/definitions/body"
+        },
+        "breadcrumbs": {
+          "$ref": "#/definitions/hmrc_manual_breadcrumbs"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "child_section_groups": {
+          "$ref": "#/definitions/hmrc_manual_child_section_groups"
+        },
+        "manual": {
+          "$ref": "#/definitions/manual_section_parent"
+        },
+        "organisations": {
+          "$ref": "#/definitions/manual_organisations"
+        },
+        "section_id": {
+          "type": "string"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "required": [
+        "title",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
     "frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "base_path",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
-          "document_type": {
-            "type": "string"
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
           },
-          "schema_name": {
-            "type": "string"
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
           },
-          "public_updated_at": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
             "type": "string"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
-            "type": "string"
+          "country": {
+            "$ref": "#/definitions/country"
           },
           "description": {
             "anyOf": [
@@ -378,36 +845,11 @@
               }
             ]
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "details": {
+            "type": "object",
+            "additionalProperties": true
           },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
+          "document_type": {
             "type": "string"
           },
           "links": {
@@ -417,145 +859,205 @@
                 "$ref": "#/definitions/frontend_links"
               }
             }
-          }
-        }
-      }
-    },
-    "base_path_less_frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "locale"
-        ],
-        "properties": {
-          "document_type": {
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
             "type": "string"
           },
           "schema_name": {
             "type": "string"
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
+          "title": {
+            "type": "string"
           },
           "web_url": {
             "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
             "type": "string",
             "format": "uri"
           },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
           },
-          "public_updated_at": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
             "type": "string"
           },
-          "content_id": {
-            "$ref": "#/definitions/guid"
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
           },
           "title": {
             "type": "string"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
           }
         }
       }
     },
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "section_id",
-        "manual"
-      ],
-      "properties": {
-        "section_id": {
-          "type": "string"
-        },
-        "breadcrumbs": {
-          "$ref": "#/definitions/hmrc_manual_breadcrumbs"
-        },
-        "body": {
-          "$ref": "#/definitions/body"
-        },
-        "manual": {
-          "$ref": "#/definitions/manual_section_parent"
-        },
-        "organisations": {
-          "$ref": "#/definitions/manual_organisations"
-        },
-        "child_section_groups": {
-          "$ref": "#/definitions/hmrc_manual_child_section_groups"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
       }
     },
-    "external_link": {
+    "image": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
+        "alt_text": {
           "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "url": {
           "type": "string",
@@ -566,17 +1068,17 @@
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -593,212 +1095,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -857,98 +1169,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -957,10 +1302,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -968,6 +1309,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -990,79 +1335,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1074,13 +1548,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1088,61 +1556,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1150,418 +1581,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1571,9 +1595,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/hmrc_manual_section/notification/schema.json
+++ b/dist/formats/hmrc_manual_section/notification/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "content_id",
@@ -17,12 +16,25 @@
     "title",
     "update_type"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -34,60 +46,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -252,60 +212,9 @@
         "written_statement"
       ]
     },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "hmrc_manual_section"
-      ]
-    },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
-    },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
     "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "govuk_request_id": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
     },
     "expanded_links": {
       "type": "object",
@@ -314,39 +223,577 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "govuk_request_id": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "hmrc_manual_section"
+      ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "base_path_less_frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "required": [
+        "section_id",
+        "manual"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "body": {
+          "$ref": "#/definitions/body"
+        },
+        "breadcrumbs": {
+          "$ref": "#/definitions/hmrc_manual_breadcrumbs"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "child_section_groups": {
+          "$ref": "#/definitions/hmrc_manual_child_section_groups"
+        },
+        "manual": {
+          "$ref": "#/definitions/manual_section_parent"
+        },
+        "organisations": {
+          "$ref": "#/definitions/manual_organisations"
+        },
+        "section_id": {
+          "type": "string"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "required": [
+        "title",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
     "frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "base_path",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
-          "document_type": {
-            "type": "string"
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
           },
-          "schema_name": {
-            "type": "string"
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
           },
-          "public_updated_at": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
             "type": "string"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
-            "type": "string"
+          "country": {
+            "$ref": "#/definitions/country"
           },
           "description": {
             "anyOf": [
@@ -358,36 +805,11 @@
               }
             ]
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "details": {
+            "type": "object",
+            "additionalProperties": true
           },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
+          "document_type": {
             "type": "string"
           },
           "links": {
@@ -397,145 +819,205 @@
                 "$ref": "#/definitions/frontend_links"
               }
             }
-          }
-        }
-      }
-    },
-    "base_path_less_frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "locale"
-        ],
-        "properties": {
-          "document_type": {
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
             "type": "string"
           },
           "schema_name": {
             "type": "string"
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
+          "title": {
+            "type": "string"
           },
           "web_url": {
             "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
             "type": "string",
             "format": "uri"
           },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
           },
-          "public_updated_at": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
             "type": "string"
           },
-          "content_id": {
-            "$ref": "#/definitions/guid"
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
           },
           "title": {
             "type": "string"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
           }
         }
       }
     },
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "section_id",
-        "manual"
-      ],
-      "properties": {
-        "section_id": {
-          "type": "string"
-        },
-        "breadcrumbs": {
-          "$ref": "#/definitions/hmrc_manual_breadcrumbs"
-        },
-        "body": {
-          "$ref": "#/definitions/body"
-        },
-        "manual": {
-          "$ref": "#/definitions/manual_section_parent"
-        },
-        "organisations": {
-          "$ref": "#/definitions/manual_organisations"
-        },
-        "child_section_groups": {
-          "$ref": "#/definitions/hmrc_manual_child_section_groups"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
       }
     },
-    "external_link": {
+    "image": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
+        "alt_text": {
           "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "url": {
           "type": "string",
@@ -546,17 +1028,17 @@
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -573,212 +1055,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -837,98 +1129,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -937,10 +1262,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -948,6 +1269,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -970,79 +1295,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1054,13 +1508,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1068,61 +1516,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1130,418 +1541,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1551,9 +1555,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/hmrc_manual_section/publisher_v2/links.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/links.json
@@ -3,25 +3,10 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "previous_version": {
-      "type": "string"
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/guid_list"
-        },
         "mainstream_browse_pages": {
           "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/guid_list"
@@ -30,8 +15,12 @@
           "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/guid_list"
         },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
@@ -51,38 +40,50 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/guid_list"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
         }
       }
+    },
+    "previous_version": {
+      "type": "string"
     }
   },
   "definitions": {
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
     "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
       "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
     "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
         {
           "type": "string"
@@ -90,22 +91,158 @@
         {
           "type": "null"
         }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+      ]
     },
-    "external_related_links": {
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -116,20 +253,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -146,212 +616,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -410,98 +690,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -510,10 +823,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -521,6 +830,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -543,79 +856,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -627,13 +1069,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -641,61 +1077,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -703,418 +1102,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1124,9 +1116,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/hmrc_manual_section/publisher_v2/schema.json
+++ b/dist/formats/hmrc_manual_section/publisher_v2/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "title",
     "details",
@@ -13,12 +12,22 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "description": {
       "anyOf": [
@@ -30,84 +39,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "access_limited": {
-      "$ref": "#/definitions/access_limited"
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "change_note": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "previous_version": {
-      "type": "string"
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "links": {
-      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string",
@@ -272,78 +205,109 @@
         "written_statement"
       ]
     },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "hmrc_manual_section"
       ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "section_id",
-        "manual"
-      ],
-      "properties": {
-        "section_id": {
-          "type": "string"
-        },
-        "breadcrumbs": {
-          "$ref": "#/definitions/hmrc_manual_breadcrumbs"
-        },
-        "body": {
-          "$ref": "#/definitions/body"
-        },
-        "manual": {
-          "$ref": "#/definitions/manual_section_parent"
-        },
-        "organisations": {
-          "$ref": "#/definitions/manual_organisations"
-        },
-        "child_section_groups": {
-          "$ref": "#/definitions/hmrc_manual_child_section_groups"
-        }
-      }
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policy_areas": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
     },
     "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
       "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
     "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
         {
           "type": "string"
@@ -351,22 +315,186 @@
         {
           "type": "null"
         }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+      ]
     },
-    "external_related_links": {
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "required": [
+        "section_id",
+        "manual"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "body": {
+          "$ref": "#/definitions/body"
+        },
+        "breadcrumbs": {
+          "$ref": "#/definitions/hmrc_manual_breadcrumbs"
+        },
+        "child_section_groups": {
+          "$ref": "#/definitions/hmrc_manual_child_section_groups"
+        },
+        "manual": {
+          "$ref": "#/definitions/manual_section_parent"
+        },
+        "organisations": {
+          "$ref": "#/definitions/manual_organisations"
+        },
+        "section_id": {
+          "type": "string"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -377,20 +505,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -407,212 +868,31 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
         }
       }
     },
-    "redirect_route": {
+    "links": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
       "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
         }
       }
     },
@@ -671,98 +951,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -771,10 +1084,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -782,6 +1091,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -804,79 +1117,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -888,13 +1330,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -902,61 +1338,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -964,418 +1363,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1385,9 +1377,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/homepage/frontend/schema.json
+++ b/dist/formats/homepage/frontend/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "links",
@@ -12,12 +11,25 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -29,123 +41,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "root_taxons": {
-          "description": "Defines a set of Taxonomy trees rooted in this node.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_pages": {
-          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "meets_user_needs": {
-          "description": "The user needs this piece of content meets.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "organisations": {
-          "description": "All organisations linked to this content item. This should include lead organisations.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "parent": {
-          "description": "The parent content item.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policy_areas": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "primary_publishing_organisation": {
-          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "available_translations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "children": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policies": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "document_collections": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "child_taxons": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -310,140 +207,266 @@
         "written_statement"
       ]
     },
+    "email_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "available_translations": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "policies": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policy_areas": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "primary_publishing_organisation": {
+          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "root_taxons": {
+          "description": "Defines a set of Taxonomy trees rooted in this node.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "homepage"
       ]
     },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    "title": {
+      "type": "string"
     },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
-    "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
     },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
-    "frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "base_path",
-          "locale"
-        ],
-        "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
-          },
-          "document_type": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
             "type": "string"
-          },
-          "schema_name": {
-            "type": "string"
-          },
-          "public_updated_at": {
-            "type": "string"
-          },
-          "content_id": {
-            "$ref": "#/definitions/guid"
-          },
-          "title": {
-            "type": "string"
-          },
-          "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
-            "type": "string"
-          },
-          "links": {
-            "type": "object",
-            "patternProperties": {
-              "^[a-z_]+$": {
-                "$ref": "#/definitions/frontend_links"
-              }
-            }
           }
         }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
       }
     },
     "base_path_less_frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "document_type": {
-            "type": "string"
-          },
-          "schema_name": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
           "api_path": {
             "$ref": "#/definitions/absolute_path"
@@ -453,25 +476,93 @@
             "type": "string",
             "format": "uri"
           },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "public_updated_at": {
-            "type": "string"
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
+          "document_type": {
             "type": "string"
           },
           "locale": {
             "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
           }
         }
       }
@@ -484,56 +575,50 @@
         }
       }
     },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
     },
-    "external_related_links": {
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -544,20 +629,437 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "base_path",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
+            "type": "string"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "country": {
+            "$ref": "#/definitions/country"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "details": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "links": {
+            "type": "object",
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links"
+              }
+            }
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -574,212 +1076,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -838,98 +1150,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -938,10 +1283,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -949,6 +1290,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -971,79 +1316,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1055,13 +1529,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1069,61 +1537,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1131,418 +1562,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1552,9 +1576,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/homepage/notification/schema.json
+++ b/dist/formats/homepage/notification/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "content_id",
@@ -17,12 +16,25 @@
     "title",
     "update_type"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -34,60 +46,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -252,60 +212,9 @@
         "written_statement"
       ]
     },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "homepage"
-      ]
-    },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
-    },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
     "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "govuk_request_id": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
     },
     "expanded_links": {
       "type": "object",
@@ -314,112 +223,206 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "govuk_request_id": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "homepage"
+      ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
-    "frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "base_path",
-          "locale"
-        ],
-        "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
-          },
-          "document_type": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
             "type": "string"
-          },
-          "schema_name": {
-            "type": "string"
-          },
-          "public_updated_at": {
-            "type": "string"
-          },
-          "content_id": {
-            "$ref": "#/definitions/guid"
-          },
-          "title": {
-            "type": "string"
-          },
-          "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
-            "type": "string"
-          },
-          "links": {
-            "type": "object",
-            "patternProperties": {
-              "^[a-z_]+$": {
-                "$ref": "#/definitions/frontend_links"
-              }
-            }
           }
         }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
       }
     },
     "base_path_less_frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "document_type": {
-            "type": "string"
-          },
-          "schema_name": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
           "api_path": {
             "$ref": "#/definitions/absolute_path"
@@ -429,25 +432,93 @@
             "type": "string",
             "format": "uri"
           },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "public_updated_at": {
-            "type": "string"
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
+          "document_type": {
             "type": "string"
           },
           "locale": {
             "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
           }
         }
       }
@@ -460,56 +531,50 @@
         }
       }
     },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
     },
-    "external_related_links": {
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -520,20 +585,437 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "base_path",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
+            "type": "string"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "country": {
+            "$ref": "#/definitions/country"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "details": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "links": {
+            "type": "object",
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links"
+              }
+            }
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -550,212 +1032,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -814,98 +1106,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -914,10 +1239,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -925,6 +1246,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -947,79 +1272,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1031,13 +1485,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1045,61 +1493,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1107,418 +1518,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1528,9 +1532,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/homepage/publisher_v2/links.json
+++ b/dist/formats/homepage/publisher_v2/links.json
@@ -3,29 +3,10 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "previous_version": {
-      "type": "string"
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "root_taxons": {
-          "description": "Defines a set of Taxonomy trees rooted in this node.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/guid_list"
-        },
         "mainstream_browse_pages": {
           "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/guid_list"
@@ -34,8 +15,12 @@
           "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/guid_list"
         },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
@@ -55,38 +40,54 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "root_taxons": {
+          "description": "Defines a set of Taxonomy trees rooted in this node.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/guid_list"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
         }
       }
+    },
+    "previous_version": {
+      "type": "string"
     }
   },
   "definitions": {
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
     "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
       "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
     "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
         {
           "type": "string"
@@ -94,22 +95,158 @@
         {
           "type": "null"
         }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+      ]
     },
-    "external_related_links": {
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -120,20 +257,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -150,212 +620,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -414,98 +694,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -514,10 +827,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -525,6 +834,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -547,79 +860,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -631,13 +1073,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -645,61 +1081,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -707,418 +1106,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1128,9 +1120,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/homepage/publisher_v2/schema.json
+++ b/dist/formats/homepage/publisher_v2/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "title",
     "details",
@@ -13,12 +12,22 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "description": {
       "anyOf": [
@@ -30,84 +39,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "access_limited": {
-      "$ref": "#/definitions/access_limited"
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "change_note": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "previous_version": {
-      "type": "string"
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "links": {
-      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string",
@@ -272,55 +205,109 @@
         "written_statement"
       ]
     },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "homepage"
       ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
-    "details": {
-      "type": "object",
-      "properties": {
-      }
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policy_areas": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
     },
     "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
       "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
     "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
         {
           "type": "string"
@@ -328,22 +315,163 @@
         {
           "type": "null"
         }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+      ]
     },
-    "external_related_links": {
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "properties": {
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -354,20 +482,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -384,212 +845,31 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
         }
       }
     },
-    "redirect_route": {
+    "links": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
       "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
         }
       }
     },
@@ -648,98 +928,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -748,10 +1061,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -759,6 +1068,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -781,79 +1094,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -865,13 +1307,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -879,61 +1315,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -941,418 +1340,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1362,9 +1354,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/html_publication/frontend/schema.json
+++ b/dist/formats/html_publication/frontend/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "links",
@@ -12,12 +11,25 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -29,116 +41,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_pages": {
-          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "meets_user_needs": {
-          "description": "The user needs this piece of content meets.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "organisations": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "parent": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policy_areas": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "primary_publishing_organisation": {
-          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "available_translations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "children": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policies": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "document_collections": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "child_taxons": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -303,67 +207,639 @@
         "written_statement"
       ]
     },
+    "email_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "available_translations": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "organisations": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "parent": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policies": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policy_areas": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "primary_publishing_organisation": {
+          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "html_publication"
       ]
     },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    "title": {
+      "type": "string"
     },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
-    "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
     },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "base_path_less_frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "required": [
+        "body",
+        "public_timestamp",
+        "first_published_version"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "body": {
+          "$ref": "#/definitions/body"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "first_published_version": {
+          "type": "boolean"
+        },
+        "headings": {
+          "description": "DEPRECATED. A list of headings used to display a contents list. Superceded in https://github.com/alphagov/government-frontend/pull/384",
+          "type": "string"
+        },
+        "isbn": {
+          "description": "Identifies the Print ISBN to be displayed when printing an HTML Publication",
+          "type": "string"
+        },
+        "print_meta_data_contact_address": {
+          "description": "Identifies the contact address of the institution which has produced the HTML Publication. To be displayed when printing an HTML Publication",
+          "type": "string"
+        },
+        "public_timestamp": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "web_isbn": {
+          "description": "Identifies the Web ISBN to be displayed when printing an HTML Publication",
+          "type": "string"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "required": [
+        "title",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
     "frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "base_path",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
-          "document_type": {
-            "type": "string"
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
           },
-          "schema_name": {
-            "type": "string"
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
           },
-          "public_updated_at": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
             "type": "string"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
-            "type": "string"
+          "country": {
+            "$ref": "#/definitions/country"
           },
           "description": {
             "anyOf": [
@@ -375,36 +851,11 @@
               }
             ]
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "details": {
+            "type": "object",
+            "additionalProperties": true
           },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
+          "document_type": {
             "type": "string"
           },
           "links": {
@@ -414,154 +865,205 @@
                 "$ref": "#/definitions/frontend_links"
               }
             }
-          }
-        }
-      }
-    },
-    "base_path_less_frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "locale"
-        ],
-        "properties": {
-          "document_type": {
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
             "type": "string"
           },
           "schema_name": {
             "type": "string"
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
+          "title": {
+            "type": "string"
           },
           "web_url": {
             "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
             "type": "string",
             "format": "uri"
           },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
           },
-          "public_updated_at": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
             "type": "string"
           },
-          "content_id": {
-            "$ref": "#/definitions/guid"
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
           },
           "title": {
             "type": "string"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
           }
         }
       }
     },
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "body",
-        "public_timestamp",
-        "first_published_version"
-      ],
-      "properties": {
-        "body": {
-          "$ref": "#/definitions/body"
-        },
-        "headings": {
-          "description": "DEPRECATED. A list of headings used to display a contents list. Superceded in https://github.com/alphagov/government-frontend/pull/384",
-          "type": "string"
-        },
-        "public_timestamp": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_version": {
-          "type": "boolean"
-        },
-        "isbn": {
-          "type": "string",
-          "description": "Identifies the Print ISBN to be displayed when printing an HTML Publication"
-        },
-        "web_isbn": {
-          "type": "string",
-          "description": "Identifies the Web ISBN to be displayed when printing an HTML Publication"
-        },
-        "print_meta_data_contact_address": {
-          "type": "string",
-          "description": "Identifies the contact address of the institution which has produced the HTML Publication. To be displayed when printing an HTML Publication"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
       }
     },
-    "external_link": {
+    "image": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
+        "alt_text": {
           "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "url": {
           "type": "string",
@@ -572,17 +1074,17 @@
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -599,212 +1101,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -863,98 +1175,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -963,10 +1308,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -974,6 +1315,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -996,79 +1341,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1080,13 +1554,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1094,61 +1562,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1156,418 +1587,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1577,9 +1601,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/html_publication/notification/schema.json
+++ b/dist/formats/html_publication/notification/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "content_id",
@@ -17,12 +16,25 @@
     "title",
     "update_type"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -34,60 +46,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -252,60 +212,9 @@
         "written_statement"
       ]
     },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "html_publication"
-      ]
-    },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
-    },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
     "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "govuk_request_id": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
     },
     "expanded_links": {
       "type": "object",
@@ -314,39 +223,586 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "govuk_request_id": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "html_publication"
+      ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "base_path_less_frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "required": [
+        "body",
+        "public_timestamp",
+        "first_published_version"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "body": {
+          "$ref": "#/definitions/body"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "first_published_version": {
+          "type": "boolean"
+        },
+        "headings": {
+          "description": "DEPRECATED. A list of headings used to display a contents list. Superceded in https://github.com/alphagov/government-frontend/pull/384",
+          "type": "string"
+        },
+        "isbn": {
+          "description": "Identifies the Print ISBN to be displayed when printing an HTML Publication",
+          "type": "string"
+        },
+        "print_meta_data_contact_address": {
+          "description": "Identifies the contact address of the institution which has produced the HTML Publication. To be displayed when printing an HTML Publication",
+          "type": "string"
+        },
+        "public_timestamp": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "web_isbn": {
+          "description": "Identifies the Web ISBN to be displayed when printing an HTML Publication",
+          "type": "string"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "required": [
+        "title",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
     "frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "base_path",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
-          "document_type": {
-            "type": "string"
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
           },
-          "schema_name": {
-            "type": "string"
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
           },
-          "public_updated_at": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
             "type": "string"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
-            "type": "string"
+          "country": {
+            "$ref": "#/definitions/country"
           },
           "description": {
             "anyOf": [
@@ -358,36 +814,11 @@
               }
             ]
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "details": {
+            "type": "object",
+            "additionalProperties": true
           },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
+          "document_type": {
             "type": "string"
           },
           "links": {
@@ -397,154 +828,205 @@
                 "$ref": "#/definitions/frontend_links"
               }
             }
-          }
-        }
-      }
-    },
-    "base_path_less_frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "locale"
-        ],
-        "properties": {
-          "document_type": {
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
             "type": "string"
           },
           "schema_name": {
             "type": "string"
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
+          "title": {
+            "type": "string"
           },
           "web_url": {
             "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
             "type": "string",
             "format": "uri"
           },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
           },
-          "public_updated_at": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
             "type": "string"
           },
-          "content_id": {
-            "$ref": "#/definitions/guid"
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
           },
           "title": {
             "type": "string"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
           }
         }
       }
     },
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "body",
-        "public_timestamp",
-        "first_published_version"
-      ],
-      "properties": {
-        "body": {
-          "$ref": "#/definitions/body"
-        },
-        "headings": {
-          "description": "DEPRECATED. A list of headings used to display a contents list. Superceded in https://github.com/alphagov/government-frontend/pull/384",
-          "type": "string"
-        },
-        "public_timestamp": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_version": {
-          "type": "boolean"
-        },
-        "isbn": {
-          "type": "string",
-          "description": "Identifies the Print ISBN to be displayed when printing an HTML Publication"
-        },
-        "web_isbn": {
-          "type": "string",
-          "description": "Identifies the Web ISBN to be displayed when printing an HTML Publication"
-        },
-        "print_meta_data_contact_address": {
-          "type": "string",
-          "description": "Identifies the contact address of the institution which has produced the HTML Publication. To be displayed when printing an HTML Publication"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
       }
     },
-    "external_link": {
+    "image": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
+        "alt_text": {
           "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "url": {
           "type": "string",
@@ -555,17 +1037,17 @@
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -582,212 +1064,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -846,98 +1138,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -946,10 +1271,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -957,6 +1278,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -979,79 +1304,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1063,13 +1517,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1077,61 +1525,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1139,418 +1550,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1560,9 +1564,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/html_publication/publisher_v2/links.json
+++ b/dist/formats/html_publication/publisher_v2/links.json
@@ -3,25 +3,10 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "previous_version": {
-      "type": "string"
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/guid_list"
-        },
         "mainstream_browse_pages": {
           "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/guid_list"
@@ -30,8 +15,12 @@
           "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/guid_list"
         },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
@@ -51,38 +40,50 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/guid_list"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
         }
       }
+    },
+    "previous_version": {
+      "type": "string"
     }
   },
   "definitions": {
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
     "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
       "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
     "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
         {
           "type": "string"
@@ -90,22 +91,158 @@
         {
           "type": "null"
         }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+      ]
     },
-    "external_related_links": {
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -116,20 +253,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -146,212 +616,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -410,98 +690,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -510,10 +823,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -521,6 +830,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -543,79 +856,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -627,13 +1069,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -641,61 +1077,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -703,418 +1102,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1124,9 +1116,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/html_publication/publisher_v2/schema.json
+++ b/dist/formats/html_publication/publisher_v2/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "title",
     "details",
@@ -13,12 +12,22 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "description": {
       "anyOf": [
@@ -30,84 +39,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "access_limited": {
-      "$ref": "#/definitions/access_limited"
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "change_note": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "previous_version": {
-      "type": "string"
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "links": {
-      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string",
@@ -272,98 +205,109 @@
         "written_statement"
       ]
     },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "html_publication"
       ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "body",
-        "public_timestamp",
-        "first_published_version"
-      ],
-      "properties": {
-        "body": {
-          "$ref": "#/definitions/body"
-        },
-        "headings": {
-          "description": "DEPRECATED. A list of headings used to display a contents list. Superceded in https://github.com/alphagov/government-frontend/pull/384",
-          "type": "string"
-        },
-        "public_timestamp": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "first_published_version": {
-          "type": "boolean"
-        },
-        "isbn": {
-          "type": "string",
-          "description": "Identifies the Print ISBN to be displayed when printing an HTML Publication"
-        },
-        "web_isbn": {
-          "type": "string",
-          "description": "Identifies the Web ISBN to be displayed when printing an HTML Publication"
-        },
-        "print_meta_data_contact_address": {
-          "type": "string",
-          "description": "Identifies the contact address of the institution which has produced the HTML Publication. To be displayed when printing an HTML Publication"
-        }
-      }
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "organisations": {
-          "$ref": "#/definitions/guid_list"
-        },
-        "parent": {
-          "$ref": "#/definitions/guid_list"
-        },
-        "primary_publishing_organisation": {
-          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
-          "$ref": "#/definitions/guid_list",
-          "maxItems": 1
-        },
-        "policy_areas": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
     },
     "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
       "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
     "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
         {
           "type": "string"
@@ -371,22 +315,195 @@
         {
           "type": "null"
         }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+      ]
     },
-    "external_related_links": {
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "required": [
+        "body",
+        "public_timestamp",
+        "first_published_version"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "body": {
+          "$ref": "#/definitions/body"
+        },
+        "first_published_version": {
+          "type": "boolean"
+        },
+        "headings": {
+          "description": "DEPRECATED. A list of headings used to display a contents list. Superceded in https://github.com/alphagov/government-frontend/pull/384",
+          "type": "string"
+        },
+        "isbn": {
+          "description": "Identifies the Print ISBN to be displayed when printing an HTML Publication",
+          "type": "string"
+        },
+        "print_meta_data_contact_address": {
+          "description": "Identifies the contact address of the institution which has produced the HTML Publication. To be displayed when printing an HTML Publication",
+          "type": "string"
+        },
+        "public_timestamp": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "web_isbn": {
+          "description": "Identifies the Web ISBN to be displayed when printing an HTML Publication",
+          "type": "string"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -397,20 +514,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -427,212 +877,42 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
         }
       }
     },
-    "redirect_route": {
+    "links": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
       "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
+        "organisations": {
+          "$ref": "#/definitions/guid_list"
         },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
+        "parent": {
+          "$ref": "#/definitions/guid_list"
         },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
         },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
+        "primary_publishing_organisation": {
+          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
         }
       }
     },
@@ -691,98 +971,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -791,10 +1104,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -802,6 +1111,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -824,79 +1137,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -908,13 +1350,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -922,61 +1358,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -984,418 +1383,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1405,9 +1397,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/licence/frontend/schema.json
+++ b/dist/formats/licence/frontend/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "links",
@@ -12,12 +11,25 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -29,119 +41,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_pages": {
-          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "meets_user_needs": {
-          "description": "The user needs this piece of content meets.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "organisations": {
-          "description": "All organisations linked to this content item. This should include lead organisations.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "parent": {
-          "description": "The parent content item.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policy_areas": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "primary_publishing_organisation": {
-          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "available_translations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "children": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policies": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "document_collections": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "child_taxons": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -306,67 +207,636 @@
         "written_statement"
       ]
     },
+    "email_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "available_translations": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "policies": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policy_areas": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "primary_publishing_organisation": {
+          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "licence"
       ]
     },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    "title": {
+      "type": "string"
     },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
-    "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
     },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "base_path_less_frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "required": [
+        "licence_identifier"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "continuation_link": {
+          "description": "Link to licence competent authority.",
+          "type": "string",
+          "format": "uri"
+        },
+        "external_related_links": {
+          "$ref": "#/definitions/external_related_links"
+        },
+        "licence_identifier": {
+          "description": "Unique ID for a licence, starting with an LGSL code.",
+          "type": "string"
+        },
+        "licence_overview": {
+          "$ref": "#/definitions/body_html_and_govspeak"
+        },
+        "licence_short_description": {
+          "description": "One line curated description, will appear in Licence Finder results.",
+          "type": "string"
+        },
+        "will_continue_on": {
+          "$ref": "#/definitions/will_continue_on"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "required": [
+        "title",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
     "frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "base_path",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
-          "document_type": {
-            "type": "string"
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
           },
-          "schema_name": {
-            "type": "string"
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
           },
-          "public_updated_at": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
             "type": "string"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
-            "type": "string"
+          "country": {
+            "$ref": "#/definitions/country"
           },
           "description": {
             "anyOf": [
@@ -378,36 +848,11 @@
               }
             ]
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "details": {
+            "type": "object",
+            "additionalProperties": true
           },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
+          "document_type": {
             "type": "string"
           },
           "links": {
@@ -417,148 +862,205 @@
                 "$ref": "#/definitions/frontend_links"
               }
             }
-          }
-        }
-      }
-    },
-    "base_path_less_frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "locale"
-        ],
-        "properties": {
-          "document_type": {
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
             "type": "string"
           },
           "schema_name": {
             "type": "string"
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
+          "title": {
+            "type": "string"
           },
           "web_url": {
             "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
             "type": "string",
             "format": "uri"
           },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
           },
-          "public_updated_at": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
             "type": "string"
           },
-          "content_id": {
-            "$ref": "#/definitions/guid"
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
           },
           "title": {
             "type": "string"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
           }
         }
       }
     },
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "licence_identifier"
-      ],
-      "properties": {
-        "will_continue_on": {
-          "$ref": "#/definitions/will_continue_on"
-        },
-        "continuation_link": {
-          "description": "Link to licence competent authority.",
-          "type": "string",
-          "format": "uri"
-        },
-        "licence_short_description": {
-          "description": "One line curated description, will appear in Licence Finder results.",
-          "type": "string"
-        },
-        "licence_overview": {
-          "$ref": "#/definitions/body_html_and_govspeak"
-        },
-        "licence_identifier": {
-          "description": "Unique ID for a licence, starting with an LGSL code.",
-          "type": "string"
-        },
-        "external_related_links": {
-          "$ref": "#/definitions/external_related_links"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
       }
     },
-    "external_link": {
+    "image": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
+        "alt_text": {
           "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "url": {
           "type": "string",
@@ -569,17 +1071,17 @@
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -596,212 +1098,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -860,98 +1172,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -960,10 +1305,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -971,6 +1312,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -993,79 +1338,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1077,13 +1551,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1091,61 +1559,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1153,418 +1584,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1574,9 +1598,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/licence/notification/schema.json
+++ b/dist/formats/licence/notification/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "content_id",
@@ -17,12 +16,25 @@
     "title",
     "update_type"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -34,60 +46,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -252,60 +212,9 @@
         "written_statement"
       ]
     },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "licence"
-      ]
-    },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
-    },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
     "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "govuk_request_id": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
     },
     "expanded_links": {
       "type": "object",
@@ -314,39 +223,580 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "govuk_request_id": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "licence"
+      ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "base_path_less_frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "required": [
+        "licence_identifier"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "continuation_link": {
+          "description": "Link to licence competent authority.",
+          "type": "string",
+          "format": "uri"
+        },
+        "external_related_links": {
+          "$ref": "#/definitions/external_related_links"
+        },
+        "licence_identifier": {
+          "description": "Unique ID for a licence, starting with an LGSL code.",
+          "type": "string"
+        },
+        "licence_overview": {
+          "$ref": "#/definitions/body_html_and_govspeak"
+        },
+        "licence_short_description": {
+          "description": "One line curated description, will appear in Licence Finder results.",
+          "type": "string"
+        },
+        "will_continue_on": {
+          "$ref": "#/definitions/will_continue_on"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "required": [
+        "title",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
     "frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "base_path",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
-          "document_type": {
-            "type": "string"
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
           },
-          "schema_name": {
-            "type": "string"
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
           },
-          "public_updated_at": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
             "type": "string"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
-            "type": "string"
+          "country": {
+            "$ref": "#/definitions/country"
           },
           "description": {
             "anyOf": [
@@ -358,36 +808,11 @@
               }
             ]
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "details": {
+            "type": "object",
+            "additionalProperties": true
           },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
+          "document_type": {
             "type": "string"
           },
           "links": {
@@ -397,148 +822,205 @@
                 "$ref": "#/definitions/frontend_links"
               }
             }
-          }
-        }
-      }
-    },
-    "base_path_less_frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "locale"
-        ],
-        "properties": {
-          "document_type": {
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
             "type": "string"
           },
           "schema_name": {
             "type": "string"
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
+          "title": {
+            "type": "string"
           },
           "web_url": {
             "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
             "type": "string",
             "format": "uri"
           },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
           },
-          "public_updated_at": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
             "type": "string"
           },
-          "content_id": {
-            "$ref": "#/definitions/guid"
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
           },
           "title": {
             "type": "string"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
           }
         }
       }
     },
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "licence_identifier"
-      ],
-      "properties": {
-        "will_continue_on": {
-          "$ref": "#/definitions/will_continue_on"
-        },
-        "continuation_link": {
-          "description": "Link to licence competent authority.",
-          "type": "string",
-          "format": "uri"
-        },
-        "licence_short_description": {
-          "description": "One line curated description, will appear in Licence Finder results.",
-          "type": "string"
-        },
-        "licence_overview": {
-          "$ref": "#/definitions/body_html_and_govspeak"
-        },
-        "licence_identifier": {
-          "description": "Unique ID for a licence, starting with an LGSL code.",
-          "type": "string"
-        },
-        "external_related_links": {
-          "$ref": "#/definitions/external_related_links"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
       }
     },
-    "external_link": {
+    "image": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
+        "alt_text": {
           "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "url": {
           "type": "string",
@@ -549,17 +1031,17 @@
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -576,212 +1058,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -840,98 +1132,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -940,10 +1265,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -951,6 +1272,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -973,79 +1298,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1057,13 +1511,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1071,61 +1519,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1133,418 +1544,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1554,9 +1558,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/licence/publisher_v2/links.json
+++ b/dist/formats/licence/publisher_v2/links.json
@@ -3,25 +3,10 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "previous_version": {
-      "type": "string"
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/guid_list"
-        },
         "mainstream_browse_pages": {
           "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/guid_list"
@@ -30,8 +15,12 @@
           "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/guid_list"
         },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
@@ -51,38 +40,50 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/guid_list"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
         }
       }
+    },
+    "previous_version": {
+      "type": "string"
     }
   },
   "definitions": {
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
     "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
       "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
     "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
         {
           "type": "string"
@@ -90,22 +91,158 @@
         {
           "type": "null"
         }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+      ]
     },
-    "external_related_links": {
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -116,20 +253,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -146,212 +616,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -410,98 +690,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -510,10 +823,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -521,6 +830,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -543,79 +856,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -627,13 +1069,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -641,61 +1077,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -703,418 +1102,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1124,9 +1116,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/licence/publisher_v2/schema.json
+++ b/dist/formats/licence/publisher_v2/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "title",
     "details",
@@ -13,12 +12,22 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "description": {
       "anyOf": [
@@ -30,84 +39,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "access_limited": {
-      "$ref": "#/definitions/access_limited"
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "change_note": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "previous_version": {
-      "type": "string"
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "links": {
-      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string",
@@ -272,81 +205,109 @@
         "written_statement"
       ]
     },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "licence"
       ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "licence_identifier"
-      ],
-      "properties": {
-        "will_continue_on": {
-          "$ref": "#/definitions/will_continue_on"
-        },
-        "continuation_link": {
-          "description": "Link to licence competent authority.",
-          "type": "string",
-          "format": "uri"
-        },
-        "licence_short_description": {
-          "description": "One line curated description, will appear in Licence Finder results.",
-          "type": "string"
-        },
-        "licence_overview": {
-          "$ref": "#/definitions/body_html_and_govspeak"
-        },
-        "licence_identifier": {
-          "description": "Unique ID for a licence, starting with an LGSL code.",
-          "type": "string"
-        },
-        "external_related_links": {
-          "$ref": "#/definitions/external_related_links"
-        }
-      }
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policy_areas": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
     },
     "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
       "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
     "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
         {
           "type": "string"
@@ -354,22 +315,189 @@
         {
           "type": "null"
         }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+      ]
     },
-    "external_related_links": {
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "required": [
+        "licence_identifier"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "continuation_link": {
+          "description": "Link to licence competent authority.",
+          "type": "string",
+          "format": "uri"
+        },
+        "external_related_links": {
+          "$ref": "#/definitions/external_related_links"
+        },
+        "licence_identifier": {
+          "description": "Unique ID for a licence, starting with an LGSL code.",
+          "type": "string"
+        },
+        "licence_overview": {
+          "$ref": "#/definitions/body_html_and_govspeak"
+        },
+        "licence_short_description": {
+          "description": "One line curated description, will appear in Licence Finder results.",
+          "type": "string"
+        },
+        "will_continue_on": {
+          "$ref": "#/definitions/will_continue_on"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -380,20 +508,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -410,212 +871,31 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
         }
       }
     },
-    "redirect_route": {
+    "links": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
       "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
         }
       }
     },
@@ -674,98 +954,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -774,10 +1087,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -785,6 +1094,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -807,79 +1120,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -891,13 +1333,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -905,61 +1341,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -967,418 +1366,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1388,9 +1380,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/local_transaction/frontend/schema.json
+++ b/dist/formats/local_transaction/frontend/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "links",
@@ -12,12 +11,25 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -29,119 +41,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_pages": {
-          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "meets_user_needs": {
-          "description": "The user needs this piece of content meets.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "organisations": {
-          "description": "All organisations linked to this content item. This should include lead organisations.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "parent": {
-          "description": "The parent content item.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policy_areas": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "primary_publishing_organisation": {
-          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "available_translations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "children": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policies": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "document_collections": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "child_taxons": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -306,140 +207,262 @@
         "written_statement"
       ]
     },
+    "email_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "available_translations": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "policies": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policy_areas": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "primary_publishing_organisation": {
+          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "local_transaction"
       ]
     },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    "title": {
+      "type": "string"
     },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
-    "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
     },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
-    "frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "base_path",
-          "locale"
-        ],
-        "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
-          },
-          "document_type": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
             "type": "string"
-          },
-          "schema_name": {
-            "type": "string"
-          },
-          "public_updated_at": {
-            "type": "string"
-          },
-          "content_id": {
-            "$ref": "#/definitions/guid"
-          },
-          "title": {
-            "type": "string"
-          },
-          "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
-            "type": "string"
-          },
-          "links": {
-            "type": "object",
-            "patternProperties": {
-              "^[a-z_]+$": {
-                "$ref": "#/definitions/frontend_links"
-              }
-            }
           }
         }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
       }
     },
     "base_path_less_frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "document_type": {
-            "type": "string"
-          },
-          "schema_name": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
           "api_path": {
             "$ref": "#/definitions/absolute_path"
@@ -449,51 +472,113 @@
             "type": "string",
             "format": "uri"
           },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "public_updated_at": {
-            "type": "string"
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
+          "document_type": {
             "type": "string"
           },
           "locale": {
             "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
           }
         }
       }
     },
     "details": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "lgsl_code",
         "service_tiers"
       ],
+      "additionalProperties": false,
       "properties": {
-        "lgsl_code": {
-          "description": "The Local Government Service List code for the local transaction service",
-          "type": "integer"
+        "change_history": {
+          "$ref": "#/definitions/change_history"
         },
-        "lgil_override": {
-          "description": "[DEPRECATED]The Local Government Interaction List override code for the local transaction interaction",
-          "anyOf": [
-            {
-              "type": "integer"
-            },
-            {
-              "type": "null"
-            }
-          ]
+        "external_related_links": {
+          "$ref": "#/definitions/external_related_links"
+        },
+        "introduction": {
+          "$ref": "#/definitions/body_html_and_govspeak"
         },
         "lgil_code": {
           "description": "The Local Government Interaction List code for the local transaction interaction",
@@ -506,15 +591,20 @@
             }
           ]
         },
-        "service_tiers": {
-          "description": "List of local government tiers that provide the service",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+        "lgil_override": {
+          "description": "[DEPRECATED]The Local Government Interaction List override code for the local transaction interaction",
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
-        "introduction": {
-          "$ref": "#/definitions/body_html_and_govspeak"
+        "lgsl_code": {
+          "description": "The Local Government Service List code for the local transaction service",
+          "type": "integer"
         },
         "more_information": {
           "$ref": "#/definitions/body_html_and_govspeak"
@@ -522,64 +612,59 @@
         "need_to_know": {
           "$ref": "#/definitions/body_html_and_govspeak"
         },
-        "external_related_links": {
-          "$ref": "#/definitions/external_related_links"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
+        "service_tiers": {
+          "description": "List of local government tiers that provide the service",
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -590,20 +675,437 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "base_path",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
+            "type": "string"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "country": {
+            "$ref": "#/definitions/country"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "details": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "links": {
+            "type": "object",
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links"
+              }
+            }
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -620,212 +1122,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -884,98 +1196,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -984,10 +1329,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -995,6 +1336,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -1017,79 +1362,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1101,13 +1575,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1115,61 +1583,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1177,418 +1608,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1598,9 +1622,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/local_transaction/notification/schema.json
+++ b/dist/formats/local_transaction/notification/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "content_id",
@@ -17,12 +16,25 @@
     "title",
     "update_type"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -34,60 +46,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -252,60 +212,9 @@
         "written_statement"
       ]
     },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "local_transaction"
-      ]
-    },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
-    },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
     "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "govuk_request_id": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
     },
     "expanded_links": {
       "type": "object",
@@ -314,112 +223,206 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "govuk_request_id": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "local_transaction"
+      ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
-    "frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "base_path",
-          "locale"
-        ],
-        "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
-          },
-          "document_type": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
             "type": "string"
-          },
-          "schema_name": {
-            "type": "string"
-          },
-          "public_updated_at": {
-            "type": "string"
-          },
-          "content_id": {
-            "$ref": "#/definitions/guid"
-          },
-          "title": {
-            "type": "string"
-          },
-          "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
-            "type": "string"
-          },
-          "links": {
-            "type": "object",
-            "patternProperties": {
-              "^[a-z_]+$": {
-                "$ref": "#/definitions/frontend_links"
-              }
-            }
           }
         }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
       }
     },
     "base_path_less_frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "document_type": {
-            "type": "string"
-          },
-          "schema_name": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
           "api_path": {
             "$ref": "#/definitions/absolute_path"
@@ -429,51 +432,113 @@
             "type": "string",
             "format": "uri"
           },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "public_updated_at": {
-            "type": "string"
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
+          "document_type": {
             "type": "string"
           },
           "locale": {
             "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
           }
         }
       }
     },
     "details": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "lgsl_code",
         "service_tiers"
       ],
+      "additionalProperties": false,
       "properties": {
-        "lgsl_code": {
-          "description": "The Local Government Service List code for the local transaction service",
-          "type": "integer"
+        "change_history": {
+          "$ref": "#/definitions/change_history"
         },
-        "lgil_override": {
-          "description": "[DEPRECATED]The Local Government Interaction List override code for the local transaction interaction",
-          "anyOf": [
-            {
-              "type": "integer"
-            },
-            {
-              "type": "null"
-            }
-          ]
+        "external_related_links": {
+          "$ref": "#/definitions/external_related_links"
+        },
+        "introduction": {
+          "$ref": "#/definitions/body_html_and_govspeak"
         },
         "lgil_code": {
           "description": "The Local Government Interaction List code for the local transaction interaction",
@@ -486,15 +551,20 @@
             }
           ]
         },
-        "service_tiers": {
-          "description": "List of local government tiers that provide the service",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+        "lgil_override": {
+          "description": "[DEPRECATED]The Local Government Interaction List override code for the local transaction interaction",
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
-        "introduction": {
-          "$ref": "#/definitions/body_html_and_govspeak"
+        "lgsl_code": {
+          "description": "The Local Government Service List code for the local transaction service",
+          "type": "integer"
         },
         "more_information": {
           "$ref": "#/definitions/body_html_and_govspeak"
@@ -502,64 +572,59 @@
         "need_to_know": {
           "$ref": "#/definitions/body_html_and_govspeak"
         },
-        "external_related_links": {
-          "$ref": "#/definitions/external_related_links"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
+        "service_tiers": {
+          "description": "List of local government tiers that provide the service",
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -570,20 +635,437 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "base_path",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
+            "type": "string"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "country": {
+            "$ref": "#/definitions/country"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "details": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "links": {
+            "type": "object",
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links"
+              }
+            }
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -600,212 +1082,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -864,98 +1156,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -964,10 +1289,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -975,6 +1296,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -997,79 +1322,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1081,13 +1535,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1095,61 +1543,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1157,418 +1568,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1578,9 +1582,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/local_transaction/publisher_v2/links.json
+++ b/dist/formats/local_transaction/publisher_v2/links.json
@@ -3,25 +3,10 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "previous_version": {
-      "type": "string"
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/guid_list"
-        },
         "mainstream_browse_pages": {
           "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/guid_list"
@@ -30,8 +15,12 @@
           "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/guid_list"
         },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
@@ -51,38 +40,50 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/guid_list"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
         }
       }
+    },
+    "previous_version": {
+      "type": "string"
     }
   },
   "definitions": {
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
     "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
       "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
     "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
         {
           "type": "string"
@@ -90,22 +91,158 @@
         {
           "type": "null"
         }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+      ]
     },
-    "external_related_links": {
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -116,20 +253,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -146,212 +616,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -410,98 +690,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -510,10 +823,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -521,6 +830,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -543,79 +856,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -627,13 +1069,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -641,61 +1077,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -703,418 +1102,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1124,9 +1116,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/local_transaction/publisher_v2/schema.json
+++ b/dist/formats/local_transaction/publisher_v2/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "title",
     "details",
@@ -13,12 +12,22 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "description": {
       "anyOf": [
@@ -30,84 +39,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "access_limited": {
-      "$ref": "#/definitions/access_limited"
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "change_note": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "previous_version": {
-      "type": "string"
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "links": {
-      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string",
@@ -272,36 +205,237 @@
         "written_statement"
       ]
     },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "local_transaction"
       ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
-    "details": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
       "type": "object",
       "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
       "required": [
         "lgsl_code",
         "service_tiers"
       ],
+      "additionalProperties": false,
       "properties": {
-        "lgsl_code": {
-          "description": "The Local Government Service List code for the local transaction service",
-          "type": "integer"
+        "external_related_links": {
+          "$ref": "#/definitions/external_related_links"
         },
-        "lgil_override": {
-          "description": "[DEPRECATED]The Local Government Interaction List override code for the local transaction interaction",
-          "anyOf": [
-            {
-              "type": "integer"
-            },
-            {
-              "type": "null"
-            }
-          ]
+        "introduction": {
+          "$ref": "#/definitions/body_html_and_govspeak"
         },
         "lgil_code": {
           "description": "The Local Government Interaction List code for the local transaction interaction",
@@ -314,15 +448,20 @@
             }
           ]
         },
-        "service_tiers": {
-          "description": "List of local government tiers that provide the service",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+        "lgil_override": {
+          "description": "[DEPRECATED]The Local Government Interaction List override code for the local transaction interaction",
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
-        "introduction": {
-          "$ref": "#/definitions/body_html_and_govspeak"
+        "lgsl_code": {
+          "description": "The Local Government Service List code for the local transaction service",
+          "type": "integer"
         },
         "more_information": {
           "$ref": "#/definitions/body_html_and_govspeak"
@@ -330,70 +469,59 @@
         "need_to_know": {
           "$ref": "#/definitions/body_html_and_govspeak"
         },
-        "external_related_links": {
-          "$ref": "#/definitions/external_related_links"
-        }
-      }
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policy_areas": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
+        "service_tiers": {
+          "description": "List of local government tiers that provide the service",
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -404,20 +532,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -434,212 +895,31 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
         }
       }
     },
-    "redirect_route": {
+    "links": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
       "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
         }
       }
     },
@@ -698,98 +978,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -798,10 +1111,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -809,6 +1118,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -831,79 +1144,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -915,13 +1357,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -929,61 +1365,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -991,418 +1390,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1412,9 +1404,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "links",
@@ -12,12 +11,25 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -29,135 +41,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "top_level_browse_pages": {
-          "description": "All top-level browse pages",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "active_top_level_browse_page": {
-          "description": "The top-level browse page which is active",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "second_level_browse_pages": {
-          "description": "All 2nd level browse pages under active_top_level_browse_page",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "related_topics": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_pages": {
-          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "meets_user_needs": {
-          "description": "The user needs this piece of content meets.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "organisations": {
-          "description": "All organisations linked to this content item. This should include lead organisations.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "parent": {
-          "description": "The parent content item.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policy_areas": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "primary_publishing_organisation": {
-          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "available_translations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "children": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policies": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "document_collections": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "child_taxons": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -322,67 +207,643 @@
         "written_statement"
       ]
     },
+    "email_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "active_top_level_browse_page": {
+          "description": "The top-level browse page which is active",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "available_translations": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "policies": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policy_areas": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "primary_publishing_organisation": {
+          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "related_topics": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "second_level_browse_pages": {
+          "description": "All 2nd level browse pages under active_top_level_browse_page",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "top_level_browse_pages": {
+          "description": "All top-level browse pages",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "mainstream_browse_page"
       ]
     },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    "title": {
+      "type": "string"
     },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
-    "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
     },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "base_path_less_frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "groups": {
+          "$ref": "#/definitions/topic_groups"
+        },
+        "internal_name": {
+          "$ref": "#/definitions/taxonomy_internal_name"
+        },
+        "ordered_second_level_browse_pages": {
+          "description": "All 2nd level browse pages under active_top_level_browse_page, with ordering preserved",
+          "$ref": "#/definitions/guid_list"
+        },
+        "second_level_ordering": {
+          "enum": [
+            "alphabetical",
+            "curated"
+          ]
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "required": [
+        "title",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
     "frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "base_path",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
-          "document_type": {
-            "type": "string"
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
           },
-          "schema_name": {
-            "type": "string"
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
           },
-          "public_updated_at": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
             "type": "string"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
-            "type": "string"
+          "country": {
+            "$ref": "#/definitions/country"
           },
           "description": {
             "anyOf": [
@@ -394,36 +855,11 @@
               }
             ]
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "details": {
+            "type": "object",
+            "additionalProperties": true
           },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
+          "document_type": {
             "type": "string"
           },
           "links": {
@@ -433,139 +869,205 @@
                 "$ref": "#/definitions/frontend_links"
               }
             }
-          }
-        }
-      }
-    },
-    "base_path_less_frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "locale"
-        ],
-        "properties": {
-          "document_type": {
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
             "type": "string"
           },
           "schema_name": {
             "type": "string"
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
+          "title": {
+            "type": "string"
           },
           "web_url": {
             "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
             "type": "string",
             "format": "uri"
           },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
           },
-          "public_updated_at": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
             "type": "string"
           },
-          "content_id": {
-            "$ref": "#/definitions/guid"
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
           },
           "title": {
             "type": "string"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
           }
         }
       }
     },
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "internal_name": {
-          "$ref": "#/definitions/taxonomy_internal_name"
-        },
-        "second_level_ordering": {
-          "enum": [
-            "alphabetical",
-            "curated"
-          ]
-        },
-        "ordered_second_level_browse_pages": {
-          "description": "All 2nd level browse pages under active_top_level_browse_page, with ordering preserved",
-          "$ref": "#/definitions/guid_list"
-        },
-        "groups": {
-          "$ref": "#/definitions/topic_groups"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
       }
     },
-    "external_link": {
+    "image": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
+        "alt_text": {
           "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "url": {
           "type": "string",
@@ -576,17 +1078,17 @@
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -603,212 +1105,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -867,98 +1179,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -967,10 +1312,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -978,6 +1319,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -1000,79 +1345,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1084,13 +1558,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1098,61 +1566,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1160,418 +1591,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1581,9 +1605,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/mainstream_browse_page/notification/schema.json
+++ b/dist/formats/mainstream_browse_page/notification/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "content_id",
@@ -17,12 +16,25 @@
     "title",
     "update_type"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -34,60 +46,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -252,60 +212,9 @@
         "written_statement"
       ]
     },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "mainstream_browse_page"
-      ]
-    },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
-    },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
     "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "govuk_request_id": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
     },
     "expanded_links": {
       "type": "object",
@@ -314,39 +223,571 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "govuk_request_id": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "mainstream_browse_page"
+      ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "base_path_less_frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "groups": {
+          "$ref": "#/definitions/topic_groups"
+        },
+        "internal_name": {
+          "$ref": "#/definitions/taxonomy_internal_name"
+        },
+        "ordered_second_level_browse_pages": {
+          "description": "All 2nd level browse pages under active_top_level_browse_page, with ordering preserved",
+          "$ref": "#/definitions/guid_list"
+        },
+        "second_level_ordering": {
+          "enum": [
+            "alphabetical",
+            "curated"
+          ]
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "required": [
+        "title",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
     "frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "base_path",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
-          "document_type": {
-            "type": "string"
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
           },
-          "schema_name": {
-            "type": "string"
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
           },
-          "public_updated_at": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
             "type": "string"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
-            "type": "string"
+          "country": {
+            "$ref": "#/definitions/country"
           },
           "description": {
             "anyOf": [
@@ -358,36 +799,11 @@
               }
             ]
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "details": {
+            "type": "object",
+            "additionalProperties": true
           },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
+          "document_type": {
             "type": "string"
           },
           "links": {
@@ -397,139 +813,205 @@
                 "$ref": "#/definitions/frontend_links"
               }
             }
-          }
-        }
-      }
-    },
-    "base_path_less_frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "locale"
-        ],
-        "properties": {
-          "document_type": {
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
             "type": "string"
           },
           "schema_name": {
             "type": "string"
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
+          "title": {
+            "type": "string"
           },
           "web_url": {
             "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
             "type": "string",
             "format": "uri"
           },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
           },
-          "public_updated_at": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
             "type": "string"
           },
-          "content_id": {
-            "$ref": "#/definitions/guid"
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
           },
           "title": {
             "type": "string"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
           }
         }
       }
     },
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "internal_name": {
-          "$ref": "#/definitions/taxonomy_internal_name"
-        },
-        "second_level_ordering": {
-          "enum": [
-            "alphabetical",
-            "curated"
-          ]
-        },
-        "ordered_second_level_browse_pages": {
-          "description": "All 2nd level browse pages under active_top_level_browse_page, with ordering preserved",
-          "$ref": "#/definitions/guid_list"
-        },
-        "groups": {
-          "$ref": "#/definitions/topic_groups"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
       }
     },
-    "external_link": {
+    "image": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
+        "alt_text": {
           "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "url": {
           "type": "string",
@@ -540,17 +1022,17 @@
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -567,212 +1049,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -831,98 +1123,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -931,10 +1256,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -942,6 +1263,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -964,79 +1289,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1048,13 +1502,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1062,61 +1510,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1124,418 +1535,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1545,9 +1549,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/mainstream_browse_page/publisher_v2/links.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/links.json
@@ -3,40 +3,14 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "previous_version": {
-      "type": "string"
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "top_level_browse_pages": {
-          "description": "All top-level browse pages",
-          "$ref": "#/definitions/guid_list"
-        },
         "active_top_level_browse_page": {
           "description": "The top-level browse page which is active",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
-        },
-        "second_level_browse_pages": {
-          "description": "All 2nd level browse pages under active_top_level_browse_page",
-          "$ref": "#/definitions/guid_list"
-        },
-        "related_topics": {
-          "$ref": "#/definitions/guid_list"
-        },
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/guid_list"
         },
         "mainstream_browse_pages": {
           "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
@@ -46,8 +20,12 @@
           "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/guid_list"
         },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
@@ -67,38 +45,61 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "related_topics": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "second_level_browse_pages": {
+          "description": "All 2nd level browse pages under active_top_level_browse_page",
+          "$ref": "#/definitions/guid_list"
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/guid_list"
+        },
+        "top_level_browse_pages": {
+          "description": "All top-level browse pages",
+          "$ref": "#/definitions/guid_list"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
         }
       }
+    },
+    "previous_version": {
+      "type": "string"
     }
   },
   "definitions": {
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
     "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
       "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
     "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
         {
           "type": "string"
@@ -106,22 +107,158 @@
         {
           "type": "null"
         }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+      ]
     },
-    "external_related_links": {
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -132,20 +269,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -162,212 +632,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -426,98 +706,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -526,10 +839,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -537,6 +846,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -559,79 +872,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -643,13 +1085,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -657,61 +1093,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -719,418 +1118,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1140,9 +1132,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/mainstream_browse_page/publisher_v2/schema.json
+++ b/dist/formats/mainstream_browse_page/publisher_v2/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "title",
     "details",
@@ -13,12 +12,22 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "description": {
       "anyOf": [
@@ -30,84 +39,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "access_limited": {
-      "$ref": "#/definitions/access_limited"
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "change_note": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "previous_version": {
-      "type": "string"
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "links": {
-      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string",
@@ -272,72 +205,109 @@
         "written_statement"
       ]
     },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "mainstream_browse_page"
       ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "internal_name": {
-          "$ref": "#/definitions/taxonomy_internal_name"
-        },
-        "second_level_ordering": {
-          "enum": [
-            "alphabetical",
-            "curated"
-          ]
-        },
-        "ordered_second_level_browse_pages": {
-          "description": "All 2nd level browse pages under active_top_level_browse_page, with ordering preserved",
-          "$ref": "#/definitions/guid_list"
-        },
-        "groups": {
-          "$ref": "#/definitions/topic_groups"
-        }
-      }
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policy_areas": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
     },
     "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
       "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
     "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
         {
           "type": "string"
@@ -345,22 +315,180 @@
         {
           "type": "null"
         }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+      ]
     },
-    "external_related_links": {
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "groups": {
+          "$ref": "#/definitions/topic_groups"
+        },
+        "internal_name": {
+          "$ref": "#/definitions/taxonomy_internal_name"
+        },
+        "ordered_second_level_browse_pages": {
+          "description": "All 2nd level browse pages under active_top_level_browse_page, with ordering preserved",
+          "$ref": "#/definitions/guid_list"
+        },
+        "second_level_ordering": {
+          "enum": [
+            "alphabetical",
+            "curated"
+          ]
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -371,20 +499,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -401,212 +862,31 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
         }
       }
     },
-    "redirect_route": {
+    "links": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
       "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
         }
       }
     },
@@ -665,98 +945,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -765,10 +1078,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -776,6 +1085,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -798,79 +1111,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -882,13 +1324,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -896,61 +1332,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -958,418 +1357,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1379,9 +1371,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/manual/frontend/schema.json
+++ b/dist/formats/manual/frontend/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "links",
@@ -12,12 +11,25 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -29,122 +41,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "organisations": {
-          "description": "All organisations linked to this content item. This should include lead organisations.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "sections": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "available_translations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_pages": {
-          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "meets_user_needs": {
-          "description": "The user needs this piece of content meets.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "parent": {
-          "description": "The parent content item.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policy_areas": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "primary_publishing_organisation": {
-          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "children": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policies": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "document_collections": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "child_taxons": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -309,67 +207,629 @@
         "written_statement"
       ]
     },
+    "email_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "available_translations": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "policies": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policy_areas": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "primary_publishing_organisation": {
+          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "sections": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "manual"
       ]
     },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    "title": {
+      "type": "string"
     },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
-    "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
     },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "base_path_less_frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "required": [
+        "body"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "body": {
+          "$ref": "#/definitions/body_html_and_govspeak"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "change_notes": {
+          "$ref": "#/definitions/manual_change_notes"
+        },
+        "child_section_groups": {
+          "$ref": "#/definitions/manual_child_section_groups"
+        },
+        "organisations": {
+          "$ref": "#/definitions/manual_organisations"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "required": [
+        "title",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
     "frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "base_path",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
-          "document_type": {
-            "type": "string"
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
           },
-          "schema_name": {
-            "type": "string"
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
           },
-          "public_updated_at": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
             "type": "string"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
-            "type": "string"
+          "country": {
+            "$ref": "#/definitions/country"
           },
           "description": {
             "anyOf": [
@@ -381,36 +841,11 @@
               }
             ]
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "details": {
+            "type": "object",
+            "additionalProperties": true
           },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
+          "document_type": {
             "type": "string"
           },
           "links": {
@@ -420,138 +855,205 @@
                 "$ref": "#/definitions/frontend_links"
               }
             }
-          }
-        }
-      }
-    },
-    "base_path_less_frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "locale"
-        ],
-        "properties": {
-          "document_type": {
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
             "type": "string"
           },
           "schema_name": {
             "type": "string"
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
+          "title": {
+            "type": "string"
           },
           "web_url": {
             "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
             "type": "string",
             "format": "uri"
           },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
           },
-          "public_updated_at": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
             "type": "string"
           },
-          "content_id": {
-            "$ref": "#/definitions/guid"
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
           },
           "title": {
             "type": "string"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
           }
         }
       }
     },
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "body"
-      ],
-      "properties": {
-        "body": {
-          "$ref": "#/definitions/body_html_and_govspeak"
-        },
-        "child_section_groups": {
-          "$ref": "#/definitions/manual_child_section_groups"
-        },
-        "change_notes": {
-          "$ref": "#/definitions/manual_change_notes"
-        },
-        "organisations": {
-          "$ref": "#/definitions/manual_organisations"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
       }
     },
-    "external_link": {
+    "image": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
+        "alt_text": {
           "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "url": {
           "type": "string",
@@ -562,17 +1064,17 @@
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -589,212 +1091,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -853,98 +1165,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -953,10 +1298,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -964,6 +1305,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -986,79 +1331,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1070,13 +1544,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1084,61 +1552,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1146,418 +1577,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1567,9 +1591,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/manual/notification/schema.json
+++ b/dist/formats/manual/notification/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "content_id",
@@ -17,12 +16,25 @@
     "title",
     "update_type"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -34,60 +46,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -252,60 +212,9 @@
         "written_statement"
       ]
     },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "manual"
-      ]
-    },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
-    },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
     "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "govuk_request_id": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
     },
     "expanded_links": {
       "type": "object",
@@ -314,39 +223,570 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "govuk_request_id": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "manual"
+      ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "base_path_less_frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "required": [
+        "body"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "body": {
+          "$ref": "#/definitions/body_html_and_govspeak"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "change_notes": {
+          "$ref": "#/definitions/manual_change_notes"
+        },
+        "child_section_groups": {
+          "$ref": "#/definitions/manual_child_section_groups"
+        },
+        "organisations": {
+          "$ref": "#/definitions/manual_organisations"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "required": [
+        "title",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
     "frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "base_path",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
-          "document_type": {
-            "type": "string"
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
           },
-          "schema_name": {
-            "type": "string"
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
           },
-          "public_updated_at": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
             "type": "string"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
-            "type": "string"
+          "country": {
+            "$ref": "#/definitions/country"
           },
           "description": {
             "anyOf": [
@@ -358,36 +798,11 @@
               }
             ]
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "details": {
+            "type": "object",
+            "additionalProperties": true
           },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
+          "document_type": {
             "type": "string"
           },
           "links": {
@@ -397,138 +812,205 @@
                 "$ref": "#/definitions/frontend_links"
               }
             }
-          }
-        }
-      }
-    },
-    "base_path_less_frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "locale"
-        ],
-        "properties": {
-          "document_type": {
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
             "type": "string"
           },
           "schema_name": {
             "type": "string"
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
+          "title": {
+            "type": "string"
           },
           "web_url": {
             "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
             "type": "string",
             "format": "uri"
           },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
           },
-          "public_updated_at": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
             "type": "string"
           },
-          "content_id": {
-            "$ref": "#/definitions/guid"
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
           },
           "title": {
             "type": "string"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
           }
         }
       }
     },
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "body"
-      ],
-      "properties": {
-        "body": {
-          "$ref": "#/definitions/body_html_and_govspeak"
-        },
-        "child_section_groups": {
-          "$ref": "#/definitions/manual_child_section_groups"
-        },
-        "change_notes": {
-          "$ref": "#/definitions/manual_change_notes"
-        },
-        "organisations": {
-          "$ref": "#/definitions/manual_organisations"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
       }
     },
-    "external_link": {
+    "image": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
+        "alt_text": {
           "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "url": {
           "type": "string",
@@ -539,17 +1021,17 @@
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -566,212 +1048,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -830,98 +1122,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -930,10 +1255,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -941,6 +1262,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -963,79 +1288,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1047,13 +1501,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1061,61 +1509,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1123,418 +1534,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1544,9 +1548,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/manual/publisher_v2/links.json
+++ b/dist/formats/manual/publisher_v2/links.json
@@ -3,33 +3,11 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "previous_version": {
-      "type": "string"
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "organisations": {
-          "description": "All organisations linked to this content item. This should include lead organisations.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "sections": {
-          "$ref": "#/definitions/guid_list"
-        },
         "available_translations": {
-          "$ref": "#/definitions/guid_list"
-        },
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/guid_list"
         },
         "mainstream_browse_pages": {
@@ -40,8 +18,16 @@
           "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/guid_list"
         },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {
@@ -57,38 +43,53 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "sections": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/guid_list"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
         }
       }
+    },
+    "previous_version": {
+      "type": "string"
     }
   },
   "definitions": {
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
     "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
       "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
     "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
         {
           "type": "string"
@@ -96,22 +97,158 @@
         {
           "type": "null"
         }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+      ]
     },
-    "external_related_links": {
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -122,20 +259,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -152,212 +622,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -416,98 +696,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -516,10 +829,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -527,6 +836,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -549,79 +862,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -633,13 +1075,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -647,61 +1083,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -709,418 +1108,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1130,9 +1122,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/manual/publisher_v2/schema.json
+++ b/dist/formats/manual/publisher_v2/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "title",
     "details",
@@ -13,12 +12,22 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "description": {
       "anyOf": [
@@ -30,84 +39,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "access_limited": {
-      "$ref": "#/definitions/access_limited"
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "change_note": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "previous_version": {
-      "type": "string"
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "links": {
-      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string",
@@ -272,71 +205,109 @@
         "written_statement"
       ]
     },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "manual"
       ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "body"
-      ],
-      "properties": {
-        "body": {
-          "$ref": "#/definitions/body_html_and_govspeak"
-        },
-        "child_section_groups": {
-          "$ref": "#/definitions/manual_child_section_groups"
-        },
-        "change_notes": {
-          "$ref": "#/definitions/manual_change_notes"
-        },
-        "organisations": {
-          "$ref": "#/definitions/manual_organisations"
-        }
-      }
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policy_areas": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
     },
     "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
       "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
     "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
         {
           "type": "string"
@@ -344,22 +315,179 @@
         {
           "type": "null"
         }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+      ]
     },
-    "external_related_links": {
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "required": [
+        "body"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "body": {
+          "$ref": "#/definitions/body_html_and_govspeak"
+        },
+        "change_notes": {
+          "$ref": "#/definitions/manual_change_notes"
+        },
+        "child_section_groups": {
+          "$ref": "#/definitions/manual_child_section_groups"
+        },
+        "organisations": {
+          "$ref": "#/definitions/manual_organisations"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -370,20 +498,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -400,212 +861,31 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
         }
       }
     },
-    "redirect_route": {
+    "links": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
       "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
         }
       }
     },
@@ -664,98 +944,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -764,10 +1077,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -775,6 +1084,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -797,79 +1110,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -881,13 +1323,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -895,61 +1331,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -957,418 +1356,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1378,9 +1370,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/manual_section/frontend/schema.json
+++ b/dist/formats/manual_section/frontend/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "links",
@@ -12,12 +11,25 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -29,122 +41,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "organisations": {
-          "description": "All organisations linked to this content item. This should include lead organisations.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "manual": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "available_translations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_pages": {
-          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "meets_user_needs": {
-          "description": "The user needs this piece of content meets.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "parent": {
-          "description": "The parent content item.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policy_areas": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "primary_publishing_organisation": {
-          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "children": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policies": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "document_collections": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "child_taxons": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -309,67 +207,631 @@
         "written_statement"
       ]
     },
+    "email_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "available_translations": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "manual": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "policies": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policy_areas": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "primary_publishing_organisation": {
+          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "manual_section"
       ]
     },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    "title": {
+      "type": "string"
     },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
-    "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
     },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "base_path_less_frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "required": [
+        "body",
+        "manual",
+        "organisations"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "attachments": {
+          "$ref": "#/definitions/asset_link_list"
+        },
+        "body": {
+          "$ref": "#/definitions/body_html_and_govspeak"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "manual": {
+          "$ref": "#/definitions/manual_section_parent"
+        },
+        "organisations": {
+          "$ref": "#/definitions/manual_organisations"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "required": [
+        "title",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
     "frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "base_path",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
-          "document_type": {
-            "type": "string"
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
           },
-          "schema_name": {
-            "type": "string"
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
           },
-          "public_updated_at": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
             "type": "string"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
-            "type": "string"
+          "country": {
+            "$ref": "#/definitions/country"
           },
           "description": {
             "anyOf": [
@@ -381,36 +843,11 @@
               }
             ]
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "details": {
+            "type": "object",
+            "additionalProperties": true
           },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
+          "document_type": {
             "type": "string"
           },
           "links": {
@@ -420,140 +857,205 @@
                 "$ref": "#/definitions/frontend_links"
               }
             }
-          }
-        }
-      }
-    },
-    "base_path_less_frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "locale"
-        ],
-        "properties": {
-          "document_type": {
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
             "type": "string"
           },
           "schema_name": {
             "type": "string"
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
+          "title": {
+            "type": "string"
           },
           "web_url": {
             "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
             "type": "string",
             "format": "uri"
           },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
           },
-          "public_updated_at": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
             "type": "string"
           },
-          "content_id": {
-            "$ref": "#/definitions/guid"
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
           },
           "title": {
             "type": "string"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
           }
         }
       }
     },
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "body",
-        "manual",
-        "organisations"
-      ],
-      "properties": {
-        "body": {
-          "$ref": "#/definitions/body_html_and_govspeak"
-        },
-        "attachments": {
-          "$ref": "#/definitions/asset_link_list"
-        },
-        "manual": {
-          "$ref": "#/definitions/manual_section_parent"
-        },
-        "organisations": {
-          "$ref": "#/definitions/manual_organisations"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
       }
     },
-    "external_link": {
+    "image": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
+        "alt_text": {
           "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "url": {
           "type": "string",
@@ -564,17 +1066,17 @@
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -591,212 +1093,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -855,98 +1167,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -955,10 +1300,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -966,6 +1307,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -988,79 +1333,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1072,13 +1546,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1086,61 +1554,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1148,418 +1579,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1569,9 +1593,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/manual_section/notification/schema.json
+++ b/dist/formats/manual_section/notification/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "content_id",
@@ -17,12 +16,25 @@
     "title",
     "update_type"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -34,60 +46,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -252,60 +212,9 @@
         "written_statement"
       ]
     },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "manual_section"
-      ]
-    },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
-    },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
     "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "govuk_request_id": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
     },
     "expanded_links": {
       "type": "object",
@@ -314,39 +223,572 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "govuk_request_id": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "manual_section"
+      ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "base_path_less_frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "required": [
+        "body",
+        "manual",
+        "organisations"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "attachments": {
+          "$ref": "#/definitions/asset_link_list"
+        },
+        "body": {
+          "$ref": "#/definitions/body_html_and_govspeak"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "manual": {
+          "$ref": "#/definitions/manual_section_parent"
+        },
+        "organisations": {
+          "$ref": "#/definitions/manual_organisations"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "required": [
+        "title",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
     "frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "base_path",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
-          "document_type": {
-            "type": "string"
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
           },
-          "schema_name": {
-            "type": "string"
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
           },
-          "public_updated_at": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
             "type": "string"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
-            "type": "string"
+          "country": {
+            "$ref": "#/definitions/country"
           },
           "description": {
             "anyOf": [
@@ -358,36 +800,11 @@
               }
             ]
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "details": {
+            "type": "object",
+            "additionalProperties": true
           },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
+          "document_type": {
             "type": "string"
           },
           "links": {
@@ -397,140 +814,205 @@
                 "$ref": "#/definitions/frontend_links"
               }
             }
-          }
-        }
-      }
-    },
-    "base_path_less_frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "locale"
-        ],
-        "properties": {
-          "document_type": {
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
             "type": "string"
           },
           "schema_name": {
             "type": "string"
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
+          "title": {
+            "type": "string"
           },
           "web_url": {
             "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
             "type": "string",
             "format": "uri"
           },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
           },
-          "public_updated_at": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
             "type": "string"
           },
-          "content_id": {
-            "$ref": "#/definitions/guid"
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
           },
           "title": {
             "type": "string"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
           }
         }
       }
     },
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "body",
-        "manual",
-        "organisations"
-      ],
-      "properties": {
-        "body": {
-          "$ref": "#/definitions/body_html_and_govspeak"
-        },
-        "attachments": {
-          "$ref": "#/definitions/asset_link_list"
-        },
-        "manual": {
-          "$ref": "#/definitions/manual_section_parent"
-        },
-        "organisations": {
-          "$ref": "#/definitions/manual_organisations"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
       }
     },
-    "external_link": {
+    "image": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
+        "alt_text": {
           "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "url": {
           "type": "string",
@@ -541,17 +1023,17 @@
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -568,212 +1050,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -832,98 +1124,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -932,10 +1257,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -943,6 +1264,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -965,79 +1290,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1049,13 +1503,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1063,61 +1511,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1125,418 +1536,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1546,9 +1550,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/manual_section/publisher_v2/links.json
+++ b/dist/formats/manual_section/publisher_v2/links.json
@@ -3,25 +3,22 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "previous_version": {
-      "type": "string"
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "organisations": {
-          "description": "All organisations linked to this content item. This should include lead organisations.",
+        "available_translations": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         },
         "manual": {
           "$ref": "#/definitions/guid_list"
         },
-        "available_translations": {
-          "$ref": "#/definitions/guid_list"
-        },
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
+        "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/guid_list"
         },
         "ordered_related_items": {
@@ -32,16 +29,8 @@
           "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/guid_list"
         },
-        "mainstream_browse_pages": {
-          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "meets_user_needs": {
-          "description": "The user needs this piece of content meets.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {
@@ -57,38 +46,50 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/guid_list"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
         }
       }
+    },
+    "previous_version": {
+      "type": "string"
     }
   },
   "definitions": {
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
     "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
       "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
     "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
         {
           "type": "string"
@@ -96,22 +97,158 @@
         {
           "type": "null"
         }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+      ]
     },
-    "external_related_links": {
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -122,20 +259,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -152,212 +622,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -416,98 +696,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -516,10 +829,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -527,6 +836,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -549,79 +862,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -633,13 +1075,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -647,61 +1083,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -709,418 +1108,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1130,9 +1122,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/manual_section/publisher_v2/schema.json
+++ b/dist/formats/manual_section/publisher_v2/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "title",
     "details",
@@ -13,12 +12,22 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "description": {
       "anyOf": [
@@ -30,84 +39,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "access_limited": {
-      "$ref": "#/definitions/access_limited"
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "change_note": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "previous_version": {
-      "type": "string"
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "links": {
-      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string",
@@ -272,28 +205,238 @@
         "written_statement"
       ]
     },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "manual_section"
       ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
-    "details": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
       "type": "object",
       "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
       "required": [
         "body",
         "manual",
         "organisations"
       ],
+      "additionalProperties": false,
       "properties": {
-        "body": {
-          "$ref": "#/definitions/body_html_and_govspeak"
-        },
         "attachments": {
           "$ref": "#/definitions/asset_link_list"
+        },
+        "body": {
+          "$ref": "#/definitions/body_html_and_govspeak"
         },
         "manual": {
           "$ref": "#/definitions/manual_section_parent"
@@ -303,65 +446,50 @@
         }
       }
     },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policy_areas": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -372,20 +500,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -402,212 +863,31 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
         }
       }
     },
-    "redirect_route": {
+    "links": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
       "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
         }
       }
     },
@@ -666,98 +946,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -766,10 +1079,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -777,6 +1086,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -799,79 +1112,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -883,13 +1325,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -897,61 +1333,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -959,418 +1358,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1380,9 +1372,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/need/frontend/schema.json
+++ b/dist/formats/need/frontend/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "links",
@@ -12,12 +11,25 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -29,119 +41,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_pages": {
-          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "meets_user_needs": {
-          "description": "The user needs this piece of content meets.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "organisations": {
-          "description": "All organisations linked to this content item. This should include lead organisations.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "parent": {
-          "description": "The parent content item.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policy_areas": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "primary_publishing_organisation": {
-          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "available_translations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "children": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policies": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "document_collections": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "child_taxons": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -306,67 +207,678 @@
         "written_statement"
       ]
     },
+    "email_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "available_translations": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "policies": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policy_areas": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "primary_publishing_organisation": {
+          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "need"
       ]
     },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    "title": {
+      "type": "string"
     },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
-    "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
     },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "base_path_less_frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "required": [
+        "role",
+        "goal",
+        "benefit"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "applies_to_all_organisations": {
+          "description": "Whether all linked organisations meet this need",
+          "type": "boolean"
+        },
+        "benefit": {
+          "description": "Why the user wants to do it",
+          "type": "string"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "goal": {
+          "description": "What the user wants to do",
+          "type": "string"
+        },
+        "impact": {
+          "description": "Impact of GOV.UK not doing this",
+          "type": "string"
+        },
+        "justifications": {
+          "description": "How this need fits in the proposition for GOV.UK",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "legislation": {
+          "description": "Legislation that underpins this need",
+          "type": "string"
+        },
+        "met_when": {
+          "description": "Provides criteria that define when this user need has been met",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "need_id": {
+          "description": "Six digit id which used to be the primary id for Needs. Still being displayed in Maslow and Info-Frontend, but likely to be deprecated in the future.",
+          "type": "string"
+        },
+        "other_evidence": {
+          "description": "Any other evidence to support this need, ie. user research, campaigns, user demand",
+          "type": "string"
+        },
+        "role": {
+          "description": "The type of user, such as a small business, a tax agent, a healthcare practitioner",
+          "type": "string"
+        },
+        "yearly_need_views": {
+          "description": "Number of pageviews specific to this need generated each year",
+          "type": "integer"
+        },
+        "yearly_searches": {
+          "description": "Number of searches specific to this need carried out each year",
+          "type": "integer"
+        },
+        "yearly_site_views": {
+          "description": "Number of yearly pageviews of the whole site of the requester",
+          "type": "integer"
+        },
+        "yearly_user_contacts": {
+          "description": "Number of user contacts received about this need each year. Includes calls to contact centres, emails, customer service tickets",
+          "type": "integer"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "required": [
+        "title",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
     "frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "base_path",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
-          "document_type": {
-            "type": "string"
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
           },
-          "schema_name": {
-            "type": "string"
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
           },
-          "public_updated_at": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
             "type": "string"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
-            "type": "string"
+          "country": {
+            "$ref": "#/definitions/country"
           },
           "description": {
             "anyOf": [
@@ -378,36 +890,11 @@
               }
             ]
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "details": {
+            "type": "object",
+            "additionalProperties": true
           },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
+          "document_type": {
             "type": "string"
           },
           "links": {
@@ -417,190 +904,205 @@
                 "$ref": "#/definitions/frontend_links"
               }
             }
-          }
-        }
-      }
-    },
-    "base_path_less_frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "locale"
-        ],
-        "properties": {
-          "document_type": {
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
             "type": "string"
           },
           "schema_name": {
             "type": "string"
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
+          "title": {
+            "type": "string"
           },
           "web_url": {
             "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
             "type": "string",
             "format": "uri"
           },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
           },
-          "public_updated_at": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
             "type": "string"
           },
-          "content_id": {
-            "$ref": "#/definitions/guid"
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
           },
           "title": {
             "type": "string"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
           }
         }
       }
     },
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "role",
-        "goal",
-        "benefit"
-      ],
-      "properties": {
-        "role": {
-          "type": "string",
-          "description": "The type of user, such as a small business, a tax agent, a healthcare practitioner"
-        },
-        "goal": {
-          "type": "string",
-          "description": "What the user wants to do"
-        },
-        "benefit": {
-          "type": "string",
-          "description": "Why the user wants to do it"
-        },
-        "applies_to_all_organisations": {
-          "type": "boolean",
-          "description": "Whether all linked organisations meet this need"
-        },
-        "impact": {
-          "type": "string",
-          "description": "Impact of GOV.UK not doing this"
-        },
-        "justifications": {
-          "description": "How this need fits in the proposition for GOV.UK",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "legislation": {
-          "type": "string",
-          "description": "Legislation that underpins this need"
-        },
-        "met_when": {
-          "description": "Provides criteria that define when this user need has been met",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "other_evidence": {
-          "type": "string",
-          "description": "Any other evidence to support this need, ie. user research, campaigns, user demand"
-        },
-        "need_id": {
-          "type": "string",
-          "description": "Six digit id which used to be the primary id for Needs. Still being displayed in Maslow and Info-Frontend, but likely to be deprecated in the future."
-        },
-        "yearly_need_views": {
-          "type": "integer",
-          "description": "Number of pageviews specific to this need generated each year"
-        },
-        "yearly_searches": {
-          "type": "integer",
-          "description": "Number of searches specific to this need carried out each year"
-        },
-        "yearly_site_views": {
-          "type": "integer",
-          "description": "Number of yearly pageviews of the whole site of the requester"
-        },
-        "yearly_user_contacts": {
-          "type": "integer",
-          "description": "Number of user contacts received about this need each year. Includes calls to contact centres, emails, customer service tickets"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
       }
     },
-    "external_link": {
+    "image": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
+        "alt_text": {
           "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "url": {
           "type": "string",
@@ -611,17 +1113,17 @@
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -638,212 +1140,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -902,98 +1214,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -1002,10 +1347,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -1013,6 +1354,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -1035,79 +1380,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1119,13 +1593,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1133,61 +1601,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1195,418 +1626,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1616,9 +1640,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/need/notification/schema.json
+++ b/dist/formats/need/notification/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "content_id",
@@ -17,12 +16,25 @@
     "title",
     "update_type"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -34,60 +46,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -252,60 +212,9 @@
         "written_statement"
       ]
     },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "need"
-      ]
-    },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
-    },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
     "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "govuk_request_id": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
     },
     "expanded_links": {
       "type": "object",
@@ -314,39 +223,622 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "govuk_request_id": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "need"
+      ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "base_path_less_frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "required": [
+        "role",
+        "goal",
+        "benefit"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "applies_to_all_organisations": {
+          "description": "Whether all linked organisations meet this need",
+          "type": "boolean"
+        },
+        "benefit": {
+          "description": "Why the user wants to do it",
+          "type": "string"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "goal": {
+          "description": "What the user wants to do",
+          "type": "string"
+        },
+        "impact": {
+          "description": "Impact of GOV.UK not doing this",
+          "type": "string"
+        },
+        "justifications": {
+          "description": "How this need fits in the proposition for GOV.UK",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "legislation": {
+          "description": "Legislation that underpins this need",
+          "type": "string"
+        },
+        "met_when": {
+          "description": "Provides criteria that define when this user need has been met",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "need_id": {
+          "description": "Six digit id which used to be the primary id for Needs. Still being displayed in Maslow and Info-Frontend, but likely to be deprecated in the future.",
+          "type": "string"
+        },
+        "other_evidence": {
+          "description": "Any other evidence to support this need, ie. user research, campaigns, user demand",
+          "type": "string"
+        },
+        "role": {
+          "description": "The type of user, such as a small business, a tax agent, a healthcare practitioner",
+          "type": "string"
+        },
+        "yearly_need_views": {
+          "description": "Number of pageviews specific to this need generated each year",
+          "type": "integer"
+        },
+        "yearly_searches": {
+          "description": "Number of searches specific to this need carried out each year",
+          "type": "integer"
+        },
+        "yearly_site_views": {
+          "description": "Number of yearly pageviews of the whole site of the requester",
+          "type": "integer"
+        },
+        "yearly_user_contacts": {
+          "description": "Number of user contacts received about this need each year. Includes calls to contact centres, emails, customer service tickets",
+          "type": "integer"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "required": [
+        "title",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
     "frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "base_path",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
-          "document_type": {
-            "type": "string"
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
           },
-          "schema_name": {
-            "type": "string"
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
           },
-          "public_updated_at": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
             "type": "string"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
-            "type": "string"
+          "country": {
+            "$ref": "#/definitions/country"
           },
           "description": {
             "anyOf": [
@@ -358,36 +850,11 @@
               }
             ]
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "details": {
+            "type": "object",
+            "additionalProperties": true
           },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
+          "document_type": {
             "type": "string"
           },
           "links": {
@@ -397,190 +864,205 @@
                 "$ref": "#/definitions/frontend_links"
               }
             }
-          }
-        }
-      }
-    },
-    "base_path_less_frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "locale"
-        ],
-        "properties": {
-          "document_type": {
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
             "type": "string"
           },
           "schema_name": {
             "type": "string"
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
+          "title": {
+            "type": "string"
           },
           "web_url": {
             "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
             "type": "string",
             "format": "uri"
           },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
           },
-          "public_updated_at": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
             "type": "string"
           },
-          "content_id": {
-            "$ref": "#/definitions/guid"
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
           },
           "title": {
             "type": "string"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
           }
         }
       }
     },
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "role",
-        "goal",
-        "benefit"
-      ],
-      "properties": {
-        "role": {
-          "type": "string",
-          "description": "The type of user, such as a small business, a tax agent, a healthcare practitioner"
-        },
-        "goal": {
-          "type": "string",
-          "description": "What the user wants to do"
-        },
-        "benefit": {
-          "type": "string",
-          "description": "Why the user wants to do it"
-        },
-        "applies_to_all_organisations": {
-          "type": "boolean",
-          "description": "Whether all linked organisations meet this need"
-        },
-        "impact": {
-          "type": "string",
-          "description": "Impact of GOV.UK not doing this"
-        },
-        "justifications": {
-          "description": "How this need fits in the proposition for GOV.UK",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "legislation": {
-          "type": "string",
-          "description": "Legislation that underpins this need"
-        },
-        "met_when": {
-          "description": "Provides criteria that define when this user need has been met",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "other_evidence": {
-          "type": "string",
-          "description": "Any other evidence to support this need, ie. user research, campaigns, user demand"
-        },
-        "need_id": {
-          "type": "string",
-          "description": "Six digit id which used to be the primary id for Needs. Still being displayed in Maslow and Info-Frontend, but likely to be deprecated in the future."
-        },
-        "yearly_need_views": {
-          "type": "integer",
-          "description": "Number of pageviews specific to this need generated each year"
-        },
-        "yearly_searches": {
-          "type": "integer",
-          "description": "Number of searches specific to this need carried out each year"
-        },
-        "yearly_site_views": {
-          "type": "integer",
-          "description": "Number of yearly pageviews of the whole site of the requester"
-        },
-        "yearly_user_contacts": {
-          "type": "integer",
-          "description": "Number of user contacts received about this need each year. Includes calls to contact centres, emails, customer service tickets"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
       }
     },
-    "external_link": {
+    "image": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
+        "alt_text": {
           "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "url": {
           "type": "string",
@@ -591,17 +1073,17 @@
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -618,212 +1100,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -882,98 +1174,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -982,10 +1307,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -993,6 +1314,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -1015,79 +1340,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1099,13 +1553,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1113,61 +1561,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1175,418 +1586,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1596,9 +1600,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/need/publisher_v2/links.json
+++ b/dist/formats/need/publisher_v2/links.json
@@ -3,25 +3,10 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "previous_version": {
-      "type": "string"
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/guid_list"
-        },
         "mainstream_browse_pages": {
           "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/guid_list"
@@ -30,8 +15,12 @@
           "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/guid_list"
         },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
@@ -51,38 +40,50 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/guid_list"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
         }
       }
+    },
+    "previous_version": {
+      "type": "string"
     }
   },
   "definitions": {
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
     "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
       "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
     "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
         {
           "type": "string"
@@ -90,22 +91,158 @@
         {
           "type": "null"
         }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+      ]
     },
-    "external_related_links": {
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -116,20 +253,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -146,212 +616,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -410,98 +690,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -510,10 +823,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -521,6 +830,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -543,79 +856,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -627,13 +1069,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -641,61 +1077,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -703,418 +1102,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1124,9 +1116,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/need/publisher_v2/schema.json
+++ b/dist/formats/need/publisher_v2/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "title",
     "details",
@@ -13,12 +12,22 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "description": {
       "anyOf": [
@@ -30,84 +39,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "access_limited": {
-      "$ref": "#/definitions/access_limited"
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "change_note": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "previous_version": {
-      "type": "string"
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "links": {
-      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string",
@@ -272,42 +205,248 @@
         "written_statement"
       ]
     },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "need"
       ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
-    "details": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
       "type": "object",
       "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
       "required": [
         "role",
         "goal",
         "benefit"
       ],
+      "additionalProperties": false,
       "properties": {
-        "role": {
-          "type": "string",
-          "description": "The type of user, such as a small business, a tax agent, a healthcare practitioner"
-        },
-        "goal": {
-          "type": "string",
-          "description": "What the user wants to do"
+        "applies_to_all_organisations": {
+          "description": "Whether all linked organisations meet this need",
+          "type": "boolean"
         },
         "benefit": {
-          "type": "string",
-          "description": "Why the user wants to do it"
+          "description": "Why the user wants to do it",
+          "type": "string"
         },
-        "applies_to_all_organisations": {
-          "type": "boolean",
-          "description": "Whether all linked organisations meet this need"
+        "goal": {
+          "description": "What the user wants to do",
+          "type": "string"
         },
         "impact": {
-          "type": "string",
-          "description": "Impact of GOV.UK not doing this"
+          "description": "Impact of GOV.UK not doing this",
+          "type": "string"
         },
         "justifications": {
           "description": "How this need fits in the proposition for GOV.UK",
@@ -317,8 +456,8 @@
           }
         },
         "legislation": {
-          "type": "string",
-          "description": "Legislation that underpins this need"
+          "description": "Legislation that underpins this need",
+          "type": "string"
         },
         "met_when": {
           "description": "Provides criteria that define when this user need has been met",
@@ -327,91 +466,80 @@
             "type": "string"
           }
         },
-        "other_evidence": {
-          "type": "string",
-          "description": "Any other evidence to support this need, ie. user research, campaigns, user demand"
-        },
         "need_id": {
-          "type": "string",
-          "description": "Six digit id which used to be the primary id for Needs. Still being displayed in Maslow and Info-Frontend, but likely to be deprecated in the future."
-        },
-        "yearly_need_views": {
-          "type": "integer",
-          "description": "Number of pageviews specific to this need generated each year"
-        },
-        "yearly_searches": {
-          "type": "integer",
-          "description": "Number of searches specific to this need carried out each year"
-        },
-        "yearly_site_views": {
-          "type": "integer",
-          "description": "Number of yearly pageviews of the whole site of the requester"
-        },
-        "yearly_user_contacts": {
-          "type": "integer",
-          "description": "Number of user contacts received about this need each year. Includes calls to contact centres, emails, customer service tickets"
-        }
-      }
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policy_areas": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
+          "description": "Six digit id which used to be the primary id for Needs. Still being displayed in Maslow and Info-Frontend, but likely to be deprecated in the future.",
           "type": "string"
         },
-        {
-          "type": "null"
+        "other_evidence": {
+          "description": "Any other evidence to support this need, ie. user research, campaigns, user demand",
+          "type": "string"
+        },
+        "role": {
+          "description": "The type of user, such as a small business, a tax agent, a healthcare practitioner",
+          "type": "string"
+        },
+        "yearly_need_views": {
+          "description": "Number of pageviews specific to this need generated each year",
+          "type": "integer"
+        },
+        "yearly_searches": {
+          "description": "Number of searches specific to this need carried out each year",
+          "type": "integer"
+        },
+        "yearly_site_views": {
+          "description": "Number of yearly pageviews of the whole site of the requester",
+          "type": "integer"
+        },
+        "yearly_user_contacts": {
+          "description": "Number of user contacts received about this need each year. Includes calls to contact centres, emails, customer service tickets",
+          "type": "integer"
         }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+      }
     },
-    "external_related_links": {
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -422,20 +550,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -452,212 +913,31 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
         }
       }
     },
-    "redirect_route": {
+    "links": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
       "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
         }
       }
     },
@@ -716,98 +996,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -816,10 +1129,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -827,6 +1136,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -849,79 +1162,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -933,13 +1375,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -947,61 +1383,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1009,418 +1408,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1430,9 +1422,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/news_article/frontend/schema.json
+++ b/dist/formats/news_article/frontend/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "links",
@@ -12,12 +11,25 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -29,142 +41,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "related_policies": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ministers": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "topical_events": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "world_locations": {
-          "$ref": "#/definitions/base_path_less_frontend_links"
-        },
-        "worldwide_organisations": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "roles": {
-          "description": "Used to power Email Alert Api subscriptions for Whitehall content",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "people": {
-          "description": "Used to power Email Alert Api subscriptions for Whitehall content",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_pages": {
-          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "meets_user_needs": {
-          "description": "The user needs this piece of content meets.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "organisations": {
-          "description": "All organisations linked to this content item. This should include lead organisations.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "parent": {
-          "description": "The parent content item.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policy_areas": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "primary_publishing_organisation": {
-          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "available_translations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "children": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policies": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "document_collections": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "child_taxons": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -329,67 +207,661 @@
         "written_statement"
       ]
     },
+    "email_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "available_translations": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ministers": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "people": {
+          "description": "Used to power Email Alert Api subscriptions for Whitehall content",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policies": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policy_areas": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "primary_publishing_organisation": {
+          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "related_policies": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "roles": {
+          "description": "Used to power Email Alert Api subscriptions for Whitehall content",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "topical_events": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "world_locations": {
+          "$ref": "#/definitions/base_path_less_frontend_links"
+        },
+        "worldwide_organisations": {
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "news_article"
       ]
     },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    "title": {
+      "type": "string"
     },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
-    "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
     },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "base_path_less_frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "required": [
+        "body",
+        "first_public_at",
+        "government",
+        "political"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "body": {
+          "$ref": "#/definitions/body"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "emphasised_organisations": {
+          "$ref": "#/definitions/emphasised_organisations"
+        },
+        "first_public_at": {
+          "$ref": "#/definitions/first_public_at"
+        },
+        "government": {
+          "$ref": "#/definitions/government"
+        },
+        "image": {
+          "$ref": "#/definitions/image"
+        },
+        "political": {
+          "$ref": "#/definitions/political"
+        },
+        "tags": {
+          "$ref": "#/definitions/tags"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "required": [
+        "title",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
     "frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "base_path",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
-          "document_type": {
-            "type": "string"
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
           },
-          "schema_name": {
-            "type": "string"
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
           },
-          "public_updated_at": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
             "type": "string"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
-            "type": "string"
+          "country": {
+            "$ref": "#/definitions/country"
           },
           "description": {
             "anyOf": [
@@ -401,36 +873,11 @@
               }
             ]
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "details": {
+            "type": "object",
+            "additionalProperties": true
           },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
+          "document_type": {
             "type": "string"
           },
           "links": {
@@ -440,150 +887,205 @@
                 "$ref": "#/definitions/frontend_links"
               }
             }
-          }
-        }
-      }
-    },
-    "base_path_less_frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "locale"
-        ],
-        "properties": {
-          "document_type": {
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
             "type": "string"
           },
           "schema_name": {
             "type": "string"
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
+          "title": {
+            "type": "string"
           },
           "web_url": {
             "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
             "type": "string",
             "format": "uri"
           },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
           },
-          "public_updated_at": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
             "type": "string"
           },
-          "content_id": {
-            "$ref": "#/definitions/guid"
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
           },
           "title": {
             "type": "string"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
           }
         }
       }
     },
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "body",
-        "first_public_at",
-        "government",
-        "political"
-      ],
-      "properties": {
-        "body": {
-          "$ref": "#/definitions/body"
-        },
-        "image": {
-          "$ref": "#/definitions/image"
-        },
-        "first_public_at": {
-          "$ref": "#/definitions/first_public_at"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        },
-        "tags": {
-          "$ref": "#/definitions/tags"
-        },
-        "emphasised_organisations": {
-          "$ref": "#/definitions/emphasised_organisations"
-        },
-        "government": {
-          "$ref": "#/definitions/government"
-        },
-        "political": {
-          "$ref": "#/definitions/political"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
       }
     },
-    "external_link": {
+    "image": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
+        "alt_text": {
           "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "url": {
           "type": "string",
@@ -594,17 +1096,17 @@
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -621,212 +1123,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -885,98 +1197,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -985,10 +1330,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -996,6 +1337,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -1018,79 +1363,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1102,13 +1576,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1116,61 +1584,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1178,418 +1609,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1599,9 +1623,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/news_article/notification/schema.json
+++ b/dist/formats/news_article/notification/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "content_id",
@@ -17,12 +16,25 @@
     "title",
     "update_type"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -34,60 +46,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -252,60 +212,9 @@
         "written_statement"
       ]
     },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "news_article"
-      ]
-    },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
-    },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
     "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "govuk_request_id": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
     },
     "expanded_links": {
       "type": "object",
@@ -314,39 +223,582 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "govuk_request_id": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "news_article"
+      ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "base_path_less_frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "required": [
+        "body",
+        "first_public_at",
+        "government",
+        "political"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "body": {
+          "$ref": "#/definitions/body"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "emphasised_organisations": {
+          "$ref": "#/definitions/emphasised_organisations"
+        },
+        "first_public_at": {
+          "$ref": "#/definitions/first_public_at"
+        },
+        "government": {
+          "$ref": "#/definitions/government"
+        },
+        "image": {
+          "$ref": "#/definitions/image"
+        },
+        "political": {
+          "$ref": "#/definitions/political"
+        },
+        "tags": {
+          "$ref": "#/definitions/tags"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "required": [
+        "title",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
     "frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "base_path",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
-          "document_type": {
-            "type": "string"
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
           },
-          "schema_name": {
-            "type": "string"
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
           },
-          "public_updated_at": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
             "type": "string"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
-            "type": "string"
+          "country": {
+            "$ref": "#/definitions/country"
           },
           "description": {
             "anyOf": [
@@ -358,36 +810,11 @@
               }
             ]
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "details": {
+            "type": "object",
+            "additionalProperties": true
           },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
+          "document_type": {
             "type": "string"
           },
           "links": {
@@ -397,150 +824,205 @@
                 "$ref": "#/definitions/frontend_links"
               }
             }
-          }
-        }
-      }
-    },
-    "base_path_less_frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "locale"
-        ],
-        "properties": {
-          "document_type": {
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
             "type": "string"
           },
           "schema_name": {
             "type": "string"
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
+          "title": {
+            "type": "string"
           },
           "web_url": {
             "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
             "type": "string",
             "format": "uri"
           },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
           },
-          "public_updated_at": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
             "type": "string"
           },
-          "content_id": {
-            "$ref": "#/definitions/guid"
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
           },
           "title": {
             "type": "string"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
           }
         }
       }
     },
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "body",
-        "first_public_at",
-        "government",
-        "political"
-      ],
-      "properties": {
-        "body": {
-          "$ref": "#/definitions/body"
-        },
-        "image": {
-          "$ref": "#/definitions/image"
-        },
-        "first_public_at": {
-          "$ref": "#/definitions/first_public_at"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        },
-        "tags": {
-          "$ref": "#/definitions/tags"
-        },
-        "emphasised_organisations": {
-          "$ref": "#/definitions/emphasised_organisations"
-        },
-        "government": {
-          "$ref": "#/definitions/government"
-        },
-        "political": {
-          "$ref": "#/definitions/political"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
       }
     },
-    "external_link": {
+    "image": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
+        "alt_text": {
           "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "url": {
           "type": "string",
@@ -551,17 +1033,17 @@
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -578,212 +1060,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -842,98 +1134,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -942,10 +1267,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -953,6 +1274,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -975,79 +1300,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1059,13 +1513,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1073,61 +1521,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1135,418 +1546,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1556,9 +1560,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/news_article/publisher_v2/links.json
+++ b/dist/formats/news_article/publisher_v2/links.json
@@ -3,48 +3,10 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "previous_version": {
-      "type": "string"
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "related_policies": {
-          "$ref": "#/definitions/guid_list"
-        },
-        "ministers": {
-          "$ref": "#/definitions/guid_list"
-        },
-        "topical_events": {
-          "$ref": "#/definitions/guid_list"
-        },
-        "world_locations": {
-          "$ref": "#/definitions/guid_list"
-        },
-        "worldwide_organisations": {
-          "$ref": "#/definitions/guid_list"
-        },
-        "roles": {
-          "$ref": "#/definitions/guid_list",
-          "description": "Used to power Email Alert Api subscriptions for Whitehall content"
-        },
-        "people": {
-          "$ref": "#/definitions/guid_list",
-          "description": "Used to power Email Alert Api subscriptions for Whitehall content"
-        },
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/guid_list"
-        },
         "mainstream_browse_pages": {
           "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/guid_list"
@@ -53,8 +15,15 @@
           "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/guid_list"
         },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+        "ministers": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
@@ -66,6 +35,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "people": {
+          "description": "Used to power Email Alert Api subscriptions for Whitehall content",
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"
@@ -74,38 +47,66 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "related_policies": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "roles": {
+          "description": "Used to power Email Alert Api subscriptions for Whitehall content",
+          "$ref": "#/definitions/guid_list"
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/guid_list"
+        },
+        "topical_events": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "world_locations": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "worldwide_organisations": {
+          "$ref": "#/definitions/guid_list"
         }
       }
+    },
+    "previous_version": {
+      "type": "string"
     }
   },
   "definitions": {
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
     "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
       "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
     "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
         {
           "type": "string"
@@ -113,22 +114,158 @@
         {
           "type": "null"
         }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+      ]
     },
-    "external_related_links": {
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -139,20 +276,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -169,212 +639,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -433,98 +713,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -533,10 +846,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -544,6 +853,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -566,79 +879,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -650,13 +1092,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -664,61 +1100,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -726,418 +1125,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1147,9 +1139,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/news_article/publisher_v2/schema.json
+++ b/dist/formats/news_article/publisher_v2/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "title",
     "details",
@@ -13,12 +12,22 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "description": {
       "anyOf": [
@@ -30,84 +39,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "access_limited": {
-      "$ref": "#/definitions/access_limited"
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "change_note": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "previous_version": {
-      "type": "string"
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "links": {
-      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string",
@@ -272,86 +205,109 @@
         "written_statement"
       ]
     },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "news_article"
       ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "body",
-        "first_public_at",
-        "government",
-        "political"
-      ],
-      "properties": {
-        "body": {
-          "$ref": "#/definitions/body"
-        },
-        "image": {
-          "$ref": "#/definitions/image"
-        },
-        "first_public_at": {
-          "$ref": "#/definitions/first_public_at"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        },
-        "tags": {
-          "$ref": "#/definitions/tags"
-        },
-        "emphasised_organisations": {
-          "$ref": "#/definitions/emphasised_organisations"
-        },
-        "government": {
-          "$ref": "#/definitions/government"
-        },
-        "political": {
-          "$ref": "#/definitions/political"
-        }
-      }
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policy_areas": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
     },
     "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
       "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
     "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
         {
           "type": "string"
@@ -359,22 +315,194 @@
         {
           "type": "null"
         }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+      ]
     },
-    "external_related_links": {
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "required": [
+        "body",
+        "first_public_at",
+        "government",
+        "political"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "body": {
+          "$ref": "#/definitions/body"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "emphasised_organisations": {
+          "$ref": "#/definitions/emphasised_organisations"
+        },
+        "first_public_at": {
+          "$ref": "#/definitions/first_public_at"
+        },
+        "government": {
+          "$ref": "#/definitions/government"
+        },
+        "image": {
+          "$ref": "#/definitions/image"
+        },
+        "political": {
+          "$ref": "#/definitions/political"
+        },
+        "tags": {
+          "$ref": "#/definitions/tags"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -385,20 +513,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -415,212 +876,31 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
         }
       }
     },
-    "redirect_route": {
+    "links": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
       "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
         }
       }
     },
@@ -679,98 +959,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -779,10 +1092,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -790,6 +1099,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -812,79 +1125,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -896,13 +1338,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -910,61 +1346,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -972,418 +1371,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1393,9 +1385,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/place/frontend/schema.json
+++ b/dist/formats/place/frontend/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "links",
@@ -12,12 +11,25 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -29,119 +41,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_pages": {
-          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "meets_user_needs": {
-          "description": "The user needs this piece of content meets.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "organisations": {
-          "description": "All organisations linked to this content item. This should include lead organisations.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "parent": {
-          "description": "The parent content item.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policy_areas": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "primary_publishing_organisation": {
-          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "available_translations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "children": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policies": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "document_collections": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "child_taxons": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -306,140 +207,262 @@
         "written_statement"
       ]
     },
+    "email_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "available_translations": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "policies": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policy_areas": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "primary_publishing_organisation": {
+          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "place"
       ]
     },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    "title": {
+      "type": "string"
     },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
-    "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
     },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
-    "frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "base_path",
-          "locale"
-        ],
-        "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
-          },
-          "document_type": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
             "type": "string"
-          },
-          "schema_name": {
-            "type": "string"
-          },
-          "public_updated_at": {
-            "type": "string"
-          },
-          "content_id": {
-            "$ref": "#/definitions/guid"
-          },
-          "title": {
-            "type": "string"
-          },
-          "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
-            "type": "string"
-          },
-          "links": {
-            "type": "object",
-            "patternProperties": {
-              "^[a-z_]+$": {
-                "$ref": "#/definitions/frontend_links"
-              }
-            }
           }
         }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
       }
     },
     "base_path_less_frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "document_type": {
-            "type": "string"
-          },
-          "schema_name": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
           "api_path": {
             "$ref": "#/definitions/absolute_path"
@@ -449,25 +472,93 @@
             "type": "string",
             "format": "uri"
           },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "public_updated_at": {
-            "type": "string"
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
+          "document_type": {
             "type": "string"
           },
           "locale": {
             "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
           }
         }
       }
@@ -476,6 +567,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
         "external_related_links": {
           "$ref": "#/definitions/external_related_links"
         },
@@ -490,62 +584,53 @@
         },
         "place_type": {
           "type": "string"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
         }
       }
     },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -556,20 +641,437 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "base_path",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
+            "type": "string"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "country": {
+            "$ref": "#/definitions/country"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "details": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "links": {
+            "type": "object",
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links"
+              }
+            }
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -586,212 +1088,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -850,98 +1162,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -950,10 +1295,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -961,6 +1302,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -983,79 +1328,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1067,13 +1541,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1081,61 +1549,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1143,418 +1574,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1564,9 +1588,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/place/notification/schema.json
+++ b/dist/formats/place/notification/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "content_id",
@@ -17,12 +16,25 @@
     "title",
     "update_type"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -34,60 +46,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -252,60 +212,9 @@
         "written_statement"
       ]
     },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "place"
-      ]
-    },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
-    },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
     "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "govuk_request_id": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
     },
     "expanded_links": {
       "type": "object",
@@ -314,112 +223,206 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "govuk_request_id": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "place"
+      ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
-    "frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "base_path",
-          "locale"
-        ],
-        "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
-          },
-          "document_type": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
             "type": "string"
-          },
-          "schema_name": {
-            "type": "string"
-          },
-          "public_updated_at": {
-            "type": "string"
-          },
-          "content_id": {
-            "$ref": "#/definitions/guid"
-          },
-          "title": {
-            "type": "string"
-          },
-          "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
-            "type": "string"
-          },
-          "links": {
-            "type": "object",
-            "patternProperties": {
-              "^[a-z_]+$": {
-                "$ref": "#/definitions/frontend_links"
-              }
-            }
           }
         }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
       }
     },
     "base_path_less_frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "document_type": {
-            "type": "string"
-          },
-          "schema_name": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
           "api_path": {
             "$ref": "#/definitions/absolute_path"
@@ -429,25 +432,93 @@
             "type": "string",
             "format": "uri"
           },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "public_updated_at": {
-            "type": "string"
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
+          "document_type": {
             "type": "string"
           },
           "locale": {
             "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
           }
         }
       }
@@ -456,6 +527,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
         "external_related_links": {
           "$ref": "#/definitions/external_related_links"
         },
@@ -470,62 +544,53 @@
         },
         "place_type": {
           "type": "string"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
         }
       }
     },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -536,20 +601,437 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "base_path",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
+            "type": "string"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "country": {
+            "$ref": "#/definitions/country"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "details": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "links": {
+            "type": "object",
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links"
+              }
+            }
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -566,212 +1048,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -830,98 +1122,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -930,10 +1255,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -941,6 +1262,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -963,79 +1288,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1047,13 +1501,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1061,61 +1509,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1123,418 +1534,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1544,9 +1548,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/place/publisher_v2/links.json
+++ b/dist/formats/place/publisher_v2/links.json
@@ -3,25 +3,10 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "previous_version": {
-      "type": "string"
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/guid_list"
-        },
         "mainstream_browse_pages": {
           "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/guid_list"
@@ -30,8 +15,12 @@
           "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/guid_list"
         },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
@@ -51,38 +40,50 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/guid_list"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
         }
       }
+    },
+    "previous_version": {
+      "type": "string"
     }
   },
   "definitions": {
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
     "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
       "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
     "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
         {
           "type": "string"
@@ -90,22 +91,158 @@
         {
           "type": "null"
         }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+      ]
     },
-    "external_related_links": {
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -116,20 +253,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -146,212 +616,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -410,98 +690,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -510,10 +823,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -521,6 +830,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -543,79 +856,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -627,13 +1069,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -641,61 +1077,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -703,418 +1102,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1124,9 +1116,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/place/publisher_v2/schema.json
+++ b/dist/formats/place/publisher_v2/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "title",
     "details",
@@ -13,12 +12,22 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "description": {
       "anyOf": [
@@ -30,84 +39,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "access_limited": {
-      "$ref": "#/definitions/access_limited"
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "change_note": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "previous_version": {
-      "type": "string"
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "links": {
-      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string",
@@ -272,14 +205,224 @@
         "written_statement"
       ]
     },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "place"
       ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,
@@ -301,65 +444,50 @@
         }
       }
     },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policy_areas": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -370,20 +498,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -400,212 +861,31 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
         }
       }
     },
-    "redirect_route": {
+    "links": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
       "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
         }
       }
     },
@@ -664,98 +944,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -764,10 +1077,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -775,6 +1084,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -797,79 +1110,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -881,13 +1323,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -895,61 +1331,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -957,418 +1356,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1378,9 +1370,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/placeholder/frontend/schema.json
+++ b/dist/formats/placeholder/frontend/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "links",
@@ -12,12 +11,25 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -29,123 +41,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_pages": {
-          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "meets_user_needs": {
-          "description": "The user needs this piece of content meets.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "organisations": {
-          "description": "All organisations linked to this content item. This should include lead organisations.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "parent": {
-          "description": "The parent content item.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policy_areas": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "primary_publishing_organisation": {
-          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "featured_policies": {
-          "description": "Featured policies primarily for use with Whitehall organisations",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "available_translations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "children": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policies": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "document_collections": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "child_taxons": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -310,139 +207,265 @@
         "written_statement"
       ]
     },
-    "schema_name": {
-      "type": "string",
-      "pattern": "^(placeholder|placeholder_.+)$",
-      "description": "Should be of the form 'placeholder_my_format_name'. 'placeholder' is allowed for backwards compatibility."
-    },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
-    },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
     "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
     },
     "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
       "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "available_translations": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "featured_policies": {
+          "description": "Featured policies primarily for use with Whitehall organisations",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "policies": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policy_areas": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "primary_publishing_organisation": {
+          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
+    "schema_name": {
+      "description": "Should be of the form 'placeholder_my_format_name'. 'placeholder' is allowed for backwards compatibility.",
+      "type": "string",
+      "pattern": "^(placeholder|placeholder_.+)$"
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
     },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
-    "frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "base_path",
-          "locale"
-        ],
-        "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
-          },
-          "document_type": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
             "type": "string"
-          },
-          "schema_name": {
-            "type": "string"
-          },
-          "public_updated_at": {
-            "type": "string"
-          },
-          "content_id": {
-            "$ref": "#/definitions/guid"
-          },
-          "title": {
-            "type": "string"
-          },
-          "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
-            "type": "string"
-          },
-          "links": {
-            "type": "object",
-            "patternProperties": {
-              "^[a-z_]+$": {
-                "$ref": "#/definitions/frontend_links"
-              }
-            }
           }
         }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
       }
     },
     "base_path_less_frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "document_type": {
-            "type": "string"
-          },
-          "schema_name": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
           "api_path": {
             "$ref": "#/definitions/absolute_path"
@@ -452,25 +475,93 @@
             "type": "string",
             "format": "uri"
           },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "public_updated_at": {
-            "type": "string"
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
+          "document_type": {
             "type": "string"
           },
           "locale": {
             "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
           }
         }
       }
@@ -482,34 +573,32 @@
         "analytics_identifier": {
           "$ref": "#/definitions/analytics_identifier"
         },
-        "change_note": {
-          "$ref": "#/definitions/change_note"
-        },
-        "start_date": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Used for topical events, so that related documents can get the date. Remove when topical events are migrated."
-        },
-        "end_date": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Used for topical events, so that related documents can get the date. Remove when topical events are migrated."
-        },
         "brand": {
+          "description": "Used for organisations, to allow us to publish branding / logo information. Remove when organisations are migrated.",
           "type": [
             "string",
             "null"
-          ],
-          "description": "Used for organisations, to allow us to publish branding / logo information. Remove when organisations are migrated."
+          ]
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "change_note": {
+          "$ref": "#/definitions/change_note"
+        },
+        "end_date": {
+          "description": "Used for topical events, so that related documents can get the date. Remove when topical events are migrated.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "external_related_links": {
+          "$ref": "#/definitions/external_related_links"
         },
         "logo": {
           "type": "object",
           "properties": {
-            "formatted_title": {
-              "type": "string",
-              "description": "Used for organisations, to allow us to publish branding / logo information. Remove when organisations are migrated."
-            },
             "crest": {
+              "description": "Used for organisations, to allow us to publish branding / logo information. Remove when organisations are migrated.",
               "type": [
                 "string",
                 "null"
@@ -526,8 +615,11 @@
                 "ukaea",
                 "wales",
                 null
-              ],
-              "description": "Used for organisations, to allow us to publish branding / logo information. Remove when organisations are migrated."
+              ]
+            },
+            "formatted_title": {
+              "description": "Used for organisations, to allow us to publish branding / logo information. Remove when organisations are migrated.",
+              "type": "string"
             },
             "image": {
               "description": "An image for organisations that use a custom logo",
@@ -535,67 +627,60 @@
             }
           }
         },
-        "external_related_links": {
-          "$ref": "#/definitions/external_related_links"
+        "start_date": {
+          "description": "Used for topical events, so that related documents can get the date. Remove when topical events are migrated.",
+          "type": "string",
+          "format": "date-time"
         },
         "tags": {
           "$ref": "#/definitions/tags"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
         }
       }
     },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -606,20 +691,437 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "base_path",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
+            "type": "string"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "country": {
+            "$ref": "#/definitions/country"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "details": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "links": {
+            "type": "object",
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links"
+              }
+            }
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -636,212 +1138,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -900,98 +1212,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -1000,10 +1345,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -1011,6 +1352,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -1033,79 +1378,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1117,13 +1591,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1131,61 +1599,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1193,418 +1624,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1614,9 +1638,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/placeholder/notification/schema.json
+++ b/dist/formats/placeholder/notification/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "content_id",
@@ -17,12 +16,25 @@
     "title",
     "update_type"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -34,60 +46,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -252,59 +212,9 @@
         "written_statement"
       ]
     },
-    "schema_name": {
-      "type": "string",
-      "pattern": "^(placeholder|placeholder_.+)$",
-      "description": "Should be of the form 'placeholder_my_format_name'. 'placeholder' is allowed for backwards compatibility."
-    },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
-    },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
     "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "govuk_request_id": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
     },
     "expanded_links": {
       "type": "object",
@@ -313,112 +223,205 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "govuk_request_id": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
+    "schema_name": {
+      "description": "Should be of the form 'placeholder_my_format_name'. 'placeholder' is allowed for backwards compatibility.",
+      "type": "string",
+      "pattern": "^(placeholder|placeholder_.+)$"
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
-    "frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "base_path",
-          "locale"
-        ],
-        "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
-          },
-          "document_type": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
             "type": "string"
-          },
-          "schema_name": {
-            "type": "string"
-          },
-          "public_updated_at": {
-            "type": "string"
-          },
-          "content_id": {
-            "$ref": "#/definitions/guid"
-          },
-          "title": {
-            "type": "string"
-          },
-          "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
-            "type": "string"
-          },
-          "links": {
-            "type": "object",
-            "patternProperties": {
-              "^[a-z_]+$": {
-                "$ref": "#/definitions/frontend_links"
-              }
-            }
           }
         }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
       }
     },
     "base_path_less_frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "document_type": {
-            "type": "string"
-          },
-          "schema_name": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
           "api_path": {
             "$ref": "#/definitions/absolute_path"
@@ -428,25 +431,93 @@
             "type": "string",
             "format": "uri"
           },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "public_updated_at": {
-            "type": "string"
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
+          "document_type": {
             "type": "string"
           },
           "locale": {
             "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
           }
         }
       }
@@ -458,34 +529,32 @@
         "analytics_identifier": {
           "$ref": "#/definitions/analytics_identifier"
         },
-        "change_note": {
-          "$ref": "#/definitions/change_note"
-        },
-        "start_date": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Used for topical events, so that related documents can get the date. Remove when topical events are migrated."
-        },
-        "end_date": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Used for topical events, so that related documents can get the date. Remove when topical events are migrated."
-        },
         "brand": {
+          "description": "Used for organisations, to allow us to publish branding / logo information. Remove when organisations are migrated.",
           "type": [
             "string",
             "null"
-          ],
-          "description": "Used for organisations, to allow us to publish branding / logo information. Remove when organisations are migrated."
+          ]
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "change_note": {
+          "$ref": "#/definitions/change_note"
+        },
+        "end_date": {
+          "description": "Used for topical events, so that related documents can get the date. Remove when topical events are migrated.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "external_related_links": {
+          "$ref": "#/definitions/external_related_links"
         },
         "logo": {
           "type": "object",
           "properties": {
-            "formatted_title": {
-              "type": "string",
-              "description": "Used for organisations, to allow us to publish branding / logo information. Remove when organisations are migrated."
-            },
             "crest": {
+              "description": "Used for organisations, to allow us to publish branding / logo information. Remove when organisations are migrated.",
               "type": [
                 "string",
                 "null"
@@ -502,8 +571,11 @@
                 "ukaea",
                 "wales",
                 null
-              ],
-              "description": "Used for organisations, to allow us to publish branding / logo information. Remove when organisations are migrated."
+              ]
+            },
+            "formatted_title": {
+              "description": "Used for organisations, to allow us to publish branding / logo information. Remove when organisations are migrated.",
+              "type": "string"
             },
             "image": {
               "description": "An image for organisations that use a custom logo",
@@ -511,67 +583,60 @@
             }
           }
         },
-        "external_related_links": {
-          "$ref": "#/definitions/external_related_links"
+        "start_date": {
+          "description": "Used for topical events, so that related documents can get the date. Remove when topical events are migrated.",
+          "type": "string",
+          "format": "date-time"
         },
         "tags": {
           "$ref": "#/definitions/tags"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
         }
       }
     },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -582,20 +647,437 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "base_path",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
+            "type": "string"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "country": {
+            "$ref": "#/definitions/country"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "details": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "links": {
+            "type": "object",
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links"
+              }
+            }
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -612,212 +1094,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -876,98 +1168,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -976,10 +1301,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -987,6 +1308,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -1009,79 +1334,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1093,13 +1547,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1107,61 +1555,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1169,418 +1580,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1590,9 +1594,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/placeholder/publisher_v2/links.json
+++ b/dist/formats/placeholder/publisher_v2/links.json
@@ -3,25 +3,10 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "previous_version": {
-      "type": "string"
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/guid_list"
-        },
         "mainstream_browse_pages": {
           "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/guid_list"
@@ -30,8 +15,12 @@
           "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/guid_list"
         },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
@@ -51,38 +40,50 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/guid_list"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
         }
       }
+    },
+    "previous_version": {
+      "type": "string"
     }
   },
   "definitions": {
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
     "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
       "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
     "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
         {
           "type": "string"
@@ -90,22 +91,158 @@
         {
           "type": "null"
         }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+      ]
     },
-    "external_related_links": {
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -116,20 +253,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -146,212 +616,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -410,98 +690,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -510,10 +823,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -521,6 +830,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -543,79 +856,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -627,13 +1069,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -641,61 +1077,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -703,418 +1102,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1124,9 +1116,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/placeholder/publisher_v2/schema.json
+++ b/dist/formats/placeholder/publisher_v2/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "title",
     "details",
@@ -13,12 +12,22 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "description": {
       "anyOf": [
@@ -30,84 +39,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "access_limited": {
-      "$ref": "#/definitions/access_limited"
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "change_note": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "previous_version": {
-      "type": "string"
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "links": {
-      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string",
@@ -272,13 +205,223 @@
         "written_statement"
       ]
     },
-    "schema_name": {
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
       "type": "string",
-      "pattern": "^(placeholder|placeholder_.+)$",
-      "description": "Should be of the form 'placeholder_my_format_name'. 'placeholder' is allowed for backwards compatibility."
+      "format": "date-time"
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
+    "schema_name": {
+      "description": "Should be of the form 'placeholder_my_format_name'. 'placeholder' is allowed for backwards compatibility.",
+      "type": "string",
+      "pattern": "^(placeholder|placeholder_.+)$"
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,
@@ -286,34 +429,29 @@
         "analytics_identifier": {
           "$ref": "#/definitions/analytics_identifier"
         },
-        "change_note": {
-          "$ref": "#/definitions/change_note"
-        },
-        "start_date": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Used for topical events, so that related documents can get the date. Remove when topical events are migrated."
-        },
-        "end_date": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Used for topical events, so that related documents can get the date. Remove when topical events are migrated."
-        },
         "brand": {
+          "description": "Used for organisations, to allow us to publish branding / logo information. Remove when organisations are migrated.",
           "type": [
             "string",
             "null"
-          ],
-          "description": "Used for organisations, to allow us to publish branding / logo information. Remove when organisations are migrated."
+          ]
+        },
+        "change_note": {
+          "$ref": "#/definitions/change_note"
+        },
+        "end_date": {
+          "description": "Used for topical events, so that related documents can get the date. Remove when topical events are migrated.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "external_related_links": {
+          "$ref": "#/definitions/external_related_links"
         },
         "logo": {
           "type": "object",
           "properties": {
-            "formatted_title": {
-              "type": "string",
-              "description": "Used for organisations, to allow us to publish branding / logo information. Remove when organisations are migrated."
-            },
             "crest": {
+              "description": "Used for organisations, to allow us to publish branding / logo information. Remove when organisations are migrated.",
               "type": [
                 "string",
                 "null"
@@ -330,8 +468,11 @@
                 "ukaea",
                 "wales",
                 null
-              ],
-              "description": "Used for organisations, to allow us to publish branding / logo information. Remove when organisations are migrated."
+              ]
+            },
+            "formatted_title": {
+              "description": "Used for organisations, to allow us to publish branding / logo information. Remove when organisations are migrated.",
+              "type": "string"
             },
             "image": {
               "description": "An image for organisations that use a custom logo",
@@ -339,77 +480,60 @@
             }
           }
         },
-        "external_related_links": {
-          "$ref": "#/definitions/external_related_links"
+        "start_date": {
+          "description": "Used for topical events, so that related documents can get the date. Remove when topical events are migrated.",
+          "type": "string",
+          "format": "date-time"
         },
         "tags": {
           "$ref": "#/definitions/tags"
         }
       }
     },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "featured_policies": {
-          "description": "Featured policies primarily for use with Whitehall organisations",
-          "$ref": "#/definitions/guid_list"
-        },
-        "policy_areas": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -420,20 +544,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -450,212 +907,35 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
         }
       }
     },
-    "redirect_route": {
+    "links": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
       "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
+        "featured_policies": {
+          "description": "Featured policies primarily for use with Whitehall organisations",
+          "$ref": "#/definitions/guid_list"
         },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
         }
       }
     },
@@ -714,98 +994,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -814,10 +1127,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -825,6 +1134,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -847,79 +1160,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -931,13 +1373,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -945,61 +1381,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1007,418 +1406,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1428,9 +1420,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/policy/frontend/schema.json
+++ b/dist/formats/policy/frontend/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "links",
@@ -12,12 +11,25 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -29,135 +41,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "people": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "working_groups": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "lead_organisations": {
-          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "related": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "email_alert_signup": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "available_translations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_pages": {
-          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "meets_user_needs": {
-          "description": "The user needs this piece of content meets.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "organisations": {
-          "description": "All organisations linked to this content item. This should include lead organisations.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "parent": {
-          "description": "The parent content item.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policy_areas": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "primary_publishing_organisation": {
-          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "children": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policies": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "document_collections": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "child_taxons": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -322,67 +207,699 @@
         "written_statement"
       ]
     },
+    "email_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "available_translations": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "email_alert_signup": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "lead_organisations": {
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "people": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policies": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policy_areas": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "primary_publishing_organisation": {
+          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "related": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "working_groups": {
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "policy"
       ]
     },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    "title": {
+      "type": "string"
     },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
-    "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
     },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "base_path_less_frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "required": [
+        "document_noun",
+        "facets"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "default_documents_per_page": {
+          "$ref": "#/definitions/finder_default_documents_per_page"
+        },
+        "default_order": {
+          "$ref": "#/definitions/finder_default_order"
+        },
+        "document_noun": {
+          "$ref": "#/definitions/finder_document_noun"
+        },
+        "email_signup_enabled": {
+          "type": "boolean"
+        },
+        "emphasised_organisations": {
+          "$ref": "#/definitions/emphasised_organisations"
+        },
+        "facets": {
+          "$ref": "#/definitions/finder_facets"
+        },
+        "filter": {
+          "$ref": "#/definitions/finder_filter"
+        },
+        "human_readable_finder_format": {
+          "type": "string"
+        },
+        "internal_name": {
+          "$ref": "#/definitions/taxonomy_internal_name"
+        },
+        "nation_applicability": {
+          "description": "TODO: Switch to using national_applicability pattern",
+          "type": "object",
+          "required": [
+            "applies_to",
+            "alternative_policies"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "alternative_policies": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [
+                  "nation",
+                  "alt_policy_url"
+                ],
+                "properties": {
+                  "alt_policy_url": {
+                    "type": "string"
+                  },
+                  "nation": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "applies_to": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "show_summaries": {
+          "$ref": "#/definitions/finder_show_summaries"
+        },
+        "summary": {
+          "$ref": "#/definitions/finder_summary"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "required": [
+        "title",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
     "frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "base_path",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
-          "document_type": {
-            "type": "string"
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
           },
-          "schema_name": {
-            "type": "string"
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
           },
-          "public_updated_at": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
             "type": "string"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
-            "type": "string"
+          "country": {
+            "$ref": "#/definitions/country"
           },
           "description": {
             "anyOf": [
@@ -394,36 +911,11 @@
               }
             ]
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "details": {
+            "type": "object",
+            "additionalProperties": true
           },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
+          "document_type": {
             "type": "string"
           },
           "links": {
@@ -433,195 +925,205 @@
                 "$ref": "#/definitions/frontend_links"
               }
             }
-          }
-        }
-      }
-    },
-    "base_path_less_frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "locale"
-        ],
-        "properties": {
-          "document_type": {
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
             "type": "string"
           },
           "schema_name": {
             "type": "string"
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
+          "title": {
+            "type": "string"
           },
           "web_url": {
             "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
             "type": "string",
             "format": "uri"
           },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
           },
-          "public_updated_at": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
             "type": "string"
           },
-          "content_id": {
-            "$ref": "#/definitions/guid"
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
           },
           "title": {
             "type": "string"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
           }
         }
       }
     },
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "document_noun",
-        "facets"
-      ],
-      "properties": {
-        "internal_name": {
-          "$ref": "#/definitions/taxonomy_internal_name"
-        },
-        "document_noun": {
-          "$ref": "#/definitions/finder_document_noun"
-        },
-        "default_documents_per_page": {
-          "$ref": "#/definitions/finder_default_documents_per_page"
-        },
-        "email_signup_enabled": {
-          "type": "boolean"
-        },
-        "default_order": {
-          "$ref": "#/definitions/finder_default_order"
-        },
-        "emphasised_organisations": {
-          "$ref": "#/definitions/emphasised_organisations"
-        },
-        "filter": {
-          "$ref": "#/definitions/finder_filter"
-        },
-        "facets": {
-          "$ref": "#/definitions/finder_facets"
-        },
-        "human_readable_finder_format": {
-          "type": "string"
-        },
-        "show_summaries": {
-          "$ref": "#/definitions/finder_show_summaries"
-        },
-        "summary": {
-          "$ref": "#/definitions/finder_summary"
-        },
-        "nation_applicability": {
-          "description": "TODO: Switch to using national_applicability pattern",
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "applies_to",
-            "alternative_policies"
-          ],
-          "properties": {
-            "applies_to": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "alternative_policies": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "required": [
-                  "nation",
-                  "alt_policy_url"
-                ],
-                "properties": {
-                  "nation": {
-                    "type": "string"
-                  },
-                  "alt_policy_url": {
-                    "type": "string"
-                  }
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
                 }
               }
             }
-          }
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
+          },
+          "title": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/external_link"
-      }
-    },
-    "external_link": {
+    "image": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
+        "alt_text": {
           "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "url": {
           "type": "string",
@@ -632,17 +1134,17 @@
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -659,212 +1161,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -923,98 +1235,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -1023,10 +1368,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -1034,6 +1375,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -1056,79 +1401,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1140,13 +1614,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1154,61 +1622,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1216,418 +1647,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1637,9 +1661,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/policy/notification/schema.json
+++ b/dist/formats/policy/notification/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "content_id",
@@ -17,12 +16,25 @@
     "title",
     "update_type"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -34,60 +46,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -252,60 +212,9 @@
         "written_statement"
       ]
     },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "policy"
-      ]
-    },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
-    },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
     "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "govuk_request_id": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
     },
     "expanded_links": {
       "type": "object",
@@ -314,39 +223,627 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "govuk_request_id": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "policy"
+      ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "base_path_less_frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "required": [
+        "document_noun",
+        "facets"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "default_documents_per_page": {
+          "$ref": "#/definitions/finder_default_documents_per_page"
+        },
+        "default_order": {
+          "$ref": "#/definitions/finder_default_order"
+        },
+        "document_noun": {
+          "$ref": "#/definitions/finder_document_noun"
+        },
+        "email_signup_enabled": {
+          "type": "boolean"
+        },
+        "emphasised_organisations": {
+          "$ref": "#/definitions/emphasised_organisations"
+        },
+        "facets": {
+          "$ref": "#/definitions/finder_facets"
+        },
+        "filter": {
+          "$ref": "#/definitions/finder_filter"
+        },
+        "human_readable_finder_format": {
+          "type": "string"
+        },
+        "internal_name": {
+          "$ref": "#/definitions/taxonomy_internal_name"
+        },
+        "nation_applicability": {
+          "description": "TODO: Switch to using national_applicability pattern",
+          "type": "object",
+          "required": [
+            "applies_to",
+            "alternative_policies"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "alternative_policies": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [
+                  "nation",
+                  "alt_policy_url"
+                ],
+                "properties": {
+                  "alt_policy_url": {
+                    "type": "string"
+                  },
+                  "nation": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "applies_to": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "show_summaries": {
+          "$ref": "#/definitions/finder_show_summaries"
+        },
+        "summary": {
+          "$ref": "#/definitions/finder_summary"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "required": [
+        "title",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
     "frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "base_path",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
-          "document_type": {
-            "type": "string"
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
           },
-          "schema_name": {
-            "type": "string"
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
           },
-          "public_updated_at": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
             "type": "string"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
-            "type": "string"
+          "country": {
+            "$ref": "#/definitions/country"
           },
           "description": {
             "anyOf": [
@@ -358,36 +855,11 @@
               }
             ]
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "details": {
+            "type": "object",
+            "additionalProperties": true
           },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
+          "document_type": {
             "type": "string"
           },
           "links": {
@@ -397,195 +869,205 @@
                 "$ref": "#/definitions/frontend_links"
               }
             }
-          }
-        }
-      }
-    },
-    "base_path_less_frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "locale"
-        ],
-        "properties": {
-          "document_type": {
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
             "type": "string"
           },
           "schema_name": {
             "type": "string"
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
+          "title": {
+            "type": "string"
           },
           "web_url": {
             "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
             "type": "string",
             "format": "uri"
           },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
           },
-          "public_updated_at": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
             "type": "string"
           },
-          "content_id": {
-            "$ref": "#/definitions/guid"
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
           },
           "title": {
             "type": "string"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
           }
         }
       }
     },
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "document_noun",
-        "facets"
-      ],
-      "properties": {
-        "internal_name": {
-          "$ref": "#/definitions/taxonomy_internal_name"
-        },
-        "document_noun": {
-          "$ref": "#/definitions/finder_document_noun"
-        },
-        "default_documents_per_page": {
-          "$ref": "#/definitions/finder_default_documents_per_page"
-        },
-        "email_signup_enabled": {
-          "type": "boolean"
-        },
-        "default_order": {
-          "$ref": "#/definitions/finder_default_order"
-        },
-        "emphasised_organisations": {
-          "$ref": "#/definitions/emphasised_organisations"
-        },
-        "filter": {
-          "$ref": "#/definitions/finder_filter"
-        },
-        "facets": {
-          "$ref": "#/definitions/finder_facets"
-        },
-        "human_readable_finder_format": {
-          "type": "string"
-        },
-        "show_summaries": {
-          "$ref": "#/definitions/finder_show_summaries"
-        },
-        "summary": {
-          "$ref": "#/definitions/finder_summary"
-        },
-        "nation_applicability": {
-          "description": "TODO: Switch to using national_applicability pattern",
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "applies_to",
-            "alternative_policies"
-          ],
-          "properties": {
-            "applies_to": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "alternative_policies": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "required": [
-                  "nation",
-                  "alt_policy_url"
-                ],
-                "properties": {
-                  "nation": {
-                    "type": "string"
-                  },
-                  "alt_policy_url": {
-                    "type": "string"
-                  }
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
                 }
               }
             }
-          }
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
+          },
+          "title": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/external_link"
-      }
-    },
-    "external_link": {
+    "image": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
+        "alt_text": {
           "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "url": {
           "type": "string",
@@ -596,17 +1078,17 @@
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -623,212 +1105,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -887,98 +1179,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -987,10 +1312,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -998,6 +1319,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -1020,79 +1345,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1104,13 +1558,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1118,61 +1566,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1180,418 +1591,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1601,9 +1605,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/policy/publisher_v2/links.json
+++ b/dist/formats/policy/publisher_v2/links.json
@@ -3,42 +3,18 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "previous_version": {
-      "type": "string"
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "people": {
-          "$ref": "#/definitions/guid_list"
-        },
-        "working_groups": {
-          "$ref": "#/definitions/guid_list"
-        },
-        "lead_organisations": {
-          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "related": {
+        "available_translations": {
           "$ref": "#/definitions/guid_list"
         },
         "email_alert_signup": {
           "$ref": "#/definitions/guid_list"
         },
-        "available_translations": {
-          "$ref": "#/definitions/guid_list"
-        },
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
+        "lead_organisations": {
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
         "mainstream_browse_pages": {
@@ -49,8 +25,12 @@
           "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/guid_list"
         },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
@@ -62,6 +42,9 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "people": {
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"
@@ -70,38 +53,56 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "related": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/guid_list"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "working_groups": {
+          "$ref": "#/definitions/guid_list"
         }
       }
+    },
+    "previous_version": {
+      "type": "string"
     }
   },
   "definitions": {
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
     "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
       "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
     "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
         {
           "type": "string"
@@ -109,22 +110,158 @@
         {
           "type": "null"
         }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+      ]
     },
-    "external_related_links": {
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -135,20 +272,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -165,212 +635,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -429,98 +709,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -529,10 +842,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -540,6 +849,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -562,79 +875,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -646,13 +1088,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -660,61 +1096,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -722,418 +1121,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1143,9 +1135,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/policy/publisher_v2/schema.json
+++ b/dist/formats/policy/publisher_v2/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "title",
     "details",
@@ -13,12 +12,22 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "description": {
       "anyOf": [
@@ -30,84 +39,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "access_limited": {
-      "$ref": "#/definitions/access_limited"
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "change_note": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "previous_version": {
-      "type": "string"
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "links": {
-      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string",
@@ -272,70 +205,268 @@
         "written_statement"
       ]
     },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "policy"
       ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
-    "details": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
       "type": "object",
       "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
       "required": [
         "document_noun",
         "facets"
       ],
+      "additionalProperties": false,
       "properties": {
-        "internal_name": {
-          "$ref": "#/definitions/taxonomy_internal_name"
-        },
-        "document_noun": {
-          "$ref": "#/definitions/finder_document_noun"
-        },
         "default_documents_per_page": {
           "$ref": "#/definitions/finder_default_documents_per_page"
-        },
-        "email_signup_enabled": {
-          "type": "boolean"
         },
         "default_order": {
           "$ref": "#/definitions/finder_default_order"
         },
+        "document_noun": {
+          "$ref": "#/definitions/finder_document_noun"
+        },
+        "email_signup_enabled": {
+          "type": "boolean"
+        },
         "emphasised_organisations": {
           "$ref": "#/definitions/emphasised_organisations"
-        },
-        "filter": {
-          "$ref": "#/definitions/finder_filter"
         },
         "facets": {
           "$ref": "#/definitions/finder_facets"
         },
+        "filter": {
+          "$ref": "#/definitions/finder_filter"
+        },
         "human_readable_finder_format": {
           "type": "string"
         },
-        "show_summaries": {
-          "$ref": "#/definitions/finder_show_summaries"
-        },
-        "summary": {
-          "$ref": "#/definitions/finder_summary"
+        "internal_name": {
+          "$ref": "#/definitions/taxonomy_internal_name"
         },
         "nation_applicability": {
           "description": "TODO: Switch to using national_applicability pattern",
           "type": "object",
-          "additionalProperties": false,
           "required": [
             "applies_to",
             "alternative_policies"
           ],
+          "additionalProperties": false,
           "properties": {
-            "applies_to": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
             "alternative_policies": {
               "type": "array",
               "items": {
@@ -345,78 +476,75 @@
                   "alt_policy_url"
                 ],
                 "properties": {
-                  "nation": {
+                  "alt_policy_url": {
                     "type": "string"
                   },
-                  "alt_policy_url": {
+                  "nation": {
                     "type": "string"
                   }
                 }
               }
+            },
+            "applies_to": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             }
           }
-        }
-      }
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policy_areas": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
         },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        "show_summaries": {
+          "$ref": "#/definitions/finder_show_summaries"
+        },
+        "summary": {
+          "$ref": "#/definitions/finder_summary"
         }
       }
     },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -427,20 +555,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -457,212 +918,31 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
         }
       }
     },
-    "redirect_route": {
+    "links": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
       "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
         }
       }
     },
@@ -721,98 +1001,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -821,10 +1134,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -832,6 +1141,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -854,79 +1167,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -938,13 +1380,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -952,61 +1388,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1014,418 +1413,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1435,9 +1427,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/publication/frontend/schema.json
+++ b/dist/formats/publication/frontend/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "links",
@@ -12,12 +11,25 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -29,138 +41,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "ministers": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "related_policies": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "related_statistical_data_sets": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "topical_events": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "world_locations": {
-          "$ref": "#/definitions/base_path_less_frontend_links"
-        },
-        "roles": {
-          "description": "Used to power Email Alert Api subscriptions for Whitehall content",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "people": {
-          "description": "Used to power Email Alert Api subscriptions for Whitehall content",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_pages": {
-          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "meets_user_needs": {
-          "description": "The user needs this piece of content meets.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "topics": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "organisations": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "parent": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policy_areas": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "primary_publishing_organisation": {
-          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "available_translations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "children": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policies": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "document_collections": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "child_taxons": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -325,67 +207,661 @@
         "written_statement"
       ]
     },
+    "email_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "available_translations": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ministers": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "organisations": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "parent": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "people": {
+          "description": "Used to power Email Alert Api subscriptions for Whitehall content",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policies": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policy_areas": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "primary_publishing_organisation": {
+          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "related_policies": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "related_statistical_data_sets": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "roles": {
+          "description": "Used to power Email Alert Api subscriptions for Whitehall content",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "topical_events": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "topics": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "world_locations": {
+          "$ref": "#/definitions/base_path_less_frontend_links"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "publication"
       ]
     },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    "title": {
+      "type": "string"
     },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
-    "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
     },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "base_path_less_frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "required": [
+        "body",
+        "documents",
+        "first_public_at",
+        "government",
+        "political"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "body": {
+          "$ref": "#/definitions/body"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "documents": {
+          "$ref": "#/definitions/attachments_with_thumbnails"
+        },
+        "emphasised_organisations": {
+          "$ref": "#/definitions/emphasised_organisations"
+        },
+        "first_public_at": {
+          "$ref": "#/definitions/first_public_at"
+        },
+        "government": {
+          "$ref": "#/definitions/government"
+        },
+        "national_applicability": {
+          "$ref": "#/definitions/national_applicability"
+        },
+        "political": {
+          "$ref": "#/definitions/political"
+        },
+        "tags": {
+          "$ref": "#/definitions/tags"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "required": [
+        "title",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
     "frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "base_path",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
-          "document_type": {
-            "type": "string"
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
           },
-          "schema_name": {
-            "type": "string"
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
           },
-          "public_updated_at": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
             "type": "string"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
-            "type": "string"
+          "country": {
+            "$ref": "#/definitions/country"
           },
           "description": {
             "anyOf": [
@@ -397,36 +873,11 @@
               }
             ]
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "details": {
+            "type": "object",
+            "additionalProperties": true
           },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
+          "document_type": {
             "type": "string"
           },
           "links": {
@@ -436,154 +887,205 @@
                 "$ref": "#/definitions/frontend_links"
               }
             }
-          }
-        }
-      }
-    },
-    "base_path_less_frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "locale"
-        ],
-        "properties": {
-          "document_type": {
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
             "type": "string"
           },
           "schema_name": {
             "type": "string"
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
+          "title": {
+            "type": "string"
           },
           "web_url": {
             "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
             "type": "string",
             "format": "uri"
           },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
           },
-          "public_updated_at": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
             "type": "string"
           },
-          "content_id": {
-            "$ref": "#/definitions/guid"
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
           },
           "title": {
             "type": "string"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
           }
         }
       }
     },
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "body",
-        "documents",
-        "first_public_at",
-        "government",
-        "political"
-      ],
-      "properties": {
-        "body": {
-          "$ref": "#/definitions/body"
-        },
-        "documents": {
-          "$ref": "#/definitions/attachments_with_thumbnails"
-        },
-        "first_public_at": {
-          "$ref": "#/definitions/first_public_at"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        },
-        "emphasised_organisations": {
-          "$ref": "#/definitions/emphasised_organisations"
-        },
-        "tags": {
-          "$ref": "#/definitions/tags"
-        },
-        "government": {
-          "$ref": "#/definitions/government"
-        },
-        "political": {
-          "$ref": "#/definitions/political"
-        },
-        "national_applicability": {
-          "$ref": "#/definitions/national_applicability"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
       }
     },
-    "external_link": {
+    "image": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
+        "alt_text": {
           "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "url": {
           "type": "string",
@@ -594,17 +1096,17 @@
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -621,212 +1123,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -885,98 +1197,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -985,10 +1330,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -996,6 +1337,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -1018,79 +1363,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1102,13 +1576,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1116,61 +1584,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1178,418 +1609,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1599,9 +1623,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/publication/notification/schema.json
+++ b/dist/formats/publication/notification/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "content_id",
@@ -17,12 +16,25 @@
     "title",
     "update_type"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -34,60 +46,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -252,60 +212,9 @@
         "written_statement"
       ]
     },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "publication"
-      ]
-    },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
-    },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
     "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "govuk_request_id": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
     },
     "expanded_links": {
       "type": "object",
@@ -314,39 +223,586 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "govuk_request_id": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "publication"
+      ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "base_path_less_frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "required": [
+        "body",
+        "documents",
+        "first_public_at",
+        "government",
+        "political"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "body": {
+          "$ref": "#/definitions/body"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "documents": {
+          "$ref": "#/definitions/attachments_with_thumbnails"
+        },
+        "emphasised_organisations": {
+          "$ref": "#/definitions/emphasised_organisations"
+        },
+        "first_public_at": {
+          "$ref": "#/definitions/first_public_at"
+        },
+        "government": {
+          "$ref": "#/definitions/government"
+        },
+        "national_applicability": {
+          "$ref": "#/definitions/national_applicability"
+        },
+        "political": {
+          "$ref": "#/definitions/political"
+        },
+        "tags": {
+          "$ref": "#/definitions/tags"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "required": [
+        "title",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
     "frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "base_path",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
-          "document_type": {
-            "type": "string"
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
           },
-          "schema_name": {
-            "type": "string"
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
           },
-          "public_updated_at": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
             "type": "string"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
-            "type": "string"
+          "country": {
+            "$ref": "#/definitions/country"
           },
           "description": {
             "anyOf": [
@@ -358,36 +814,11 @@
               }
             ]
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "details": {
+            "type": "object",
+            "additionalProperties": true
           },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
+          "document_type": {
             "type": "string"
           },
           "links": {
@@ -397,154 +828,205 @@
                 "$ref": "#/definitions/frontend_links"
               }
             }
-          }
-        }
-      }
-    },
-    "base_path_less_frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "locale"
-        ],
-        "properties": {
-          "document_type": {
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
             "type": "string"
           },
           "schema_name": {
             "type": "string"
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
+          "title": {
+            "type": "string"
           },
           "web_url": {
             "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
             "type": "string",
             "format": "uri"
           },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
           },
-          "public_updated_at": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
             "type": "string"
           },
-          "content_id": {
-            "$ref": "#/definitions/guid"
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
           },
           "title": {
             "type": "string"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
           }
         }
       }
     },
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "body",
-        "documents",
-        "first_public_at",
-        "government",
-        "political"
-      ],
-      "properties": {
-        "body": {
-          "$ref": "#/definitions/body"
-        },
-        "documents": {
-          "$ref": "#/definitions/attachments_with_thumbnails"
-        },
-        "first_public_at": {
-          "$ref": "#/definitions/first_public_at"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        },
-        "emphasised_organisations": {
-          "$ref": "#/definitions/emphasised_organisations"
-        },
-        "tags": {
-          "$ref": "#/definitions/tags"
-        },
-        "government": {
-          "$ref": "#/definitions/government"
-        },
-        "political": {
-          "$ref": "#/definitions/political"
-        },
-        "national_applicability": {
-          "$ref": "#/definitions/national_applicability"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
       }
     },
-    "external_link": {
+    "image": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
+        "alt_text": {
           "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "url": {
           "type": "string",
@@ -555,17 +1037,17 @@
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -582,212 +1064,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -846,98 +1138,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -946,10 +1271,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -957,6 +1278,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -979,79 +1304,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1063,13 +1517,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1077,61 +1525,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1139,418 +1550,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1560,9 +1564,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/publication/publisher_v2/links.json
+++ b/dist/formats/publication/publisher_v2/links.json
@@ -3,48 +3,10 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "previous_version": {
-      "type": "string"
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "ministers": {
-          "$ref": "#/definitions/guid_list"
-        },
-        "related_policies": {
-          "$ref": "#/definitions/guid_list"
-        },
-        "related_statistical_data_sets": {
-          "$ref": "#/definitions/guid_list"
-        },
-        "topical_events": {
-          "$ref": "#/definitions/guid_list"
-        },
-        "world_locations": {
-          "$ref": "#/definitions/guid_list"
-        },
-        "roles": {
-          "$ref": "#/definitions/guid_list",
-          "description": "Used to power Email Alert Api subscriptions for Whitehall content"
-        },
-        "people": {
-          "$ref": "#/definitions/guid_list",
-          "description": "Used to power Email Alert Api subscriptions for Whitehall content"
-        },
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/guid_list"
-        },
         "mainstream_browse_pages": {
           "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/guid_list"
@@ -53,8 +15,15 @@
           "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/guid_list"
         },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+        "ministers": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
@@ -66,6 +35,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "people": {
+          "description": "Used to power Email Alert Api subscriptions for Whitehall content",
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"
@@ -74,38 +47,66 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "related_policies": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "related_statistical_data_sets": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "roles": {
+          "description": "Used to power Email Alert Api subscriptions for Whitehall content",
+          "$ref": "#/definitions/guid_list"
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/guid_list"
+        },
+        "topical_events": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "world_locations": {
+          "$ref": "#/definitions/guid_list"
         }
       }
+    },
+    "previous_version": {
+      "type": "string"
     }
   },
   "definitions": {
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
     "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
       "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
     "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
         {
           "type": "string"
@@ -113,22 +114,158 @@
         {
           "type": "null"
         }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+      ]
     },
-    "external_related_links": {
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -139,20 +276,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -169,212 +639,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -433,98 +713,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -533,10 +846,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -544,6 +853,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -566,79 +879,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -650,13 +1092,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -664,61 +1100,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -726,418 +1125,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1147,9 +1139,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/publication/publisher_v2/schema.json
+++ b/dist/formats/publication/publisher_v2/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "title",
     "details",
@@ -13,12 +12,22 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "description": {
       "anyOf": [
@@ -30,84 +39,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "access_limited": {
-      "$ref": "#/definitions/access_limited"
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "change_note": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "previous_version": {
-      "type": "string"
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "links": {
-      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string",
@@ -272,17 +205,226 @@
         "written_statement"
       ]
     },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "publication"
       ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
-    "details": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
       "type": "object",
       "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
       "required": [
         "body",
         "documents",
@@ -290,33 +432,470 @@
         "government",
         "political"
       ],
+      "additionalProperties": false,
       "properties": {
         "body": {
           "$ref": "#/definitions/body"
         },
-        "documents": {
-          "$ref": "#/definitions/attachments_with_thumbnails"
-        },
-        "first_public_at": {
-          "$ref": "#/definitions/first_public_at"
-        },
         "change_history": {
           "$ref": "#/definitions/change_history"
+        },
+        "documents": {
+          "$ref": "#/definitions/attachments_with_thumbnails"
         },
         "emphasised_organisations": {
           "$ref": "#/definitions/emphasised_organisations"
         },
-        "tags": {
-          "$ref": "#/definitions/tags"
+        "first_public_at": {
+          "$ref": "#/definitions/first_public_at"
         },
         "government": {
           "$ref": "#/definitions/government"
         },
+        "national_applicability": {
+          "$ref": "#/definitions/national_applicability"
+        },
         "political": {
           "$ref": "#/definitions/political"
         },
-        "national_applicability": {
-          "$ref": "#/definitions/national_applicability"
+        "tags": {
+          "$ref": "#/definitions/tags"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "required": [
+        "title",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "required": [
+        "title",
+        "path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
+    },
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
+      "type": "object",
+      "required": [
+        "label",
+        "value"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "A human readable label",
+          "type": "string"
+        },
+        "value": {
+          "description": "A value to use for form controls",
+          "type": "string"
         }
       }
     },
@@ -334,8 +913,11 @@
           "$ref": "#/definitions/guid_list"
         },
         "people": {
-          "$ref": "#/definitions/guid_list",
-          "description": "Used to power Email Alert Api subscriptions for Whitehall content"
+          "description": "Used to power Email Alert Api subscriptions for Whitehall content",
+          "$ref": "#/definitions/guid_list"
+        },
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
         },
         "primary_publishing_organisation": {
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
@@ -349,8 +931,8 @@
           "$ref": "#/definitions/guid_list"
         },
         "roles": {
-          "$ref": "#/definitions/guid_list",
-          "description": "Used to power Email Alert Api subscriptions for Whitehall content"
+          "description": "Used to power Email Alert Api subscriptions for Whitehall content",
+          "$ref": "#/definitions/guid_list"
         },
         "topical_events": {
           "$ref": "#/definitions/guid_list"
@@ -360,308 +942,6 @@
         },
         "world_locations": {
           "$ref": "#/definitions/guid_list"
-        },
-        "policy_areas": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/external_link"
-      }
-    },
-    "external_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "title",
-        "url"
-      ],
-      "properties": {
-        "title": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        }
-      }
-    },
-    "internal_link_without_guid": {
-      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "title",
-        "path"
-      ],
-      "properties": {
-        "title": {
-          "type": "string"
-        },
-        "path": {
-          "$ref": "#/definitions/absolute_fullpath"
-        }
-      }
-    },
-    "internal_or_external_link": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/external_link"
-        },
-        {
-          "$ref": "#/definitions/internal_link_without_guid"
-        },
-        {
-          "$ref": "#/definitions/guid"
-        }
-      ]
-    },
-    "government": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "title",
-        "slug",
-        "current"
-      ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url"
-      ],
-      "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
-          "type": "string"
-        },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
-          "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -720,98 +1000,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -820,10 +1133,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -831,6 +1140,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -853,79 +1166,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -937,13 +1379,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -951,61 +1387,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1013,418 +1412,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1434,9 +1426,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/service_manual_guide/frontend/schema.json
+++ b/dist/formats/service_manual_guide/frontend/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "links",
@@ -12,12 +11,25 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -29,127 +41,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "content_owners": {
-          "description": "References a page of a GDS community responsible for maintaining the guide e.g. Agile delivery community, Design community",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "service_manual_topics": {
-          "description": "References an array of 'service_manual_topic's. Not to be confused with 'topics'.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_pages": {
-          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "meets_user_needs": {
-          "description": "The user needs this piece of content meets.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "organisations": {
-          "description": "All organisations linked to this content item. This should include lead organisations.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "parent": {
-          "description": "The parent content item.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policy_areas": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "primary_publishing_organisation": {
-          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "available_translations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "children": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policies": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "document_collections": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "child_taxons": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -314,67 +207,658 @@
         "written_statement"
       ]
     },
+    "email_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "available_translations": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "content_owners": {
+          "description": "References a page of a GDS community responsible for maintaining the guide e.g. Agile delivery community, Design community",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "policies": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policy_areas": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "primary_publishing_organisation": {
+          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "service_manual_topics": {
+          "description": "References an array of 'service_manual_topic's. Not to be confused with 'topics'.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "service_manual_guide"
       ]
     },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    "title": {
+      "type": "string"
     },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
-    "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
     },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "anchor_href": {
+      "description": "Anchor links for navigation within the same page. Format: '#anchor-link-id'",
+      "type": "string",
+      "pattern": "^#.+$"
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "base_path_less_frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "required": [
+        "body"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "body": {
+          "$ref": "#/definitions/body"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "change_note": {
+          "$ref": "#/definitions/change_note"
+        },
+        "header_links": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "title",
+              "href"
+            ],
+            "properties": {
+              "href": {
+                "$ref": "#/definitions/anchor_href"
+              },
+              "title": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "show_description": {
+          "description": "Display the description on the page if true. This is needed for the service standard points.",
+          "type": "boolean"
+        },
+        "withdrawn_notice": {
+          "$ref": "#/definitions/withdrawn_notice"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "required": [
+        "title",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
     "frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "base_path",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
-          "document_type": {
-            "type": "string"
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
           },
-          "schema_name": {
-            "type": "string"
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
           },
-          "public_updated_at": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
             "type": "string"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
-            "type": "string"
+          "country": {
+            "$ref": "#/definitions/country"
           },
           "description": {
             "anyOf": [
@@ -386,36 +870,11 @@
               }
             ]
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "details": {
+            "type": "object",
+            "additionalProperties": true
           },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
+          "document_type": {
             "type": "string"
           },
           "links": {
@@ -425,157 +884,205 @@
                 "$ref": "#/definitions/frontend_links"
               }
             }
-          }
-        }
-      }
-    },
-    "base_path_less_frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "locale"
-        ],
-        "properties": {
-          "document_type": {
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
             "type": "string"
           },
           "schema_name": {
             "type": "string"
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
+          "title": {
+            "type": "string"
           },
           "web_url": {
             "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
             "type": "string",
             "format": "uri"
           },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
           },
-          "public_updated_at": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
             "type": "string"
           },
-          "content_id": {
-            "$ref": "#/definitions/guid"
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
           },
           "title": {
             "type": "string"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
           }
         }
       }
     },
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "body"
-      ],
-      "properties": {
-        "show_description": {
-          "type": "boolean",
-          "description": "Display the description on the page if true. This is needed for the service standard points."
-        },
-        "body": {
-          "$ref": "#/definitions/body"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "header_links": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "title": {
-                "type": "string"
-              },
-              "href": {
-                "$ref": "#/definitions/anchor_href"
-              }
-            },
-            "required": [
-              "title",
-              "href"
-            ]
-          }
-        },
-        "change_note": {
-          "$ref": "#/definitions/change_note"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
       }
     },
-    "external_link": {
+    "image": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
+        "alt_text": {
           "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "url": {
           "type": "string",
@@ -586,17 +1093,17 @@
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -613,212 +1120,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -877,98 +1194,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -977,10 +1327,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -988,6 +1334,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -1010,79 +1360,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1094,13 +1573,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1108,61 +1581,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1170,418 +1606,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1591,14 +1620,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
-    },
-    "anchor_href": {
-      "type": "string",
-      "pattern": "^#.+$",
-      "description": "Anchor links for navigation within the same page. Format: '#anchor-link-id'"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/service_manual_guide/notification/schema.json
+++ b/dist/formats/service_manual_guide/notification/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "content_id",
@@ -17,12 +16,25 @@
     "title",
     "update_type"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -34,60 +46,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -252,60 +212,9 @@
         "written_statement"
       ]
     },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "service_manual_guide"
-      ]
-    },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
-    },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
     "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "govuk_request_id": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
     },
     "expanded_links": {
       "type": "object",
@@ -314,39 +223,594 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "govuk_request_id": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "service_manual_guide"
+      ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "anchor_href": {
+      "description": "Anchor links for navigation within the same page. Format: '#anchor-link-id'",
+      "type": "string",
+      "pattern": "^#.+$"
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "base_path_less_frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "required": [
+        "body"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "body": {
+          "$ref": "#/definitions/body"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "change_note": {
+          "$ref": "#/definitions/change_note"
+        },
+        "header_links": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "title",
+              "href"
+            ],
+            "properties": {
+              "href": {
+                "$ref": "#/definitions/anchor_href"
+              },
+              "title": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "show_description": {
+          "description": "Display the description on the page if true. This is needed for the service standard points.",
+          "type": "boolean"
+        },
+        "withdrawn_notice": {
+          "$ref": "#/definitions/withdrawn_notice"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "required": [
+        "title",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
     "frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "base_path",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
-          "document_type": {
-            "type": "string"
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
           },
-          "schema_name": {
-            "type": "string"
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
           },
-          "public_updated_at": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
             "type": "string"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
-            "type": "string"
+          "country": {
+            "$ref": "#/definitions/country"
           },
           "description": {
             "anyOf": [
@@ -358,36 +822,11 @@
               }
             ]
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "details": {
+            "type": "object",
+            "additionalProperties": true
           },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
+          "document_type": {
             "type": "string"
           },
           "links": {
@@ -397,157 +836,205 @@
                 "$ref": "#/definitions/frontend_links"
               }
             }
-          }
-        }
-      }
-    },
-    "base_path_less_frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "locale"
-        ],
-        "properties": {
-          "document_type": {
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
             "type": "string"
           },
           "schema_name": {
             "type": "string"
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
+          "title": {
+            "type": "string"
           },
           "web_url": {
             "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
             "type": "string",
             "format": "uri"
           },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
           },
-          "public_updated_at": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
             "type": "string"
           },
-          "content_id": {
-            "$ref": "#/definitions/guid"
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
           },
           "title": {
             "type": "string"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
           }
         }
       }
     },
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "body"
-      ],
-      "properties": {
-        "show_description": {
-          "type": "boolean",
-          "description": "Display the description on the page if true. This is needed for the service standard points."
-        },
-        "body": {
-          "$ref": "#/definitions/body"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "header_links": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "title": {
-                "type": "string"
-              },
-              "href": {
-                "$ref": "#/definitions/anchor_href"
-              }
-            },
-            "required": [
-              "title",
-              "href"
-            ]
-          }
-        },
-        "change_note": {
-          "$ref": "#/definitions/change_note"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
       }
     },
-    "external_link": {
+    "image": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
+        "alt_text": {
           "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "url": {
           "type": "string",
@@ -558,17 +1045,17 @@
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -585,212 +1072,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -849,98 +1146,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -949,10 +1279,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -960,6 +1286,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -982,79 +1312,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1066,13 +1525,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1080,61 +1533,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1142,418 +1558,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1563,14 +1572,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
-    },
-    "anchor_href": {
-      "type": "string",
-      "pattern": "^#.+$",
-      "description": "Anchor links for navigation within the same page. Format: '#anchor-link-id'"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/service_manual_guide/publisher_v2/links.json
+++ b/dist/formats/service_manual_guide/publisher_v2/links.json
@@ -3,31 +3,12 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "previous_version": {
-      "type": "string"
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
         "content_owners": {
           "description": "References a page of a GDS community responsible for maintaining the guide e.g. Agile delivery community, Design community",
-          "$ref": "#/definitions/guid_list"
-        },
-        "service_manual_topics": {
-          "description": "References an array of 'service_manual_topic's. Not to be confused with 'topics'.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/guid_list"
         },
         "mainstream_browse_pages": {
@@ -38,8 +19,12 @@
           "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/guid_list"
         },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
@@ -59,38 +44,54 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "service_manual_topics": {
+          "description": "References an array of 'service_manual_topic's. Not to be confused with 'topics'.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/guid_list"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
         }
       }
+    },
+    "previous_version": {
+      "type": "string"
     }
   },
   "definitions": {
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
     "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
       "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
     "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
         {
           "type": "string"
@@ -98,22 +99,158 @@
         {
           "type": "null"
         }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+      ]
     },
-    "external_related_links": {
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -124,20 +261,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -154,212 +624,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -418,98 +698,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -518,10 +831,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -529,6 +838,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -551,79 +864,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -635,13 +1077,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -649,61 +1085,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -711,418 +1110,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1132,9 +1124,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/service_manual_guide/publisher_v2/schema.json
+++ b/dist/formats/service_manual_guide/publisher_v2/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "title",
     "details",
@@ -13,12 +12,22 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "description": {
       "anyOf": [
@@ -30,84 +39,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "access_limited": {
-      "$ref": "#/definitions/access_limited"
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "change_note": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "previous_version": {
-      "type": "string"
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "links": {
-      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string",
@@ -272,93 +205,109 @@
         "written_statement"
       ]
     },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "service_manual_guide"
       ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "body"
-      ],
-      "properties": {
-        "show_description": {
-          "type": "boolean",
-          "description": "Display the description on the page if true. This is needed for the service standard points."
-        },
-        "body": {
-          "$ref": "#/definitions/body"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "header_links": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "title": {
-                "type": "string"
-              },
-              "href": {
-                "$ref": "#/definitions/anchor_href"
-              }
-            },
-            "required": [
-              "title",
-              "href"
-            ]
-          }
-        },
-        "change_note": {
-          "$ref": "#/definitions/change_note"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        }
-      }
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policy_areas": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
     },
     "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
       "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
     "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
         {
           "type": "string"
@@ -366,22 +315,206 @@
         {
           "type": "null"
         }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+      ]
     },
-    "external_related_links": {
+    "anchor_href": {
+      "description": "Anchor links for navigation within the same page. Format: '#anchor-link-id'",
+      "type": "string",
+      "pattern": "^#.+$"
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "required": [
+        "body"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "body": {
+          "$ref": "#/definitions/body"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "change_note": {
+          "$ref": "#/definitions/change_note"
+        },
+        "header_links": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "title",
+              "href"
+            ],
+            "properties": {
+              "href": {
+                "$ref": "#/definitions/anchor_href"
+              },
+              "title": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "show_description": {
+          "description": "Display the description on the page if true. This is needed for the service standard points.",
+          "type": "boolean"
+        },
+        "withdrawn_notice": {
+          "$ref": "#/definitions/withdrawn_notice"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -392,20 +525,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -422,212 +888,31 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
         }
       }
     },
-    "redirect_route": {
+    "links": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
       "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
         }
       }
     },
@@ -686,98 +971,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -786,10 +1104,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -797,6 +1111,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -819,79 +1137,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -903,13 +1350,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -917,61 +1358,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -979,418 +1383,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1400,14 +1397,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
-    },
-    "anchor_href": {
-      "type": "string",
-      "pattern": "^#.+$",
-      "description": "Anchor links for navigation within the same page. Format: '#anchor-link-id'"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/service_manual_homepage/frontend/schema.json
+++ b/dist/formats/service_manual_homepage/frontend/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "links",
@@ -12,12 +11,25 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -29,119 +41,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_pages": {
-          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "meets_user_needs": {
-          "description": "The user needs this piece of content meets.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "organisations": {
-          "description": "All organisations linked to this content item. This should include lead organisations.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "parent": {
-          "description": "The parent content item.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policy_areas": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "primary_publishing_organisation": {
-          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "available_translations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "children": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policies": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "document_collections": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "child_taxons": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -306,140 +207,262 @@
         "written_statement"
       ]
     },
+    "email_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "available_translations": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "policies": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policy_areas": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "primary_publishing_organisation": {
+          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "service_manual_homepage"
       ]
     },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    "title": {
+      "type": "string"
     },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
-    "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
     },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
-    "frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "base_path",
-          "locale"
-        ],
-        "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
-          },
-          "document_type": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
             "type": "string"
-          },
-          "schema_name": {
-            "type": "string"
-          },
-          "public_updated_at": {
-            "type": "string"
-          },
-          "content_id": {
-            "$ref": "#/definitions/guid"
-          },
-          "title": {
-            "type": "string"
-          },
-          "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
-            "type": "string"
-          },
-          "links": {
-            "type": "object",
-            "patternProperties": {
-              "^[a-z_]+$": {
-                "$ref": "#/definitions/frontend_links"
-              }
-            }
           }
         }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
       }
     },
     "base_path_less_frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "document_type": {
-            "type": "string"
-          },
-          "schema_name": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
           "api_path": {
             "$ref": "#/definitions/absolute_path"
@@ -449,25 +472,93 @@
             "type": "string",
             "format": "uri"
           },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "public_updated_at": {
-            "type": "string"
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
+          "document_type": {
             "type": "string"
           },
           "locale": {
             "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
           }
         }
       }
@@ -480,56 +571,50 @@
         }
       }
     },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
     },
-    "external_related_links": {
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -540,20 +625,437 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "base_path",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
+            "type": "string"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "country": {
+            "$ref": "#/definitions/country"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "details": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "links": {
+            "type": "object",
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links"
+              }
+            }
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -570,212 +1072,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -834,98 +1146,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -934,10 +1279,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -945,6 +1286,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -967,79 +1312,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1051,13 +1525,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1065,61 +1533,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1127,418 +1558,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1548,9 +1572,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/service_manual_homepage/notification/schema.json
+++ b/dist/formats/service_manual_homepage/notification/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "content_id",
@@ -17,12 +16,25 @@
     "title",
     "update_type"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -34,60 +46,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -252,60 +212,9 @@
         "written_statement"
       ]
     },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "service_manual_homepage"
-      ]
-    },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
-    },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
     "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "govuk_request_id": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
     },
     "expanded_links": {
       "type": "object",
@@ -314,112 +223,206 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "govuk_request_id": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "service_manual_homepage"
+      ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
-    "frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "base_path",
-          "locale"
-        ],
-        "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
-          },
-          "document_type": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
             "type": "string"
-          },
-          "schema_name": {
-            "type": "string"
-          },
-          "public_updated_at": {
-            "type": "string"
-          },
-          "content_id": {
-            "$ref": "#/definitions/guid"
-          },
-          "title": {
-            "type": "string"
-          },
-          "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
-            "type": "string"
-          },
-          "links": {
-            "type": "object",
-            "patternProperties": {
-              "^[a-z_]+$": {
-                "$ref": "#/definitions/frontend_links"
-              }
-            }
           }
         }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
       }
     },
     "base_path_less_frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "document_type": {
-            "type": "string"
-          },
-          "schema_name": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
           "api_path": {
             "$ref": "#/definitions/absolute_path"
@@ -429,25 +432,93 @@
             "type": "string",
             "format": "uri"
           },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "public_updated_at": {
-            "type": "string"
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
+          "document_type": {
             "type": "string"
           },
           "locale": {
             "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
           }
         }
       }
@@ -460,56 +531,50 @@
         }
       }
     },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
     },
-    "external_related_links": {
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -520,20 +585,437 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "base_path",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
+            "type": "string"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "country": {
+            "$ref": "#/definitions/country"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "details": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "links": {
+            "type": "object",
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links"
+              }
+            }
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -550,212 +1032,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -814,98 +1106,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -914,10 +1239,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -925,6 +1246,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -947,79 +1272,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1031,13 +1485,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1045,61 +1493,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1107,418 +1518,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1528,9 +1532,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/service_manual_homepage/publisher_v2/links.json
+++ b/dist/formats/service_manual_homepage/publisher_v2/links.json
@@ -3,25 +3,10 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "previous_version": {
-      "type": "string"
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/guid_list"
-        },
         "mainstream_browse_pages": {
           "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/guid_list"
@@ -30,8 +15,12 @@
           "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/guid_list"
         },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
@@ -51,38 +40,50 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/guid_list"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
         }
       }
+    },
+    "previous_version": {
+      "type": "string"
     }
   },
   "definitions": {
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
     "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
       "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
     "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
         {
           "type": "string"
@@ -90,22 +91,158 @@
         {
           "type": "null"
         }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+      ]
     },
-    "external_related_links": {
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -116,20 +253,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -146,212 +616,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -410,98 +690,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -510,10 +823,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -521,6 +830,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -543,79 +856,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -627,13 +1069,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -641,61 +1077,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -703,418 +1102,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1124,9 +1116,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/service_manual_homepage/publisher_v2/schema.json
+++ b/dist/formats/service_manual_homepage/publisher_v2/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "title",
     "details",
@@ -13,12 +12,22 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "description": {
       "anyOf": [
@@ -30,84 +39,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "access_limited": {
-      "$ref": "#/definitions/access_limited"
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "change_note": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "previous_version": {
-      "type": "string"
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "links": {
-      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string",
@@ -272,55 +205,109 @@
         "written_statement"
       ]
     },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "service_manual_homepage"
       ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
-    "details": {
-      "type": "object",
-      "properties": {
-      }
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policy_areas": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
     },
     "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
       "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
     "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
         {
           "type": "string"
@@ -328,22 +315,163 @@
         {
           "type": "null"
         }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+      ]
     },
-    "external_related_links": {
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "properties": {
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -354,20 +482,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -384,212 +845,31 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
         }
       }
     },
-    "redirect_route": {
+    "links": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
       "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
         }
       }
     },
@@ -648,98 +928,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -748,10 +1061,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -759,6 +1068,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -781,79 +1094,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -865,13 +1307,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -879,61 +1315,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -941,418 +1340,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1362,9 +1354,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/service_manual_service_standard/frontend/schema.json
+++ b/dist/formats/service_manual_service_standard/frontend/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "links",
@@ -12,12 +11,25 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -29,123 +41,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "email_alert_signup": {
-          "description": "References an email alert signup page for the service standard",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_pages": {
-          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "meets_user_needs": {
-          "description": "The user needs this piece of content meets.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "organisations": {
-          "description": "All organisations linked to this content item. This should include lead organisations.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "parent": {
-          "description": "The parent content item.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policy_areas": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "primary_publishing_organisation": {
-          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "available_translations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "children": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policies": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "document_collections": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "child_taxons": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -310,140 +207,266 @@
         "written_statement"
       ]
     },
+    "email_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "available_translations": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "email_alert_signup": {
+          "description": "References an email alert signup page for the service standard",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "policies": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policy_areas": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "primary_publishing_organisation": {
+          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "service_manual_service_standard"
       ]
     },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    "title": {
+      "type": "string"
     },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
-    "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
     },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
-    "frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "base_path",
-          "locale"
-        ],
-        "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
-          },
-          "document_type": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
             "type": "string"
-          },
-          "schema_name": {
-            "type": "string"
-          },
-          "public_updated_at": {
-            "type": "string"
-          },
-          "content_id": {
-            "$ref": "#/definitions/guid"
-          },
-          "title": {
-            "type": "string"
-          },
-          "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
-            "type": "string"
-          },
-          "links": {
-            "type": "object",
-            "patternProperties": {
-              "^[a-z_]+$": {
-                "$ref": "#/definitions/frontend_links"
-              }
-            }
           }
         }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
       }
     },
     "base_path_less_frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "document_type": {
-            "type": "string"
-          },
-          "schema_name": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
           "api_path": {
             "$ref": "#/definitions/absolute_path"
@@ -453,25 +476,93 @@
             "type": "string",
             "format": "uri"
           },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "public_updated_at": {
-            "type": "string"
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
+          "document_type": {
             "type": "string"
           },
           "locale": {
             "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
           }
         }
       }
@@ -483,66 +574,60 @@
         "body": {
           "$ref": "#/definitions/body"
         },
-        "poster_url": {
-          "type": "string",
-          "format": "uri",
-          "description": "URL to the service standard poster (absolute)"
-        },
         "change_history": {
           "$ref": "#/definitions/change_history"
+        },
+        "poster_url": {
+          "description": "URL to the service standard poster (absolute)",
+          "type": "string",
+          "format": "uri"
         }
       }
     },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -553,20 +638,437 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "base_path",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
+            "type": "string"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "country": {
+            "$ref": "#/definitions/country"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "details": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "links": {
+            "type": "object",
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links"
+              }
+            }
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -583,212 +1085,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -847,98 +1159,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -947,10 +1292,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -958,6 +1299,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -980,79 +1325,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1064,13 +1538,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1078,61 +1546,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1140,418 +1571,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1561,9 +1585,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/service_manual_service_standard/notification/schema.json
+++ b/dist/formats/service_manual_service_standard/notification/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "content_id",
@@ -17,12 +16,25 @@
     "title",
     "update_type"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -34,60 +46,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -252,60 +212,9 @@
         "written_statement"
       ]
     },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "service_manual_service_standard"
-      ]
-    },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
-    },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
     "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "govuk_request_id": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
     },
     "expanded_links": {
       "type": "object",
@@ -314,112 +223,206 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "govuk_request_id": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "service_manual_service_standard"
+      ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
-    "frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "base_path",
-          "locale"
-        ],
-        "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
-          },
-          "document_type": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
             "type": "string"
-          },
-          "schema_name": {
-            "type": "string"
-          },
-          "public_updated_at": {
-            "type": "string"
-          },
-          "content_id": {
-            "$ref": "#/definitions/guid"
-          },
-          "title": {
-            "type": "string"
-          },
-          "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
-            "type": "string"
-          },
-          "links": {
-            "type": "object",
-            "patternProperties": {
-              "^[a-z_]+$": {
-                "$ref": "#/definitions/frontend_links"
-              }
-            }
           }
         }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
       }
     },
     "base_path_less_frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "document_type": {
-            "type": "string"
-          },
-          "schema_name": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
           "api_path": {
             "$ref": "#/definitions/absolute_path"
@@ -429,25 +432,93 @@
             "type": "string",
             "format": "uri"
           },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "public_updated_at": {
-            "type": "string"
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
+          "document_type": {
             "type": "string"
           },
           "locale": {
             "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
           }
         }
       }
@@ -459,66 +530,60 @@
         "body": {
           "$ref": "#/definitions/body"
         },
-        "poster_url": {
-          "type": "string",
-          "format": "uri",
-          "description": "URL to the service standard poster (absolute)"
-        },
         "change_history": {
           "$ref": "#/definitions/change_history"
+        },
+        "poster_url": {
+          "description": "URL to the service standard poster (absolute)",
+          "type": "string",
+          "format": "uri"
         }
       }
     },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -529,20 +594,437 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "base_path",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
+            "type": "string"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "country": {
+            "$ref": "#/definitions/country"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "details": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "links": {
+            "type": "object",
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links"
+              }
+            }
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -559,212 +1041,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -823,98 +1115,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -923,10 +1248,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -934,6 +1255,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -956,79 +1281,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1040,13 +1494,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1054,61 +1502,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1116,418 +1527,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1537,9 +1541,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/service_manual_service_standard/publisher_v2/links.json
+++ b/dist/formats/service_manual_service_standard/publisher_v2/links.json
@@ -3,27 +3,12 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "previous_version": {
-      "type": "string"
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
         "email_alert_signup": {
           "description": "References an email alert signup page for the service standard",
-          "$ref": "#/definitions/guid_list"
-        },
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/guid_list"
         },
         "mainstream_browse_pages": {
@@ -34,8 +19,12 @@
           "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/guid_list"
         },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
@@ -55,38 +44,50 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/guid_list"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
         }
       }
+    },
+    "previous_version": {
+      "type": "string"
     }
   },
   "definitions": {
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
     "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
       "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
     "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
         {
           "type": "string"
@@ -94,22 +95,158 @@
         {
           "type": "null"
         }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+      ]
     },
-    "external_related_links": {
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -120,20 +257,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -150,212 +620,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -414,98 +694,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -514,10 +827,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -525,6 +834,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -547,79 +860,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -631,13 +1073,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -645,61 +1081,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -707,418 +1106,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1128,9 +1120,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/service_manual_service_standard/publisher_v2/schema.json
+++ b/dist/formats/service_manual_service_standard/publisher_v2/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "title",
     "details",
@@ -13,12 +12,22 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "description": {
       "anyOf": [
@@ -30,84 +39,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "access_limited": {
-      "$ref": "#/definitions/access_limited"
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "change_note": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "previous_version": {
-      "type": "string"
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "links": {
-      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string",
@@ -272,14 +205,224 @@
         "written_statement"
       ]
     },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "service_manual_service_standard"
       ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,
@@ -288,71 +431,56 @@
           "$ref": "#/definitions/body"
         },
         "poster_url": {
+          "description": "URL to the service standard poster (absolute)",
           "type": "string",
-          "format": "uri",
-          "description": "URL to the service standard poster (absolute)"
+          "format": "uri"
         }
       }
     },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policy_areas": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -363,20 +491,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -393,212 +854,31 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
         }
       }
     },
-    "redirect_route": {
+    "links": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
       "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
         }
       }
     },
@@ -657,98 +937,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -757,10 +1070,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -768,6 +1077,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -790,79 +1103,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -874,13 +1316,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -888,61 +1324,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -950,418 +1349,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1371,9 +1363,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/service_manual_service_toolkit/frontend/schema.json
+++ b/dist/formats/service_manual_service_toolkit/frontend/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "links",
@@ -12,12 +11,25 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -29,119 +41,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_pages": {
-          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "meets_user_needs": {
-          "description": "The user needs this piece of content meets.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "organisations": {
-          "description": "All organisations linked to this content item. This should include lead organisations.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "parent": {
-          "description": "The parent content item.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policy_areas": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "primary_publishing_organisation": {
-          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "available_translations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "children": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policies": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "document_collections": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "child_taxons": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -306,67 +207,660 @@
         "written_statement"
       ]
     },
+    "email_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "available_translations": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "policies": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policy_areas": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "primary_publishing_organisation": {
+          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "service_manual_service_toolkit"
       ]
     },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    "title": {
+      "type": "string"
     },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
-    "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
     },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "base_path_less_frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "collections": {
+          "description": "Collections of links grouped under a title and description",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "title",
+              "links"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "description": "Collection description",
+                "type": "string"
+              },
+              "links": {
+                "description": "Array of links in this collection",
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": [
+                    "title",
+                    "url"
+                  ],
+                  "additionalProperties": false,
+                  "properties": {
+                    "description": {
+                      "description": "Link description",
+                      "type": "string"
+                    },
+                    "title": {
+                      "description": "Link Title",
+                      "type": "string"
+                    },
+                    "url": {
+                      "description": "Link URL (absolute)",
+                      "type": "string",
+                      "format": "uri"
+                    }
+                  }
+                }
+              },
+              "title": {
+                "description": "Collection title",
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "required": [
+        "title",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
     "frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "base_path",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
-          "document_type": {
-            "type": "string"
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
           },
-          "schema_name": {
-            "type": "string"
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
           },
-          "public_updated_at": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
             "type": "string"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
-            "type": "string"
+          "country": {
+            "$ref": "#/definitions/country"
           },
           "description": {
             "anyOf": [
@@ -378,36 +872,11 @@
               }
             ]
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "details": {
+            "type": "object",
+            "additionalProperties": true
           },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
+          "document_type": {
             "type": "string"
           },
           "links": {
@@ -417,172 +886,205 @@
                 "$ref": "#/definitions/frontend_links"
               }
             }
-          }
-        }
-      }
-    },
-    "base_path_less_frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "locale"
-        ],
-        "properties": {
-          "document_type": {
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
             "type": "string"
           },
           "schema_name": {
             "type": "string"
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
+          "title": {
+            "type": "string"
           },
           "web_url": {
             "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
             "type": "string",
             "format": "uri"
           },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
           },
-          "public_updated_at": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
             "type": "string"
           },
-          "content_id": {
-            "$ref": "#/definitions/guid"
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
           },
           "title": {
             "type": "string"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
           }
         }
       }
     },
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "collections": {
-          "type": "array",
-          "description": "Collections of links grouped under a title and description",
-          "items": {
-            "type": "object",
-            "required": [
-              "title",
-              "links"
-            ],
-            "additionalProperties": false,
-            "properties": {
-              "title": {
-                "type": "string",
-                "description": "Collection title"
-              },
-              "description": {
-                "type": "string",
-                "description": "Collection description"
-              },
-              "links": {
-                "type": "array",
-                "description": "Array of links in this collection",
-                "items": {
-                  "type": "object",
-                  "required": [
-                    "title",
-                    "url"
-                  ],
-                  "additionalProperties": false,
-                  "properties": {
-                    "title": {
-                      "type": "string",
-                      "description": "Link Title"
-                    },
-                    "url": {
-                      "type": "string",
-                      "format": "uri",
-                      "description": "Link URL (absolute)"
-                    },
-                    "description": {
-                      "type": "string",
-                      "description": "Link description"
-                    }
-                  }
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
                 }
               }
             }
-          }
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
+          },
+          "title": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/external_link"
-      }
-    },
-    "external_link": {
+    "image": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
+        "alt_text": {
           "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "url": {
           "type": "string",
@@ -593,17 +1095,17 @@
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -620,212 +1122,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -884,98 +1196,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -984,10 +1329,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -995,6 +1336,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -1017,79 +1362,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1101,13 +1575,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1115,61 +1583,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1177,418 +1608,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1598,9 +1622,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/service_manual_service_toolkit/notification/schema.json
+++ b/dist/formats/service_manual_service_toolkit/notification/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "content_id",
@@ -17,12 +16,25 @@
     "title",
     "update_type"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -34,60 +46,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -252,60 +212,9 @@
         "written_statement"
       ]
     },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "service_manual_service_toolkit"
-      ]
-    },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
-    },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
     "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "govuk_request_id": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
     },
     "expanded_links": {
       "type": "object",
@@ -314,39 +223,604 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "govuk_request_id": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "service_manual_service_toolkit"
+      ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "base_path_less_frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "collections": {
+          "description": "Collections of links grouped under a title and description",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "title",
+              "links"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "description": "Collection description",
+                "type": "string"
+              },
+              "links": {
+                "description": "Array of links in this collection",
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": [
+                    "title",
+                    "url"
+                  ],
+                  "additionalProperties": false,
+                  "properties": {
+                    "description": {
+                      "description": "Link description",
+                      "type": "string"
+                    },
+                    "title": {
+                      "description": "Link Title",
+                      "type": "string"
+                    },
+                    "url": {
+                      "description": "Link URL (absolute)",
+                      "type": "string",
+                      "format": "uri"
+                    }
+                  }
+                }
+              },
+              "title": {
+                "description": "Collection title",
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "required": [
+        "title",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
     "frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "base_path",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
-          "document_type": {
-            "type": "string"
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
           },
-          "schema_name": {
-            "type": "string"
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
           },
-          "public_updated_at": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
             "type": "string"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
-            "type": "string"
+          "country": {
+            "$ref": "#/definitions/country"
           },
           "description": {
             "anyOf": [
@@ -358,36 +832,11 @@
               }
             ]
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "details": {
+            "type": "object",
+            "additionalProperties": true
           },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
+          "document_type": {
             "type": "string"
           },
           "links": {
@@ -397,172 +846,205 @@
                 "$ref": "#/definitions/frontend_links"
               }
             }
-          }
-        }
-      }
-    },
-    "base_path_less_frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "locale"
-        ],
-        "properties": {
-          "document_type": {
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
             "type": "string"
           },
           "schema_name": {
             "type": "string"
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
+          "title": {
+            "type": "string"
           },
           "web_url": {
             "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
             "type": "string",
             "format": "uri"
           },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
           },
-          "public_updated_at": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
             "type": "string"
           },
-          "content_id": {
-            "$ref": "#/definitions/guid"
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
           },
           "title": {
             "type": "string"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
           }
         }
       }
     },
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "collections": {
-          "type": "array",
-          "description": "Collections of links grouped under a title and description",
-          "items": {
-            "type": "object",
-            "required": [
-              "title",
-              "links"
-            ],
-            "additionalProperties": false,
-            "properties": {
-              "title": {
-                "type": "string",
-                "description": "Collection title"
-              },
-              "description": {
-                "type": "string",
-                "description": "Collection description"
-              },
-              "links": {
-                "type": "array",
-                "description": "Array of links in this collection",
-                "items": {
-                  "type": "object",
-                  "required": [
-                    "title",
-                    "url"
-                  ],
-                  "additionalProperties": false,
-                  "properties": {
-                    "title": {
-                      "type": "string",
-                      "description": "Link Title"
-                    },
-                    "url": {
-                      "type": "string",
-                      "format": "uri",
-                      "description": "Link URL (absolute)"
-                    },
-                    "description": {
-                      "type": "string",
-                      "description": "Link description"
-                    }
-                  }
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
                 }
               }
             }
-          }
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
+          },
+          "title": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/external_link"
-      }
-    },
-    "external_link": {
+    "image": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
+        "alt_text": {
           "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "url": {
           "type": "string",
@@ -573,17 +1055,17 @@
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -600,212 +1082,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -864,98 +1156,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -964,10 +1289,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -975,6 +1296,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -997,79 +1322,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1081,13 +1535,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1095,61 +1543,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1157,418 +1568,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1578,9 +1582,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/service_manual_service_toolkit/publisher_v2/links.json
+++ b/dist/formats/service_manual_service_toolkit/publisher_v2/links.json
@@ -3,25 +3,10 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "previous_version": {
-      "type": "string"
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/guid_list"
-        },
         "mainstream_browse_pages": {
           "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/guid_list"
@@ -30,8 +15,12 @@
           "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/guid_list"
         },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
@@ -51,38 +40,50 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/guid_list"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
         }
       }
+    },
+    "previous_version": {
+      "type": "string"
     }
   },
   "definitions": {
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
     "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
       "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
     "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
         {
           "type": "string"
@@ -90,22 +91,158 @@
         {
           "type": "null"
         }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+      ]
     },
-    "external_related_links": {
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -116,20 +253,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -146,212 +616,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -410,98 +690,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -510,10 +823,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -521,6 +830,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -543,79 +856,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -627,13 +1069,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -641,61 +1077,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -703,418 +1102,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1124,9 +1116,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
+++ b/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "title",
     "details",
@@ -13,12 +12,22 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "description": {
       "anyOf": [
@@ -30,84 +39,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "access_limited": {
-      "$ref": "#/definitions/access_limited"
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "change_note": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "previous_version": {
-      "type": "string"
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "links": {
-      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string",
@@ -272,21 +205,231 @@
         "written_statement"
       ]
     },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "service_manual_service_toolkit"
       ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
         "collections": {
-          "type": "array",
           "description": "Collections of links grouped under a title and description",
+          "type": "array",
           "items": {
             "type": "object",
             "required": [
@@ -295,17 +438,13 @@
             ],
             "additionalProperties": false,
             "properties": {
-              "title": {
-                "type": "string",
-                "description": "Collection title"
-              },
               "description": {
-                "type": "string",
-                "description": "Collection description"
+                "description": "Collection description",
+                "type": "string"
               },
               "links": {
-                "type": "array",
                 "description": "Array of links in this collection",
+                "type": "array",
                 "items": {
                   "type": "object",
                   "required": [
@@ -314,86 +453,75 @@
                   ],
                   "additionalProperties": false,
                   "properties": {
+                    "description": {
+                      "description": "Link description",
+                      "type": "string"
+                    },
                     "title": {
-                      "type": "string",
-                      "description": "Link Title"
+                      "description": "Link Title",
+                      "type": "string"
                     },
                     "url": {
+                      "description": "Link URL (absolute)",
                       "type": "string",
-                      "format": "uri",
-                      "description": "Link URL (absolute)"
-                    },
-                    "description": {
-                      "type": "string",
-                      "description": "Link description"
+                      "format": "uri"
                     }
                   }
                 }
+              },
+              "title": {
+                "description": "Collection title",
+                "type": "string"
               }
             }
           }
         }
       }
     },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policy_areas": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -404,20 +532,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -434,212 +895,31 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
         }
       }
     },
-    "redirect_route": {
+    "links": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
       "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
         }
       }
     },
@@ -698,98 +978,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -798,10 +1111,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -809,6 +1118,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -831,79 +1144,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -915,13 +1357,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -929,61 +1365,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -991,418 +1390,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1412,9 +1404,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/service_manual_topic/frontend/schema.json
+++ b/dist/formats/service_manual_topic/frontend/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "links",
@@ -12,12 +11,25 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -29,131 +41,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "linked_items": {
-          "description": "Includes all content ids referenced in 'details'. This is a temporary measure to expand content ids for frontends which is planned to be replaced by a dependency resolution service.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "content_owners": {
-          "description": "References a page of a GDS community responsible for maintaining the guide e.g. Agile delivery community, Design community",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "email_alert_signup": {
-          "description": "References an email alert signup page for this topic",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_pages": {
-          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "meets_user_needs": {
-          "description": "The user needs this piece of content meets.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "organisations": {
-          "description": "All organisations linked to this content item. This should include lead organisations.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "parent": {
-          "description": "The parent content item.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policy_areas": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "primary_publishing_organisation": {
-          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "available_translations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "children": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policies": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "document_collections": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "child_taxons": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -318,67 +207,633 @@
         "written_statement"
       ]
     },
+    "email_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "available_translations": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "content_owners": {
+          "description": "References a page of a GDS community responsible for maintaining the guide e.g. Agile delivery community, Design community",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "email_alert_signup": {
+          "description": "References an email alert signup page for this topic",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "linked_items": {
+          "description": "Includes all content ids referenced in 'details'. This is a temporary measure to expand content ids for frontends which is planned to be replaced by a dependency resolution service.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "policies": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policy_areas": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "primary_publishing_organisation": {
+          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "service_manual_topic"
       ]
     },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    "title": {
+      "type": "string"
     },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
-    "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
     },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "base_path_less_frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "groups": {
+          "$ref": "#/definitions/service_manual_topic_groups"
+        },
+        "visually_collapsed": {
+          "description": "A flag set by a content designer when they want the sections of a topic to be collapsed into an accordion. This will likely be used when there are many items in the topic.",
+          "type": "boolean"
+        },
+        "withdrawn_notice": {
+          "$ref": "#/definitions/withdrawn_notice"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "required": [
+        "title",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
     "frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "base_path",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
-          "document_type": {
-            "type": "string"
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
           },
-          "schema_name": {
-            "type": "string"
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
           },
-          "public_updated_at": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
             "type": "string"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
-            "type": "string"
+          "country": {
+            "$ref": "#/definitions/country"
           },
           "description": {
             "anyOf": [
@@ -390,36 +845,11 @@
               }
             ]
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "details": {
+            "type": "object",
+            "additionalProperties": true
           },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
+          "document_type": {
             "type": "string"
           },
           "links": {
@@ -429,133 +859,205 @@
                 "$ref": "#/definitions/frontend_links"
               }
             }
-          }
-        }
-      }
-    },
-    "base_path_less_frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "locale"
-        ],
-        "properties": {
-          "document_type": {
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
             "type": "string"
           },
           "schema_name": {
             "type": "string"
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
+          "title": {
+            "type": "string"
           },
           "web_url": {
             "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
             "type": "string",
             "format": "uri"
           },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
           },
-          "public_updated_at": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
             "type": "string"
           },
-          "content_id": {
-            "$ref": "#/definitions/guid"
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
           },
           "title": {
             "type": "string"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
           }
         }
       }
     },
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "visually_collapsed": {
-          "type": "boolean",
-          "description": "A flag set by a content designer when they want the sections of a topic to be collapsed into an accordion. This will likely be used when there are many items in the topic."
-        },
-        "groups": {
-          "$ref": "#/definitions/service_manual_topic_groups"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
       }
     },
-    "external_link": {
+    "image": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
+        "alt_text": {
           "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "url": {
           "type": "string",
@@ -566,17 +1068,17 @@
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -593,212 +1095,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -857,98 +1169,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -957,10 +1302,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -968,6 +1309,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -990,79 +1335,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1074,13 +1548,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1088,61 +1556,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1150,418 +1581,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1571,9 +1595,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/service_manual_topic/notification/schema.json
+++ b/dist/formats/service_manual_topic/notification/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "content_id",
@@ -17,12 +16,25 @@
     "title",
     "update_type"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -34,60 +46,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -252,60 +212,9 @@
         "written_statement"
       ]
     },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "service_manual_topic"
-      ]
-    },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
-    },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
     "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "govuk_request_id": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
     },
     "expanded_links": {
       "type": "object",
@@ -314,39 +223,565 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "govuk_request_id": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "service_manual_topic"
+      ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "base_path_less_frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "groups": {
+          "$ref": "#/definitions/service_manual_topic_groups"
+        },
+        "visually_collapsed": {
+          "description": "A flag set by a content designer when they want the sections of a topic to be collapsed into an accordion. This will likely be used when there are many items in the topic.",
+          "type": "boolean"
+        },
+        "withdrawn_notice": {
+          "$ref": "#/definitions/withdrawn_notice"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "required": [
+        "title",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
     "frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "base_path",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
-          "document_type": {
-            "type": "string"
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
           },
-          "schema_name": {
-            "type": "string"
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
           },
-          "public_updated_at": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
             "type": "string"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
-            "type": "string"
+          "country": {
+            "$ref": "#/definitions/country"
           },
           "description": {
             "anyOf": [
@@ -358,36 +793,11 @@
               }
             ]
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "details": {
+            "type": "object",
+            "additionalProperties": true
           },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
+          "document_type": {
             "type": "string"
           },
           "links": {
@@ -397,133 +807,205 @@
                 "$ref": "#/definitions/frontend_links"
               }
             }
-          }
-        }
-      }
-    },
-    "base_path_less_frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "locale"
-        ],
-        "properties": {
-          "document_type": {
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
             "type": "string"
           },
           "schema_name": {
             "type": "string"
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
+          "title": {
+            "type": "string"
           },
           "web_url": {
             "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
             "type": "string",
             "format": "uri"
           },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
           },
-          "public_updated_at": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
             "type": "string"
           },
-          "content_id": {
-            "$ref": "#/definitions/guid"
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
           },
           "title": {
             "type": "string"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
           }
         }
       }
     },
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "visually_collapsed": {
-          "type": "boolean",
-          "description": "A flag set by a content designer when they want the sections of a topic to be collapsed into an accordion. This will likely be used when there are many items in the topic."
-        },
-        "groups": {
-          "$ref": "#/definitions/service_manual_topic_groups"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
       }
     },
-    "external_link": {
+    "image": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
+        "alt_text": {
           "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "url": {
           "type": "string",
@@ -534,17 +1016,17 @@
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -561,212 +1043,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -825,98 +1117,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -925,10 +1250,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -936,6 +1257,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -958,79 +1283,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1042,13 +1496,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1056,61 +1504,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1118,418 +1529,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1539,9 +1543,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/service_manual_topic/publisher_v2/links.json
+++ b/dist/formats/service_manual_topic/publisher_v2/links.json
@@ -3,17 +3,10 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "previous_version": {
-      "type": "string"
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "linked_items": {
-          "description": "Includes all content ids referenced in 'details'. This is a temporary measure to expand content ids for frontends which is planned to be replaced by a dependency resolution service.",
-          "$ref": "#/definitions/guid_list"
-        },
         "content_owners": {
           "description": "References a page of a GDS community responsible for maintaining the guide e.g. Agile delivery community, Design community",
           "$ref": "#/definitions/guid_list"
@@ -22,16 +15,8 @@
           "description": "References an email alert signup page for this topic",
           "$ref": "#/definitions/guid_list"
         },
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
+        "linked_items": {
+          "description": "Includes all content ids referenced in 'details'. This is a temporary measure to expand content ids for frontends which is planned to be replaced by a dependency resolution service.",
           "$ref": "#/definitions/guid_list"
         },
         "mainstream_browse_pages": {
@@ -42,8 +27,12 @@
           "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/guid_list"
         },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
@@ -63,38 +52,50 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/guid_list"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
         }
       }
+    },
+    "previous_version": {
+      "type": "string"
     }
   },
   "definitions": {
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
     "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
       "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
     "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
         {
           "type": "string"
@@ -102,22 +103,158 @@
         {
           "type": "null"
         }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+      ]
     },
-    "external_related_links": {
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -128,20 +265,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -158,212 +628,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -422,98 +702,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -522,10 +835,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -533,6 +842,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -555,79 +868,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -639,13 +1081,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -653,61 +1089,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -715,418 +1114,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1136,9 +1128,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/service_manual_topic/publisher_v2/schema.json
+++ b/dist/formats/service_manual_topic/publisher_v2/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "title",
     "details",
@@ -13,12 +12,22 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "description": {
       "anyOf": [
@@ -30,84 +39,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "access_limited": {
-      "$ref": "#/definitions/access_limited"
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "change_note": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "previous_version": {
-      "type": "string"
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "links": {
-      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string",
@@ -272,66 +205,109 @@
         "written_statement"
       ]
     },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "service_manual_topic"
       ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "visually_collapsed": {
-          "type": "boolean",
-          "description": "A flag set by a content designer when they want the sections of a topic to be collapsed into an accordion. This will likely be used when there are many items in the topic."
-        },
-        "groups": {
-          "$ref": "#/definitions/service_manual_topic_groups"
-        },
-        "withdrawn_notice": {
-          "$ref": "#/definitions/withdrawn_notice"
-        }
-      }
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policy_areas": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
     },
     "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
       "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
     "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
         {
           "type": "string"
@@ -339,22 +315,174 @@
         {
           "type": "null"
         }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+      ]
     },
-    "external_related_links": {
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "groups": {
+          "$ref": "#/definitions/service_manual_topic_groups"
+        },
+        "visually_collapsed": {
+          "description": "A flag set by a content designer when they want the sections of a topic to be collapsed into an accordion. This will likely be used when there are many items in the topic.",
+          "type": "boolean"
+        },
+        "withdrawn_notice": {
+          "$ref": "#/definitions/withdrawn_notice"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -365,20 +493,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -395,212 +856,31 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
         }
       }
     },
-    "redirect_route": {
+    "links": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
       "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
         }
       }
     },
@@ -659,98 +939,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -759,10 +1072,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -770,6 +1079,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -792,79 +1105,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -876,13 +1318,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -890,61 +1326,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -952,418 +1351,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1373,9 +1365,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/simple_smart_answer/frontend/schema.json
+++ b/dist/formats/simple_smart_answer/frontend/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "links",
@@ -12,12 +11,25 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -29,119 +41,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_pages": {
-          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "meets_user_needs": {
-          "description": "The user needs this piece of content meets.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "organisations": {
-          "description": "All organisations linked to this content item. This should include lead organisations.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "parent": {
-          "description": "The parent content item.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policy_areas": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "primary_publishing_organisation": {
-          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "available_translations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "children": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policies": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "document_collections": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "child_taxons": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -306,67 +207,679 @@
         "written_statement"
       ]
     },
+    "email_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "available_translations": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "policies": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policy_areas": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "primary_publishing_organisation": {
+          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "simple_smart_answer"
       ]
     },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    "title": {
+      "type": "string"
     },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
-    "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
     },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "base_path_less_frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "required": [
+        "start_button_text"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "body": {
+          "$ref": "#/definitions/body_html_and_govspeak"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "external_related_links": {
+          "$ref": "#/definitions/external_related_links"
+        },
+        "nodes": {
+          "description": "List of nodes consisting of questions and answers",
+          "type": "array",
+          "items": {
+            "description": "A node represents either a question or an answer and results in a renderable page",
+            "type": "object",
+            "required": [
+              "kind",
+              "slug",
+              "title"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "body": {
+                "$ref": "#/definitions/body_html_and_govspeak"
+              },
+              "kind": {
+                "enum": [
+                  "question",
+                  "outcome"
+                ]
+              },
+              "options": {
+                "description": "Contains references to other nodes",
+                "type": "array",
+                "items": {
+                  "description": "An option represents a possible answer a user can select which links to another node",
+                  "type": "object",
+                  "required": [
+                    "label",
+                    "slug",
+                    "next_node"
+                  ],
+                  "additionalProperties": false,
+                  "properties": {
+                    "label": {
+                      "type": "string"
+                    },
+                    "next_node": {
+                      "type": "string"
+                    },
+                    "slug": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "slug": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "start_button_text": {
+          "$ref": "#/definitions/start_button_text"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "required": [
+        "title",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
     "frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "base_path",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
-          "document_type": {
-            "type": "string"
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
           },
-          "schema_name": {
-            "type": "string"
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
           },
-          "public_updated_at": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
             "type": "string"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
-            "type": "string"
+          "country": {
+            "$ref": "#/definitions/country"
           },
           "description": {
             "anyOf": [
@@ -378,36 +891,11 @@
               }
             ]
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "details": {
+            "type": "object",
+            "additionalProperties": true
           },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
+          "document_type": {
             "type": "string"
           },
           "links": {
@@ -417,191 +905,205 @@
                 "$ref": "#/definitions/frontend_links"
               }
             }
-          }
-        }
-      }
-    },
-    "base_path_less_frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "locale"
-        ],
-        "properties": {
-          "document_type": {
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
             "type": "string"
           },
           "schema_name": {
             "type": "string"
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
+          "title": {
+            "type": "string"
           },
           "web_url": {
             "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
             "type": "string",
             "format": "uri"
           },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
           },
-          "public_updated_at": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
             "type": "string"
           },
-          "content_id": {
-            "$ref": "#/definitions/guid"
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
           },
           "title": {
             "type": "string"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
           }
         }
       }
     },
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "start_button_text"
-      ],
-      "properties": {
-        "start_button_text": {
-          "$ref": "#/definitions/start_button_text"
-        },
-        "body": {
-          "$ref": "#/definitions/body_html_and_govspeak"
-        },
-        "nodes": {
-          "description": "List of nodes consisting of questions and answers",
-          "type": "array",
-          "items": {
-            "description": "A node represents either a question or an answer and results in a renderable page",
-            "type": "object",
-            "additionalProperties": false,
-            "required": [
-              "kind",
-              "slug",
-              "title"
-            ],
-            "properties": {
-              "kind": {
-                "enum": [
-                  "question",
-                  "outcome"
-                ]
-              },
-              "slug": {
-                "type": "string"
-              },
-              "title": {
-                "type": "string"
-              },
-              "body": {
-                "$ref": "#/definitions/body_html_and_govspeak"
-              },
-              "options": {
-                "description": "Contains references to other nodes",
-                "type": "array",
-                "items": {
-                  "description": "An option represents a possible answer a user can select which links to another node",
-                  "type": "object",
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "slug",
-                    "next_node"
-                  ],
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "slug": {
-                      "type": "string"
-                    },
-                    "next_node": {
-                      "type": "string"
-                    }
-                  }
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
                 }
               }
             }
-          }
-        },
-        "external_related_links": {
-          "$ref": "#/definitions/external_related_links"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
+          },
+          "title": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/external_link"
-      }
-    },
-    "external_link": {
+    "image": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
+        "alt_text": {
           "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "url": {
           "type": "string",
@@ -612,17 +1114,17 @@
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -639,212 +1141,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -903,98 +1215,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -1003,10 +1348,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -1014,6 +1355,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -1036,79 +1381,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1120,13 +1594,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1134,61 +1602,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1196,418 +1627,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1617,9 +1641,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/simple_smart_answer/notification/schema.json
+++ b/dist/formats/simple_smart_answer/notification/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "content_id",
@@ -17,12 +16,25 @@
     "title",
     "update_type"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -34,60 +46,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -252,60 +212,9 @@
         "written_statement"
       ]
     },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "simple_smart_answer"
-      ]
-    },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
-    },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
     "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "govuk_request_id": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
     },
     "expanded_links": {
       "type": "object",
@@ -314,39 +223,623 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "govuk_request_id": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "simple_smart_answer"
+      ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "base_path_less_frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "required": [
+        "start_button_text"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "body": {
+          "$ref": "#/definitions/body_html_and_govspeak"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "external_related_links": {
+          "$ref": "#/definitions/external_related_links"
+        },
+        "nodes": {
+          "description": "List of nodes consisting of questions and answers",
+          "type": "array",
+          "items": {
+            "description": "A node represents either a question or an answer and results in a renderable page",
+            "type": "object",
+            "required": [
+              "kind",
+              "slug",
+              "title"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "body": {
+                "$ref": "#/definitions/body_html_and_govspeak"
+              },
+              "kind": {
+                "enum": [
+                  "question",
+                  "outcome"
+                ]
+              },
+              "options": {
+                "description": "Contains references to other nodes",
+                "type": "array",
+                "items": {
+                  "description": "An option represents a possible answer a user can select which links to another node",
+                  "type": "object",
+                  "required": [
+                    "label",
+                    "slug",
+                    "next_node"
+                  ],
+                  "additionalProperties": false,
+                  "properties": {
+                    "label": {
+                      "type": "string"
+                    },
+                    "next_node": {
+                      "type": "string"
+                    },
+                    "slug": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "slug": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "start_button_text": {
+          "$ref": "#/definitions/start_button_text"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "required": [
+        "title",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
     "frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "base_path",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
-          "document_type": {
-            "type": "string"
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
           },
-          "schema_name": {
-            "type": "string"
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
           },
-          "public_updated_at": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
             "type": "string"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
-            "type": "string"
+          "country": {
+            "$ref": "#/definitions/country"
           },
           "description": {
             "anyOf": [
@@ -358,36 +851,11 @@
               }
             ]
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "details": {
+            "type": "object",
+            "additionalProperties": true
           },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
+          "document_type": {
             "type": "string"
           },
           "links": {
@@ -397,191 +865,205 @@
                 "$ref": "#/definitions/frontend_links"
               }
             }
-          }
-        }
-      }
-    },
-    "base_path_less_frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "locale"
-        ],
-        "properties": {
-          "document_type": {
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
             "type": "string"
           },
           "schema_name": {
             "type": "string"
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
+          "title": {
+            "type": "string"
           },
           "web_url": {
             "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
             "type": "string",
             "format": "uri"
           },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
           },
-          "public_updated_at": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
             "type": "string"
           },
-          "content_id": {
-            "$ref": "#/definitions/guid"
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
           },
           "title": {
             "type": "string"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
           }
         }
       }
     },
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "start_button_text"
-      ],
-      "properties": {
-        "start_button_text": {
-          "$ref": "#/definitions/start_button_text"
-        },
-        "body": {
-          "$ref": "#/definitions/body_html_and_govspeak"
-        },
-        "nodes": {
-          "description": "List of nodes consisting of questions and answers",
-          "type": "array",
-          "items": {
-            "description": "A node represents either a question or an answer and results in a renderable page",
-            "type": "object",
-            "additionalProperties": false,
-            "required": [
-              "kind",
-              "slug",
-              "title"
-            ],
-            "properties": {
-              "kind": {
-                "enum": [
-                  "question",
-                  "outcome"
-                ]
-              },
-              "slug": {
-                "type": "string"
-              },
-              "title": {
-                "type": "string"
-              },
-              "body": {
-                "$ref": "#/definitions/body_html_and_govspeak"
-              },
-              "options": {
-                "description": "Contains references to other nodes",
-                "type": "array",
-                "items": {
-                  "description": "An option represents a possible answer a user can select which links to another node",
-                  "type": "object",
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "slug",
-                    "next_node"
-                  ],
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "slug": {
-                      "type": "string"
-                    },
-                    "next_node": {
-                      "type": "string"
-                    }
-                  }
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
                 }
               }
             }
-          }
-        },
-        "external_related_links": {
-          "$ref": "#/definitions/external_related_links"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
+          },
+          "title": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/external_link"
-      }
-    },
-    "external_link": {
+    "image": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
+        "alt_text": {
           "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "url": {
           "type": "string",
@@ -592,17 +1074,17 @@
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -619,212 +1101,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -883,98 +1175,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -983,10 +1308,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -994,6 +1315,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -1016,79 +1341,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1100,13 +1554,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1114,61 +1562,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1176,418 +1587,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1597,9 +1601,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/simple_smart_answer/publisher_v2/links.json
+++ b/dist/formats/simple_smart_answer/publisher_v2/links.json
@@ -3,25 +3,10 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "previous_version": {
-      "type": "string"
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/guid_list"
-        },
         "mainstream_browse_pages": {
           "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/guid_list"
@@ -30,8 +15,12 @@
           "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/guid_list"
         },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
@@ -51,38 +40,50 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/guid_list"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
         }
       }
+    },
+    "previous_version": {
+      "type": "string"
     }
   },
   "definitions": {
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
     "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
       "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
     "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
         {
           "type": "string"
@@ -90,22 +91,158 @@
         {
           "type": "null"
         }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+      ]
     },
-    "external_related_links": {
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -116,20 +253,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -146,212 +616,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -410,98 +690,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -510,10 +823,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -521,6 +830,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -543,79 +856,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -627,13 +1069,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -641,61 +1077,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -703,418 +1102,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1124,9 +1116,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/simple_smart_answer/publisher_v2/schema.json
+++ b/dist/formats/simple_smart_answer/publisher_v2/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "title",
     "details",
@@ -13,12 +12,22 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "description": {
       "anyOf": [
@@ -30,84 +39,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "access_limited": {
-      "$ref": "#/definitions/access_limited"
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "change_note": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "previous_version": {
-      "type": "string"
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "links": {
-      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string",
@@ -272,124 +205,109 @@
         "written_statement"
       ]
     },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "simple_smart_answer"
       ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "start_button_text"
-      ],
-      "properties": {
-        "start_button_text": {
-          "$ref": "#/definitions/start_button_text"
-        },
-        "body": {
-          "$ref": "#/definitions/body_html_and_govspeak"
-        },
-        "nodes": {
-          "description": "List of nodes consisting of questions and answers",
-          "type": "array",
-          "items": {
-            "description": "A node represents either a question or an answer and results in a renderable page",
-            "type": "object",
-            "additionalProperties": false,
-            "required": [
-              "kind",
-              "slug",
-              "title"
-            ],
-            "properties": {
-              "kind": {
-                "enum": [
-                  "question",
-                  "outcome"
-                ]
-              },
-              "slug": {
-                "type": "string"
-              },
-              "title": {
-                "type": "string"
-              },
-              "body": {
-                "$ref": "#/definitions/body_html_and_govspeak"
-              },
-              "options": {
-                "description": "Contains references to other nodes",
-                "type": "array",
-                "items": {
-                  "description": "An option represents a possible answer a user can select which links to another node",
-                  "type": "object",
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "slug",
-                    "next_node"
-                  ],
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "slug": {
-                      "type": "string"
-                    },
-                    "next_node": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "external_related_links": {
-          "$ref": "#/definitions/external_related_links"
-        }
-      }
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policy_areas": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
     },
     "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
       "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
     "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
         {
           "type": "string"
@@ -397,22 +315,232 @@
         {
           "type": "null"
         }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+      ]
     },
-    "external_related_links": {
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "required": [
+        "start_button_text"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "body": {
+          "$ref": "#/definitions/body_html_and_govspeak"
+        },
+        "external_related_links": {
+          "$ref": "#/definitions/external_related_links"
+        },
+        "nodes": {
+          "description": "List of nodes consisting of questions and answers",
+          "type": "array",
+          "items": {
+            "description": "A node represents either a question or an answer and results in a renderable page",
+            "type": "object",
+            "required": [
+              "kind",
+              "slug",
+              "title"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "body": {
+                "$ref": "#/definitions/body_html_and_govspeak"
+              },
+              "kind": {
+                "enum": [
+                  "question",
+                  "outcome"
+                ]
+              },
+              "options": {
+                "description": "Contains references to other nodes",
+                "type": "array",
+                "items": {
+                  "description": "An option represents a possible answer a user can select which links to another node",
+                  "type": "object",
+                  "required": [
+                    "label",
+                    "slug",
+                    "next_node"
+                  ],
+                  "additionalProperties": false,
+                  "properties": {
+                    "label": {
+                      "type": "string"
+                    },
+                    "next_node": {
+                      "type": "string"
+                    },
+                    "slug": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "slug": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "start_button_text": {
+          "$ref": "#/definitions/start_button_text"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -423,20 +551,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -453,212 +914,31 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
         }
       }
     },
-    "redirect_route": {
+    "links": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
       "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
         }
       }
     },
@@ -717,98 +997,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -817,10 +1130,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -828,6 +1137,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -850,79 +1163,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -934,13 +1376,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -948,61 +1384,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1010,418 +1409,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1431,9 +1423,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/special_route/frontend/schema.json
+++ b/dist/formats/special_route/frontend/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "links",
@@ -12,12 +11,25 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -29,119 +41,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_pages": {
-          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "meets_user_needs": {
-          "description": "The user needs this piece of content meets.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "organisations": {
-          "description": "All organisations linked to this content item. This should include lead organisations.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "parent": {
-          "description": "The parent content item.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policy_areas": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "primary_publishing_organisation": {
-          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "available_translations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "children": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policies": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "document_collections": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "child_taxons": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -306,140 +207,262 @@
         "written_statement"
       ]
     },
+    "email_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "available_translations": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "policies": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policy_areas": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "primary_publishing_organisation": {
+          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "special_route"
       ]
     },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    "title": {
+      "type": "string"
     },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
-    "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
     },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
-    "frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "base_path",
-          "locale"
-        ],
-        "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
-          },
-          "document_type": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
             "type": "string"
-          },
-          "schema_name": {
-            "type": "string"
-          },
-          "public_updated_at": {
-            "type": "string"
-          },
-          "content_id": {
-            "$ref": "#/definitions/guid"
-          },
-          "title": {
-            "type": "string"
-          },
-          "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
-            "type": "string"
-          },
-          "links": {
-            "type": "object",
-            "patternProperties": {
-              "^[a-z_]+$": {
-                "$ref": "#/definitions/frontend_links"
-              }
-            }
           }
         }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
       }
     },
     "base_path_less_frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "document_type": {
-            "type": "string"
-          },
-          "schema_name": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
           "api_path": {
             "$ref": "#/definitions/absolute_path"
@@ -449,25 +472,93 @@
             "type": "string",
             "format": "uri"
           },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "public_updated_at": {
-            "type": "string"
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
+          "document_type": {
             "type": "string"
           },
           "locale": {
             "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
           }
         }
       }
@@ -481,56 +572,50 @@
         }
       }
     },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
     },
-    "external_related_links": {
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -541,20 +626,437 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "base_path",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
+            "type": "string"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "country": {
+            "$ref": "#/definitions/country"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "details": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "links": {
+            "type": "object",
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links"
+              }
+            }
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -571,212 +1073,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -835,98 +1147,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -935,10 +1280,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -946,6 +1287,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -968,79 +1313,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1052,13 +1526,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1066,61 +1534,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1128,418 +1559,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1549,9 +1573,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/special_route/notification/schema.json
+++ b/dist/formats/special_route/notification/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "content_id",
@@ -17,12 +16,25 @@
     "title",
     "update_type"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -34,60 +46,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -252,60 +212,9 @@
         "written_statement"
       ]
     },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "special_route"
-      ]
-    },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
-    },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
     "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "govuk_request_id": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
     },
     "expanded_links": {
       "type": "object",
@@ -314,112 +223,206 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "govuk_request_id": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "special_route"
+      ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
-    "frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "base_path",
-          "locale"
-        ],
-        "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
-          },
-          "document_type": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
             "type": "string"
-          },
-          "schema_name": {
-            "type": "string"
-          },
-          "public_updated_at": {
-            "type": "string"
-          },
-          "content_id": {
-            "$ref": "#/definitions/guid"
-          },
-          "title": {
-            "type": "string"
-          },
-          "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
-            "type": "string"
-          },
-          "links": {
-            "type": "object",
-            "patternProperties": {
-              "^[a-z_]+$": {
-                "$ref": "#/definitions/frontend_links"
-              }
-            }
           }
         }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
       }
     },
     "base_path_less_frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "document_type": {
-            "type": "string"
-          },
-          "schema_name": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
           "api_path": {
             "$ref": "#/definitions/absolute_path"
@@ -429,25 +432,93 @@
             "type": "string",
             "format": "uri"
           },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "public_updated_at": {
-            "type": "string"
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
+          "document_type": {
             "type": "string"
           },
           "locale": {
             "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
           }
         }
       }
@@ -461,56 +532,50 @@
         }
       }
     },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
     },
-    "external_related_links": {
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -521,20 +586,437 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "base_path",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
+            "type": "string"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "country": {
+            "$ref": "#/definitions/country"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "details": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "links": {
+            "type": "object",
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links"
+              }
+            }
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -551,212 +1033,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -815,98 +1107,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -915,10 +1240,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -926,6 +1247,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -948,79 +1273,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1032,13 +1486,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1046,61 +1494,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1108,418 +1519,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1529,9 +1533,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/special_route/publisher_v2/links.json
+++ b/dist/formats/special_route/publisher_v2/links.json
@@ -3,25 +3,10 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "previous_version": {
-      "type": "string"
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/guid_list"
-        },
         "mainstream_browse_pages": {
           "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/guid_list"
@@ -30,8 +15,12 @@
           "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/guid_list"
         },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
@@ -51,38 +40,50 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/guid_list"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
         }
       }
+    },
+    "previous_version": {
+      "type": "string"
     }
   },
   "definitions": {
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
     "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
       "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
     "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
         {
           "type": "string"
@@ -90,22 +91,158 @@
         {
           "type": "null"
         }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+      ]
     },
-    "external_related_links": {
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -116,20 +253,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -146,212 +616,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -410,98 +690,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -510,10 +823,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -521,6 +830,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -543,79 +856,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -627,13 +1069,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -641,61 +1077,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -703,418 +1102,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1124,9 +1116,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/special_route/publisher_v2/schema.json
+++ b/dist/formats/special_route/publisher_v2/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "title",
     "details",
@@ -13,12 +12,22 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "description": {
       "anyOf": [
@@ -30,84 +39,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "access_limited": {
-      "$ref": "#/definitions/access_limited"
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "change_note": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "previous_version": {
-      "type": "string"
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "links": {
-      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string",
@@ -272,56 +205,109 @@
         "written_statement"
       ]
     },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "special_route"
       ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-      }
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policy_areas": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
     },
     "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
       "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
     "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
         {
           "type": "string"
@@ -329,22 +315,164 @@
         {
           "type": "null"
         }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+      ]
     },
-    "external_related_links": {
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -355,20 +483,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -385,212 +846,31 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
         }
       }
     },
-    "redirect_route": {
+    "links": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
       "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
         }
       }
     },
@@ -649,98 +929,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -749,10 +1062,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -760,6 +1069,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -782,79 +1095,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -866,13 +1308,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -880,61 +1316,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -942,418 +1341,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1363,9 +1355,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/specialist_document/frontend/schema.json
+++ b/dist/formats/specialist_document/frontend/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "links",
@@ -12,12 +11,25 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -29,124 +41,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_pages": {
-          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "meets_user_needs": {
-          "description": "The user needs this piece of content meets.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "organisations": {
-          "description": "All organisations linked to this content item. This should include lead organisations.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "parent": {
-          "description": "The parent content item.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policy_areas": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "primary_publishing_organisation": {
-          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "finder": {
-          "description": "The finder for this specialist document.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "available_translations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "children": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policies": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "document_collections": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "child_taxons": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -311,1223 +207,249 @@
         "written_statement"
       ]
     },
+    "email_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "available_translations": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "finder": {
+          "description": "The finder for this specialist document.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "policies": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policy_areas": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "primary_publishing_organisation": {
+          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "specialist_document"
       ]
     },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    "title": {
+      "type": "string"
     },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
-    "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
     },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
-    "frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "base_path",
-          "locale"
-        ],
-        "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
-          },
-          "document_type": {
-            "type": "string"
-          },
-          "schema_name": {
-            "type": "string"
-          },
-          "public_updated_at": {
-            "type": "string"
-          },
-          "content_id": {
-            "$ref": "#/definitions/guid"
-          },
-          "title": {
-            "type": "string"
-          },
-          "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
-            "type": "string"
-          },
-          "links": {
-            "type": "object",
-            "patternProperties": {
-              "^[a-z_]+$": {
-                "$ref": "#/definitions/frontend_links"
-              }
-            }
-          }
-        }
-      }
-    },
-    "base_path_less_frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "locale"
-        ],
-        "properties": {
-          "document_type": {
-            "type": "string"
-          },
-          "schema_name": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "public_updated_at": {
-            "type": "string"
-          },
-          "content_id": {
-            "$ref": "#/definitions/guid"
-          },
-          "title": {
-            "type": "string"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          }
-        }
-      }
-    },
-    "details": {
+    "aaib_report_metadata": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "body",
-        "metadata",
-        "change_history"
-      ],
       "properties": {
-        "body": {
-          "$ref": "#/definitions/body_html_and_govspeak"
+        "aircraft_category": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "commercial-fixed-wing",
+              "commercial-rotorcraft",
+              "general-aviation-fixed-wing",
+              "general-aviation-rotorcraft",
+              "sport-aviation-and-balloons"
+            ]
+          }
         },
-        "attachments": {
-          "$ref": "#/definitions/asset_link_list"
+        "aircraft_type": {
+          "type": "string"
         },
-        "metadata": {
-          "$ref": "#/definitions/any_metadata"
+        "bulk_published": {
+          "type": "boolean"
         },
-        "max_cache_time": {
-          "$ref": "#/definitions/max_cache_time"
+        "date_of_occurrence": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
         },
-        "headers": {
-          "$ref": "#/definitions/nested_headers"
+        "location": {
+          "type": "string"
         },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
+        "registration": {
+          "type": "string"
         },
-        "temporary_update_type": {
-          "type": "boolean",
-          "description": "Indicates that the user should choose a new update type on the next save."
+        "report_type": {
+          "type": "string",
+          "enum": [
+            "annual-safety-report",
+            "correspondence-investigation",
+            "field-investigation",
+            "pre-1997-monthly-report",
+            "foreign-report",
+            "formal-report",
+            "special-bulletin",
+            "safety-study"
+          ]
         }
       }
     },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
     "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
       "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
     "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/external_link"
-      }
-    },
-    "external_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "title",
-        "url"
-      ],
-      "properties": {
-        "title": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        }
-      }
-    },
-    "internal_link_without_guid": {
-      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "title",
-        "path"
-      ],
-      "properties": {
-        "title": {
-          "type": "string"
-        },
-        "path": {
-          "$ref": "#/definitions/absolute_fullpath"
-        }
-      }
-    },
-    "internal_or_external_link": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/external_link"
-        },
-        {
-          "$ref": "#/definitions/internal_link_without_guid"
-        },
-        {
-          "$ref": "#/definitions/guid"
-        }
-      ]
-    },
-    "government": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "title",
-        "slug",
-        "current"
-      ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url"
-      ],
-      "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
-          "type": "string"
-        },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
-          "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
-        }
-      }
-    },
-    "locale": {
-      "type": "string",
-      "enum": [
-        "ar",
-        "az",
-        "be",
-        "bg",
-        "bn",
-        "cs",
-        "cy",
-        "de",
-        "dr",
-        "el",
-        "en",
-        "es",
-        "es-419",
-        "et",
-        "fa",
-        "fr",
-        "he",
-        "hi",
-        "hu",
-        "hy",
-        "id",
-        "it",
-        "ja",
-        "ka",
-        "ko",
-        "lt",
-        "lv",
-        "ms",
-        "pl",
-        "ps",
-        "pt",
-        "ro",
-        "ru",
-        "si",
-        "sk",
-        "so",
-        "sq",
-        "sr",
-        "sw",
-        "ta",
-        "th",
-        "tk",
-        "tr",
-        "uk",
-        "ur",
-        "uz",
-        "vi",
-        "zh",
-        "zh-hk",
-        "zh-tw"
-      ]
-    },
-    "multiple_content_types": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "content_type",
-          "content"
-        ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
-          }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "nation_applicability": {
-      "description": "An object specifying the applicability of a particular nation.",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
-        "alternative_url": {
-          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
-          "type": "string"
-        },
-        "applicable": {
-          "description": "Whether the content applies to this nation or not.",
-          "type": "boolean"
-        }
-      }
-    },
-    "national_applicability": {
-      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "england": {
-          "$ref": "#/definitions/nation_applicability"
-        },
-        "northern_ireland": {
-          "$ref": "#/definitions/nation_applicability"
-        },
-        "scotland": {
-          "$ref": "#/definitions/nation_applicability"
-        },
-        "wales": {
-          "$ref": "#/definitions/nation_applicability"
-        }
-      }
-    },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
-        }
-      }
-    },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "public_updated_at": {
-      "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "tags": {
-      "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
-      "additionalProperties": false,
-      "properties": {
-        "browse_pages": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "primary_topic": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
-    },
-    "topic_groups": {
-      "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
-            "description": "DEPRECATED",
-            "type": "string"
-          },
-          "contents": {
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/absolute_path"
-            }
-          },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
-          },
-          "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
         {
           "type": "string"
@@ -1536,51 +458,6 @@
           "type": "null"
         }
       ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "will_continue_on": {
-      "description": "Description of the website the adjoining external link will be taking the user to",
-      "type": "string"
-    },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
     },
     "any_metadata": {
       "type": "object",
@@ -1641,79 +518,40 @@
         }
       ]
     },
-    "nested_headers": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "text",
-          "level",
-          "id"
-        ],
-        "properties": {
-          "text": {
-            "type": "string"
-          },
-          "level": {
-            "type": "integer"
-          },
-          "id": {
-            "type": "string"
-          },
-          "headers": {
-            "$ref": "#/definitions/nested_headers"
-          }
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
     },
-    "aaib_report_metadata": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "bulk_published": {
-          "type": "boolean"
-        },
-        "aircraft_category": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "enum": [
-              "commercial-fixed-wing",
-              "commercial-rotorcraft",
-              "general-aviation-fixed-wing",
-              "general-aviation-rotorcraft",
-              "sport-aviation-and-balloons"
-            ]
-          }
-        },
-        "report_type": {
-          "type": "string",
-          "enum": [
-            "annual-safety-report",
-            "correspondence-investigation",
-            "field-investigation",
-            "pre-1997-monthly-report",
-            "foreign-report",
-            "formal-report",
-            "special-bulletin",
-            "safety-study"
-          ]
-        },
-        "date_of_occurrence": {
-          "type": "string",
-          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
-        },
-        "aircraft_type": {
-          "type": "string"
-        },
-        "location": {
-          "type": "string"
-        },
-        "registration": {
-          "type": "string"
-        }
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
       }
     },
     "asylum_support_decision_metadata": {
@@ -1723,19 +561,8 @@
         "bulk_published": {
           "type": "boolean"
         },
-        "tribunal_decision_judges": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "tribunal_decision_category": {
-          "type": "string",
-          "enum": [
-            "section-4-1-support-for-persons-who-are-neither-an-asylum-seeker-nor-a-failed-asylum-seeker",
-            "section-4-2-support-for-failed-asylum-seekers",
-            "section-95-support-for-asylum-seekers"
-          ]
+        "hidden_indexable_content": {
+          "type": "string"
         },
         "tribunal_decision_categories": {
           "type": "array",
@@ -1748,10 +575,19 @@
             ]
           }
         },
-        "tribunal_decision_sub_category": {
-          "type": "string"
+        "tribunal_decision_category": {
+          "type": "string",
+          "enum": [
+            "section-4-1-support-for-persons-who-are-neither-an-asylum-seeker-nor-a-failed-asylum-seeker",
+            "section-4-2-support-for-failed-asylum-seekers",
+            "section-95-support-for-asylum-seekers"
+          ]
         },
-        "tribunal_decision_sub_categories": {
+        "tribunal_decision_decision_date": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        },
+        "tribunal_decision_judges": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1767,14 +603,87 @@
         "tribunal_decision_reference_number": {
           "type": "string"
         },
-        "tribunal_decision_decision_date": {
-          "type": "string",
-          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        "tribunal_decision_sub_categories": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
-        "hidden_indexable_content": {
+        "tribunal_decision_sub_category": {
           "type": "string"
         }
       }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "base_path_less_frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
     },
     "business_finance_support_scheme_metadata": {
       "type": "object",
@@ -1859,12 +768,47 @@
         }
       }
     },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "cma_case_metadata": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
         "bulk_published": {
           "type": "boolean"
+        },
+        "case_state": {
+          "type": "string",
+          "enum": [
+            "open",
+            "closed"
+          ]
         },
         "case_type": {
           "type": "string",
@@ -1879,12 +823,9 @@
             "review-of-orders-and-undertakings"
           ]
         },
-        "case_state": {
+        "closed_date": {
           "type": "string",
-          "enum": [
-            "open",
-            "closed"
-          ]
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
         },
         "market_sector": {
           "type": "array",
@@ -1923,6 +864,10 @@
             ]
           }
         },
+        "opened_date": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        },
         "outcome_type": {
           "type": "string",
           "enum": [
@@ -1956,14 +901,129 @@
             "consumer-enforcement-changes-to-business-practices-agreed",
             "regulatory-references-and-appeals-final-determination"
           ]
+        }
+      }
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
         },
-        "opened_date": {
-          "type": "string",
-          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        "slug": {
+          "type": "string"
         },
-        "closed_date": {
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "countryside_stewardship_grant_metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "bulk_published": {
+          "type": "boolean"
+        },
+        "funding_amount": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "up-to-100",
+              "101-to-200",
+              "201-to-300",
+              "301-to-400",
+              "401-to-500",
+              "more-than-500",
+              "up-to-50-actual-costs",
+              "more-than-50-actual-costs"
+            ]
+          }
+        },
+        "grant_type": {
           "type": "string",
-          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+          "enum": [
+            "option",
+            "capital-item",
+            "supplement"
+          ]
+        },
+        "land_use": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "arable-land",
+              "boundaries",
+              "coast",
+              "educational-access",
+              "flood-risk",
+              "grassland",
+              "historic-environment",
+              "livestock-management",
+              "organic-land",
+              "priority-habitats",
+              "trees-non-woodland",
+              "uplands",
+              "vegetation-control",
+              "water-quality",
+              "wildlife-package",
+              "woodland"
+            ]
+          }
+        },
+        "tiers_or_standalone_items": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "higher-tier",
+              "mid-tier",
+              "standalone-capital-items"
+            ]
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "required": [
+        "body",
+        "metadata",
+        "change_history"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "attachments": {
+          "$ref": "#/definitions/asset_link_list"
+        },
+        "body": {
+          "$ref": "#/definitions/body_html_and_govspeak"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "headers": {
+          "$ref": "#/definitions/nested_headers"
+        },
+        "max_cache_time": {
+          "$ref": "#/definitions/max_cache_time"
+        },
+        "metadata": {
+          "$ref": "#/definitions/any_metadata"
+        },
+        "temporary_update_type": {
+          "description": "Indicates that the user should choose a new update type on the next save.",
+          "type": "boolean"
         }
       }
     },
@@ -1973,13 +1033,6 @@
       "properties": {
         "bulk_published": {
           "type": "boolean"
-        },
-        "dfid_review_status": {
-          "type": "string",
-          "enum": [
-            "unreviewed",
-            "peer_reviewed"
-          ]
         },
         "country": {
           "type": "array",
@@ -2191,30 +1244,6 @@
             "type": "string"
           }
         },
-        "first_published_at": {
-          "type": "string",
-          "pattern": "^[1-9][0-9]{3}[-/](0[1-9]|1[0-2])[-/](0[1-9]|[12][0-9]|3[0-1])$"
-        },
-        "dfid_theme": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "enum": [
-              "agriculture",
-              "climate_and_environment",
-              "economic_growth",
-              "education",
-              "food_and_nutrition",
-              "governance_and_conflict",
-              "health",
-              "humanitarian_disasters_and_emergencies",
-              "infrastructure",
-              "research_communication_and_uptake",
-              "social_change",
-              "water_and_sanitation"
-            ]
-          }
-        },
         "dfid_document_type": {
           "type": "string",
           "items": {
@@ -2244,74 +1273,37 @@
               "working_paper"
             ]
           }
-        }
-      }
-    },
-    "countryside_stewardship_grant_metadata": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "bulk_published": {
-          "type": "boolean"
         },
-        "grant_type": {
+        "dfid_review_status": {
           "type": "string",
           "enum": [
-            "option",
-            "capital-item",
-            "supplement"
+            "unreviewed",
+            "peer_reviewed"
           ]
         },
-        "land_use": {
+        "dfid_theme": {
           "type": "array",
           "items": {
             "type": "string",
             "enum": [
-              "arable-land",
-              "boundaries",
-              "coast",
-              "educational-access",
-              "flood-risk",
-              "grassland",
-              "historic-environment",
-              "livestock-management",
-              "organic-land",
-              "priority-habitats",
-              "trees-non-woodland",
-              "uplands",
-              "vegetation-control",
-              "water-quality",
-              "wildlife-package",
-              "woodland"
+              "agriculture",
+              "climate_and_environment",
+              "economic_growth",
+              "education",
+              "food_and_nutrition",
+              "governance_and_conflict",
+              "health",
+              "humanitarian_disasters_and_emergencies",
+              "infrastructure",
+              "research_communication_and_uptake",
+              "social_change",
+              "water_and_sanitation"
             ]
           }
         },
-        "tiers_or_standalone_items": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "enum": [
-              "higher-tier",
-              "mid-tier",
-              "standalone-capital-items"
-            ]
-          }
-        },
-        "funding_amount": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "enum": [
-              "up-to-100",
-              "101-to-200",
-              "201-to-300",
-              "301-to-400",
-              "401-to-500",
-              "more-than-500",
-              "up-to-50-actual-costs",
-              "more-than-50-actual-costs"
-            ]
-          }
+        "first_published_at": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}[-/](0[1-9]|1[0-2])[-/](0[1-9]|[12][0-9]|3[0-1])$"
         }
       }
     },
@@ -2321,6 +1313,10 @@
       "properties": {
         "bulk_published": {
           "type": "boolean"
+        },
+        "first_published_at": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
         },
         "therapeutic_area": {
           "type": "array",
@@ -2352,11 +1348,44 @@
               "urology-nephrology"
             ]
           }
-        },
-        "first_published_at": {
-          "type": "string",
-          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
         }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "employment_appeal_tribunal_decision_metadata": {
@@ -2375,11 +1404,9 @@
             "type": "string"
           }
         },
-        "tribunal_decision_sub_categories": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+        "tribunal_decision_decision_date": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
         },
         "tribunal_decision_landmark": {
           "type": "string",
@@ -2388,9 +1415,11 @@
             "not-landmark"
           ]
         },
-        "tribunal_decision_decision_date": {
-          "type": "string",
-          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        "tribunal_decision_sub_categories": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       }
     },
@@ -2401,12 +1430,8 @@
         "bulk_published": {
           "type": "boolean"
         },
-        "tribunal_decision_country": {
-          "type": "string",
-          "enum": [
-            "england-and-wales",
-            "scotland"
-          ]
+        "hidden_indexable_content": {
+          "type": "string"
         },
         "tribunal_decision_categories": {
           "type": "array",
@@ -2414,12 +1439,16 @@
             "type": "string"
           }
         },
+        "tribunal_decision_country": {
+          "type": "string",
+          "enum": [
+            "england-and-wales",
+            "scotland"
+          ]
+        },
         "tribunal_decision_decision_date": {
           "type": "string",
           "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
-        },
-        "hidden_indexable_content": {
-          "type": "string"
         }
       }
     },
@@ -2429,6 +1458,10 @@
       "properties": {
         "bulk_published": {
           "type": "boolean"
+        },
+        "closing_date": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
         },
         "fund_state": {
           "type": "string",
@@ -2458,6 +1491,17 @@
             ]
           }
         },
+        "funding_source": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "european-social-fund",
+              "european-regional-development-fund",
+              "european-agricoltural-fund-for-rural"
+            ]
+          }
+        },
         "location": {
           "type": "array",
           "items": {
@@ -2474,23 +1518,472 @@
               "london"
             ]
           }
-        },
-        "funding_source": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "enum": [
-              "european-social-fund",
-              "european-regional-development-fund",
-              "european-agricoltural-fund-for-rural"
-            ]
-          }
-        },
-        "closing_date": {
-          "type": "string",
-          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
         }
       }
+    },
+    "external_link": {
+      "type": "object",
+      "required": [
+        "title",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "base_path",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
+            "type": "string"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "country": {
+            "$ref": "#/definitions/country"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "details": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "links": {
+            "type": "object",
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links"
+              }
+            }
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "required": [
+        "title",
+        "path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "international_development_fund_metadata": {
       "type": "object",
@@ -2498,6 +1991,45 @@
       "properties": {
         "bulk_published": {
           "type": "boolean"
+        },
+        "development_sector": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "agriculture",
+              "climate-change",
+              "disabilities",
+              "education",
+              "empowerment-and-accountability",
+              "environment",
+              "girls-and-women",
+              "health",
+              "humanitarian-emergencies-disasters",
+              "livelihoods",
+              "peace-and-access-to-justice",
+              "private-sector-business",
+              "technology",
+              "trade",
+              "water-and-sanitation"
+            ]
+          }
+        },
+        "eligible_entities": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "non-governmental-organisations",
+              "uk-based-non-profit-organisations",
+              "uk-based-small-and-diaspora-organisations",
+              "companies",
+              "local-government",
+              "educational-institutions",
+              "individuals",
+              "humanitarian-relief-organisations"
+            ]
+          }
         },
         "fund_state": {
           "type": "string",
@@ -2542,45 +2074,6 @@
             ]
           }
         },
-        "development_sector": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "enum": [
-              "agriculture",
-              "climate-change",
-              "disabilities",
-              "education",
-              "empowerment-and-accountability",
-              "environment",
-              "girls-and-women",
-              "health",
-              "humanitarian-emergencies-disasters",
-              "livelihoods",
-              "peace-and-access-to-justice",
-              "private-sector-business",
-              "technology",
-              "trade",
-              "water-and-sanitation"
-            ]
-          }
-        },
-        "eligible_entities": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "enum": [
-              "non-governmental-organisations",
-              "uk-based-non-profit-organisations",
-              "uk-based-small-and-diaspora-organisations",
-              "companies",
-              "local-government",
-              "educational-institutions",
-              "individuals",
-              "humanitarian-relief-organisations"
-            ]
-          }
-        },
         "value_of_funding": {
           "type": "array",
           "items": {
@@ -2595,12 +2088,100 @@
         }
       }
     },
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
+      "type": "object",
+      "required": [
+        "label",
+        "value"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "A human readable label",
+          "type": "string"
+        },
+        "value": {
+          "description": "A value to use for form controls",
+          "type": "string"
+        }
+      }
+    },
+    "locale": {
+      "type": "string",
+      "enum": [
+        "ar",
+        "az",
+        "be",
+        "bg",
+        "bn",
+        "cs",
+        "cy",
+        "de",
+        "dr",
+        "el",
+        "en",
+        "es",
+        "es-419",
+        "et",
+        "fa",
+        "fr",
+        "he",
+        "hi",
+        "hu",
+        "hy",
+        "id",
+        "it",
+        "ja",
+        "ka",
+        "ko",
+        "lt",
+        "lv",
+        "ms",
+        "pl",
+        "ps",
+        "pt",
+        "ro",
+        "ru",
+        "si",
+        "sk",
+        "so",
+        "sq",
+        "sr",
+        "sw",
+        "ta",
+        "th",
+        "tk",
+        "tr",
+        "uk",
+        "ur",
+        "uz",
+        "vi",
+        "zh",
+        "zh-hk",
+        "zh-tw"
+      ]
+    },
     "maib_report_metadata": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
         "bulk_published": {
           "type": "boolean"
+        },
+        "date_of_occurrence": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        },
+        "report_type": {
+          "type": "string",
+          "enum": [
+            "investigation-report",
+            "safety-bulletin",
+            "completed-preliminary-examination",
+            "overseas-report",
+            "discontinued-investigation"
+          ]
         },
         "vessel_type": {
           "type": "array",
@@ -2614,30 +2195,122 @@
               "recreational-craft-power"
             ]
           }
-        },
-        "report_type": {
-          "type": "string",
-          "enum": [
-            "investigation-report",
-            "safety-bulletin",
-            "completed-preliminary-examination",
-            "overseas-report",
-            "discontinued-investigation"
-          ]
-        },
-        "date_of_occurrence": {
-          "type": "string",
-          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
         }
       }
+    },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
     },
     "medical_safety_alert_metadata": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "bulk_published": {
-          "type": "boolean"
-        },
         "alert_type": {
           "type": "string",
           "enum": [
@@ -2646,6 +2319,13 @@
             "field-safety-notices",
             "company-led-drugs"
           ]
+        },
+        "bulk_published": {
+          "type": "boolean"
+        },
+        "issued_date": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
         },
         "medical_specialism": {
           "type": "array",
@@ -2676,12 +2356,165 @@
               "vascular-cardiac-surgery"
             ]
           }
-        },
-        "issued_date": {
-          "type": "string",
-          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
         }
       }
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
+    },
+    "nested_headers": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "text",
+          "level",
+          "id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "headers": {
+            "$ref": "#/definitions/nested_headers"
+          },
+          "id": {
+            "type": "string"
+          },
+          "level": {
+            "type": "integer"
+          },
+          "text": {
+            "type": "string"
+          }
+        }
+      },
+      "minItems": 1
+    },
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
+    },
+    "public_updated_at": {
+      "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
     },
     "raib_report_metadata": {
       "type": "object",
@@ -2689,6 +2522,10 @@
       "properties": {
         "bulk_published": {
           "type": "boolean"
+        },
+        "date_of_occurrence": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
         },
         "railway_type": {
           "type": "array",
@@ -2711,10 +2548,113 @@
             "discontinuation-report",
             "safety-digest"
           ]
+        }
+      }
+    },
+    "redirect_route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
         },
-        "date_of_occurrence": {
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
           "type": "string",
-          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
         }
       }
     },
@@ -2722,12 +2662,53 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "bulk_published": {
-          "type": "boolean"
-        },
         "assessment_date": {
           "type": "string",
           "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        },
+        "bulk_published": {
+          "type": "boolean"
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       }
     },
@@ -2737,6 +2718,9 @@
       "properties": {
         "bulk_published": {
           "type": "boolean"
+        },
+        "hidden_indexable_content": {
+          "type": "string"
         },
         "tribunal_decision_category": {
           "type": "string",
@@ -2752,9 +2736,41 @@
         "tribunal_decision_decision_date": {
           "type": "string",
           "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
-        },
-        "hidden_indexable_content": {
-          "type": "string"
+        }
+      }
+    },
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
+      "type": "string"
+    },
+    "topic_groups": {
+      "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "description": "DEPRECATED",
+            "$ref": "#/definitions/guid_list"
+          },
+          "contents": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/absolute_path"
+            }
+          },
+          "description": {
+            "description": "DEPRECATED",
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
         }
       }
     },
@@ -2765,13 +2781,20 @@
         "bulk_published": {
           "type": "boolean"
         },
-        "tribunal_decision_judges": {
+        "hidden_indexable_content": {
+          "type": "string"
+        },
+        "tribunal_decision_categories": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "tribunal_decision_categories": {
+        "tribunal_decision_decision_date": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        },
+        "tribunal_decision_judges": {
           "type": "array",
           "items": {
             "type": "string"
@@ -2782,13 +2805,6 @@
           "items": {
             "type": "string"
           }
-        },
-        "tribunal_decision_decision_date": {
-          "type": "string",
-          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
-        },
-        "hidden_indexable_content": {
-          "type": "string"
         }
       }
     },
@@ -2796,6 +2812,18 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "alert_issue_date": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        },
+        "build_end_date": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        },
+        "build_start_date": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        },
         "bulk_published": {
           "type": "boolean"
         },
@@ -2805,6 +2833,9 @@
             "recall",
             "non_urgent_fault"
           ]
+        },
+        "faulty_item_model": {
+          "type": "string"
         },
         "faulty_item_type": {
           "type": "string",
@@ -2836,23 +2867,24 @@
             "other-manufacturer"
           ]
         },
-        "faulty_item_model": {
-          "type": "string"
-        },
         "serial_number": {
           "type": "string"
+        }
+      }
+    },
+    "will_continue_on": {
+      "description": "Description of the website the adjoining external link will be taking the user to",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
         },
-        "alert_issue_date": {
-          "type": "string",
-          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
-        },
-        "build_start_date": {
-          "type": "string",
-          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
-        },
-        "build_end_date": {
-          "type": "string",
-          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        "withdrawn_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/specialist_document/notification/schema.json
+++ b/dist/formats/specialist_document/notification/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "content_id",
@@ -17,12 +16,25 @@
     "title",
     "update_type"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -34,60 +46,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -252,60 +212,9 @@
         "written_statement"
       ]
     },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "specialist_document"
-      ]
-    },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
-    },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
     "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "govuk_request_id": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
     },
     "expanded_links": {
       "type": "object",
@@ -314,1234 +223,179 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
-    }
-  },
-  "definitions": {
-    "frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "base_path",
-          "locale"
-        ],
-        "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
-          },
-          "document_type": {
-            "type": "string"
-          },
-          "schema_name": {
-            "type": "string"
-          },
-          "public_updated_at": {
-            "type": "string"
-          },
-          "content_id": {
-            "$ref": "#/definitions/guid"
-          },
-          "title": {
-            "type": "string"
-          },
-          "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
-            "type": "string"
-          },
-          "links": {
-            "type": "object",
-            "patternProperties": {
-              "^[a-z_]+$": {
-                "$ref": "#/definitions/frontend_links"
-              }
-            }
-          }
-        }
-      }
     },
-    "base_path_less_frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "locale"
-        ],
-        "properties": {
-          "document_type": {
-            "type": "string"
-          },
-          "schema_name": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "public_updated_at": {
-            "type": "string"
-          },
-          "content_id": {
-            "$ref": "#/definitions/guid"
-          },
-          "title": {
-            "type": "string"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          }
-        }
-      }
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
     },
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "body",
-        "metadata",
-        "change_history"
-      ],
-      "properties": {
-        "body": {
-          "$ref": "#/definitions/body_html_and_govspeak"
-        },
-        "attachments": {
-          "$ref": "#/definitions/asset_link_list"
-        },
-        "metadata": {
-          "$ref": "#/definitions/any_metadata"
-        },
-        "max_cache_time": {
-          "$ref": "#/definitions/max_cache_time"
-        },
-        "headers": {
-          "$ref": "#/definitions/nested_headers"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        },
-        "temporary_update_type": {
-          "type": "boolean",
-          "description": "Indicates that the user should choose a new update type on the next save."
-        }
-      }
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
     },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/external_link"
-      }
-    },
-    "external_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "title",
-        "url"
-      ],
-      "properties": {
-        "title": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        }
-      }
-    },
-    "internal_link_without_guid": {
-      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "title",
-        "path"
-      ],
-      "properties": {
-        "title": {
-          "type": "string"
-        },
-        "path": {
-          "$ref": "#/definitions/absolute_fullpath"
-        }
-      }
-    },
-    "internal_or_external_link": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/external_link"
-        },
-        {
-          "$ref": "#/definitions/internal_link_without_guid"
-        },
-        {
-          "$ref": "#/definitions/guid"
-        }
-      ]
-    },
-    "government": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "title",
-        "slug",
-        "current"
-      ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url"
-      ],
-      "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
-          "type": "string"
-        },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
-          "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
-        }
-      }
-    },
-    "locale": {
-      "type": "string",
-      "enum": [
-        "ar",
-        "az",
-        "be",
-        "bg",
-        "bn",
-        "cs",
-        "cy",
-        "de",
-        "dr",
-        "el",
-        "en",
-        "es",
-        "es-419",
-        "et",
-        "fa",
-        "fr",
-        "he",
-        "hi",
-        "hu",
-        "hy",
-        "id",
-        "it",
-        "ja",
-        "ka",
-        "ko",
-        "lt",
-        "lv",
-        "ms",
-        "pl",
-        "ps",
-        "pt",
-        "ro",
-        "ru",
-        "si",
-        "sk",
-        "so",
-        "sq",
-        "sr",
-        "sw",
-        "ta",
-        "th",
-        "tk",
-        "tr",
-        "uk",
-        "ur",
-        "uz",
-        "vi",
-        "zh",
-        "zh-hk",
-        "zh-tw"
-      ]
-    },
-    "multiple_content_types": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "content_type",
-          "content"
-        ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
+    "govuk_request_id": {
       "type": [
         "string",
         "null"
       ]
     },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
-          }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
     },
-    "withdrawn_notice": {
+    "links": {
       "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
         }
       }
     },
-    "nation_applicability": {
-      "description": "An object specifying the applicability of a particular nation.",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
-        "alternative_url": {
-          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
-          "type": "string"
-        },
-        "applicable": {
-          "description": "Whether the content applies to this nation or not.",
-          "type": "boolean"
-        }
-      }
+    "locale": {
+      "$ref": "#/definitions/locale"
     },
-    "national_applicability": {
-      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "england": {
-          "$ref": "#/definitions/nation_applicability"
-        },
-        "northern_ireland": {
-          "$ref": "#/definitions/nation_applicability"
-        },
-        "scotland": {
-          "$ref": "#/definitions/nation_applicability"
-        },
-        "wales": {
-          "$ref": "#/definitions/nation_applicability"
-        }
-      }
-    },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
-        }
-      }
-    },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
       "type": "string"
     },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
+    "need_ids": {
       "type": "array",
       "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
         "type": "string"
       }
     },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
       "type": "string",
-      "format": "date-time"
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
     },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "previous_version": {
+      "type": "string"
     },
     "public_updated_at": {
-      "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "specialist_document"
+      ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "updated_at": {
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
-      "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
-      "additionalProperties": false,
-      "properties": {
-        "browse_pages": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "primary_topic": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
       "type": "string"
     },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
-    },
-    "topic_groups": {
-      "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
-            "description": "DEPRECATED",
-            "type": "string"
-          },
-          "contents": {
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/absolute_path"
-            }
-          },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    }
+  },
+  "definitions": {
+    "aaib_report_metadata": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
+        "aircraft_category": {
           "type": "array",
           "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
-          },
-          "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
             "type": "string",
             "enum": [
-              "text",
-              "date",
-              "topical"
+              "commercial-fixed-wing",
+              "commercial-rotorcraft",
+              "general-aviation-fixed-wing",
+              "general-aviation-rotorcraft",
+              "sport-aviation-and-balloons"
             ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
           }
+        },
+        "aircraft_type": {
+          "type": "string"
+        },
+        "bulk_published": {
+          "type": "boolean"
+        },
+        "date_of_occurrence": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        },
+        "location": {
+          "type": "string"
+        },
+        "registration": {
+          "type": "string"
+        },
+        "report_type": {
+          "type": "string",
+          "enum": [
+            "annual-safety-report",
+            "correspondence-investigation",
+            "field-investigation",
+            "pre-1997-monthly-report",
+            "foreign-report",
+            "formal-report",
+            "special-bulletin",
+            "safety-study"
+          ]
         }
       }
     },
-    "finder_show_summaries": {
-      "type": "boolean"
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
     },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
+    "access_limited": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
       "properties": {
-        "name": {
-          "type": "string"
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
         },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
+        "users": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1549,13 +403,16 @@
         }
       }
     },
-    "will_continue_on": {
-      "description": "Description of the website the adjoining external link will be taking the user to",
-      "type": "string"
-    },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "any_metadata": {
       "type": "object",
@@ -1616,79 +473,40 @@
         }
       ]
     },
-    "nested_headers": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "text",
-          "level",
-          "id"
-        ],
-        "properties": {
-          "text": {
-            "type": "string"
-          },
-          "level": {
-            "type": "integer"
-          },
-          "id": {
-            "type": "string"
-          },
-          "headers": {
-            "$ref": "#/definitions/nested_headers"
-          }
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
     },
-    "aaib_report_metadata": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "bulk_published": {
-          "type": "boolean"
-        },
-        "aircraft_category": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "enum": [
-              "commercial-fixed-wing",
-              "commercial-rotorcraft",
-              "general-aviation-fixed-wing",
-              "general-aviation-rotorcraft",
-              "sport-aviation-and-balloons"
-            ]
-          }
-        },
-        "report_type": {
-          "type": "string",
-          "enum": [
-            "annual-safety-report",
-            "correspondence-investigation",
-            "field-investigation",
-            "pre-1997-monthly-report",
-            "foreign-report",
-            "formal-report",
-            "special-bulletin",
-            "safety-study"
-          ]
-        },
-        "date_of_occurrence": {
-          "type": "string",
-          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
-        },
-        "aircraft_type": {
-          "type": "string"
-        },
-        "location": {
-          "type": "string"
-        },
-        "registration": {
-          "type": "string"
-        }
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
       }
     },
     "asylum_support_decision_metadata": {
@@ -1698,19 +516,8 @@
         "bulk_published": {
           "type": "boolean"
         },
-        "tribunal_decision_judges": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "tribunal_decision_category": {
-          "type": "string",
-          "enum": [
-            "section-4-1-support-for-persons-who-are-neither-an-asylum-seeker-nor-a-failed-asylum-seeker",
-            "section-4-2-support-for-failed-asylum-seekers",
-            "section-95-support-for-asylum-seekers"
-          ]
+        "hidden_indexable_content": {
+          "type": "string"
         },
         "tribunal_decision_categories": {
           "type": "array",
@@ -1723,10 +530,19 @@
             ]
           }
         },
-        "tribunal_decision_sub_category": {
-          "type": "string"
+        "tribunal_decision_category": {
+          "type": "string",
+          "enum": [
+            "section-4-1-support-for-persons-who-are-neither-an-asylum-seeker-nor-a-failed-asylum-seeker",
+            "section-4-2-support-for-failed-asylum-seekers",
+            "section-95-support-for-asylum-seekers"
+          ]
         },
-        "tribunal_decision_sub_categories": {
+        "tribunal_decision_decision_date": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        },
+        "tribunal_decision_judges": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1742,14 +558,87 @@
         "tribunal_decision_reference_number": {
           "type": "string"
         },
-        "tribunal_decision_decision_date": {
-          "type": "string",
-          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        "tribunal_decision_sub_categories": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
-        "hidden_indexable_content": {
+        "tribunal_decision_sub_category": {
           "type": "string"
         }
       }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "base_path_less_frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
     },
     "business_finance_support_scheme_metadata": {
       "type": "object",
@@ -1834,12 +723,47 @@
         }
       }
     },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "cma_case_metadata": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
         "bulk_published": {
           "type": "boolean"
+        },
+        "case_state": {
+          "type": "string",
+          "enum": [
+            "open",
+            "closed"
+          ]
         },
         "case_type": {
           "type": "string",
@@ -1854,12 +778,9 @@
             "review-of-orders-and-undertakings"
           ]
         },
-        "case_state": {
+        "closed_date": {
           "type": "string",
-          "enum": [
-            "open",
-            "closed"
-          ]
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
         },
         "market_sector": {
           "type": "array",
@@ -1898,6 +819,10 @@
             ]
           }
         },
+        "opened_date": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        },
         "outcome_type": {
           "type": "string",
           "enum": [
@@ -1931,14 +856,129 @@
             "consumer-enforcement-changes-to-business-practices-agreed",
             "regulatory-references-and-appeals-final-determination"
           ]
+        }
+      }
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
         },
-        "opened_date": {
-          "type": "string",
-          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        "slug": {
+          "type": "string"
         },
-        "closed_date": {
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "countryside_stewardship_grant_metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "bulk_published": {
+          "type": "boolean"
+        },
+        "funding_amount": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "up-to-100",
+              "101-to-200",
+              "201-to-300",
+              "301-to-400",
+              "401-to-500",
+              "more-than-500",
+              "up-to-50-actual-costs",
+              "more-than-50-actual-costs"
+            ]
+          }
+        },
+        "grant_type": {
           "type": "string",
-          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+          "enum": [
+            "option",
+            "capital-item",
+            "supplement"
+          ]
+        },
+        "land_use": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "arable-land",
+              "boundaries",
+              "coast",
+              "educational-access",
+              "flood-risk",
+              "grassland",
+              "historic-environment",
+              "livestock-management",
+              "organic-land",
+              "priority-habitats",
+              "trees-non-woodland",
+              "uplands",
+              "vegetation-control",
+              "water-quality",
+              "wildlife-package",
+              "woodland"
+            ]
+          }
+        },
+        "tiers_or_standalone_items": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "higher-tier",
+              "mid-tier",
+              "standalone-capital-items"
+            ]
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "required": [
+        "body",
+        "metadata",
+        "change_history"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "attachments": {
+          "$ref": "#/definitions/asset_link_list"
+        },
+        "body": {
+          "$ref": "#/definitions/body_html_and_govspeak"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "headers": {
+          "$ref": "#/definitions/nested_headers"
+        },
+        "max_cache_time": {
+          "$ref": "#/definitions/max_cache_time"
+        },
+        "metadata": {
+          "$ref": "#/definitions/any_metadata"
+        },
+        "temporary_update_type": {
+          "description": "Indicates that the user should choose a new update type on the next save.",
+          "type": "boolean"
         }
       }
     },
@@ -1948,13 +988,6 @@
       "properties": {
         "bulk_published": {
           "type": "boolean"
-        },
-        "dfid_review_status": {
-          "type": "string",
-          "enum": [
-            "unreviewed",
-            "peer_reviewed"
-          ]
         },
         "country": {
           "type": "array",
@@ -2166,30 +1199,6 @@
             "type": "string"
           }
         },
-        "first_published_at": {
-          "type": "string",
-          "pattern": "^[1-9][0-9]{3}[-/](0[1-9]|1[0-2])[-/](0[1-9]|[12][0-9]|3[0-1])$"
-        },
-        "dfid_theme": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "enum": [
-              "agriculture",
-              "climate_and_environment",
-              "economic_growth",
-              "education",
-              "food_and_nutrition",
-              "governance_and_conflict",
-              "health",
-              "humanitarian_disasters_and_emergencies",
-              "infrastructure",
-              "research_communication_and_uptake",
-              "social_change",
-              "water_and_sanitation"
-            ]
-          }
-        },
         "dfid_document_type": {
           "type": "string",
           "items": {
@@ -2219,74 +1228,37 @@
               "working_paper"
             ]
           }
-        }
-      }
-    },
-    "countryside_stewardship_grant_metadata": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "bulk_published": {
-          "type": "boolean"
         },
-        "grant_type": {
+        "dfid_review_status": {
           "type": "string",
           "enum": [
-            "option",
-            "capital-item",
-            "supplement"
+            "unreviewed",
+            "peer_reviewed"
           ]
         },
-        "land_use": {
+        "dfid_theme": {
           "type": "array",
           "items": {
             "type": "string",
             "enum": [
-              "arable-land",
-              "boundaries",
-              "coast",
-              "educational-access",
-              "flood-risk",
-              "grassland",
-              "historic-environment",
-              "livestock-management",
-              "organic-land",
-              "priority-habitats",
-              "trees-non-woodland",
-              "uplands",
-              "vegetation-control",
-              "water-quality",
-              "wildlife-package",
-              "woodland"
+              "agriculture",
+              "climate_and_environment",
+              "economic_growth",
+              "education",
+              "food_and_nutrition",
+              "governance_and_conflict",
+              "health",
+              "humanitarian_disasters_and_emergencies",
+              "infrastructure",
+              "research_communication_and_uptake",
+              "social_change",
+              "water_and_sanitation"
             ]
           }
         },
-        "tiers_or_standalone_items": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "enum": [
-              "higher-tier",
-              "mid-tier",
-              "standalone-capital-items"
-            ]
-          }
-        },
-        "funding_amount": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "enum": [
-              "up-to-100",
-              "101-to-200",
-              "201-to-300",
-              "301-to-400",
-              "401-to-500",
-              "more-than-500",
-              "up-to-50-actual-costs",
-              "more-than-50-actual-costs"
-            ]
-          }
+        "first_published_at": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}[-/](0[1-9]|1[0-2])[-/](0[1-9]|[12][0-9]|3[0-1])$"
         }
       }
     },
@@ -2296,6 +1268,10 @@
       "properties": {
         "bulk_published": {
           "type": "boolean"
+        },
+        "first_published_at": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
         },
         "therapeutic_area": {
           "type": "array",
@@ -2327,11 +1303,44 @@
               "urology-nephrology"
             ]
           }
-        },
-        "first_published_at": {
-          "type": "string",
-          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
         }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "employment_appeal_tribunal_decision_metadata": {
@@ -2350,11 +1359,9 @@
             "type": "string"
           }
         },
-        "tribunal_decision_sub_categories": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+        "tribunal_decision_decision_date": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
         },
         "tribunal_decision_landmark": {
           "type": "string",
@@ -2363,9 +1370,11 @@
             "not-landmark"
           ]
         },
-        "tribunal_decision_decision_date": {
-          "type": "string",
-          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        "tribunal_decision_sub_categories": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       }
     },
@@ -2376,12 +1385,8 @@
         "bulk_published": {
           "type": "boolean"
         },
-        "tribunal_decision_country": {
-          "type": "string",
-          "enum": [
-            "england-and-wales",
-            "scotland"
-          ]
+        "hidden_indexable_content": {
+          "type": "string"
         },
         "tribunal_decision_categories": {
           "type": "array",
@@ -2389,12 +1394,16 @@
             "type": "string"
           }
         },
+        "tribunal_decision_country": {
+          "type": "string",
+          "enum": [
+            "england-and-wales",
+            "scotland"
+          ]
+        },
         "tribunal_decision_decision_date": {
           "type": "string",
           "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
-        },
-        "hidden_indexable_content": {
-          "type": "string"
         }
       }
     },
@@ -2404,6 +1413,10 @@
       "properties": {
         "bulk_published": {
           "type": "boolean"
+        },
+        "closing_date": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
         },
         "fund_state": {
           "type": "string",
@@ -2433,6 +1446,17 @@
             ]
           }
         },
+        "funding_source": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "european-social-fund",
+              "european-regional-development-fund",
+              "european-agricoltural-fund-for-rural"
+            ]
+          }
+        },
         "location": {
           "type": "array",
           "items": {
@@ -2449,23 +1473,472 @@
               "london"
             ]
           }
-        },
-        "funding_source": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "enum": [
-              "european-social-fund",
-              "european-regional-development-fund",
-              "european-agricoltural-fund-for-rural"
-            ]
-          }
-        },
-        "closing_date": {
-          "type": "string",
-          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
         }
       }
+    },
+    "external_link": {
+      "type": "object",
+      "required": [
+        "title",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "base_path",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
+            "type": "string"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "country": {
+            "$ref": "#/definitions/country"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "details": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "links": {
+            "type": "object",
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links"
+              }
+            }
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "required": [
+        "title",
+        "path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "international_development_fund_metadata": {
       "type": "object",
@@ -2473,6 +1946,45 @@
       "properties": {
         "bulk_published": {
           "type": "boolean"
+        },
+        "development_sector": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "agriculture",
+              "climate-change",
+              "disabilities",
+              "education",
+              "empowerment-and-accountability",
+              "environment",
+              "girls-and-women",
+              "health",
+              "humanitarian-emergencies-disasters",
+              "livelihoods",
+              "peace-and-access-to-justice",
+              "private-sector-business",
+              "technology",
+              "trade",
+              "water-and-sanitation"
+            ]
+          }
+        },
+        "eligible_entities": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "non-governmental-organisations",
+              "uk-based-non-profit-organisations",
+              "uk-based-small-and-diaspora-organisations",
+              "companies",
+              "local-government",
+              "educational-institutions",
+              "individuals",
+              "humanitarian-relief-organisations"
+            ]
+          }
         },
         "fund_state": {
           "type": "string",
@@ -2517,45 +2029,6 @@
             ]
           }
         },
-        "development_sector": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "enum": [
-              "agriculture",
-              "climate-change",
-              "disabilities",
-              "education",
-              "empowerment-and-accountability",
-              "environment",
-              "girls-and-women",
-              "health",
-              "humanitarian-emergencies-disasters",
-              "livelihoods",
-              "peace-and-access-to-justice",
-              "private-sector-business",
-              "technology",
-              "trade",
-              "water-and-sanitation"
-            ]
-          }
-        },
-        "eligible_entities": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "enum": [
-              "non-governmental-organisations",
-              "uk-based-non-profit-organisations",
-              "uk-based-small-and-diaspora-organisations",
-              "companies",
-              "local-government",
-              "educational-institutions",
-              "individuals",
-              "humanitarian-relief-organisations"
-            ]
-          }
-        },
         "value_of_funding": {
           "type": "array",
           "items": {
@@ -2570,12 +2043,100 @@
         }
       }
     },
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
+      "type": "object",
+      "required": [
+        "label",
+        "value"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "A human readable label",
+          "type": "string"
+        },
+        "value": {
+          "description": "A value to use for form controls",
+          "type": "string"
+        }
+      }
+    },
+    "locale": {
+      "type": "string",
+      "enum": [
+        "ar",
+        "az",
+        "be",
+        "bg",
+        "bn",
+        "cs",
+        "cy",
+        "de",
+        "dr",
+        "el",
+        "en",
+        "es",
+        "es-419",
+        "et",
+        "fa",
+        "fr",
+        "he",
+        "hi",
+        "hu",
+        "hy",
+        "id",
+        "it",
+        "ja",
+        "ka",
+        "ko",
+        "lt",
+        "lv",
+        "ms",
+        "pl",
+        "ps",
+        "pt",
+        "ro",
+        "ru",
+        "si",
+        "sk",
+        "so",
+        "sq",
+        "sr",
+        "sw",
+        "ta",
+        "th",
+        "tk",
+        "tr",
+        "uk",
+        "ur",
+        "uz",
+        "vi",
+        "zh",
+        "zh-hk",
+        "zh-tw"
+      ]
+    },
     "maib_report_metadata": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
         "bulk_published": {
           "type": "boolean"
+        },
+        "date_of_occurrence": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        },
+        "report_type": {
+          "type": "string",
+          "enum": [
+            "investigation-report",
+            "safety-bulletin",
+            "completed-preliminary-examination",
+            "overseas-report",
+            "discontinued-investigation"
+          ]
         },
         "vessel_type": {
           "type": "array",
@@ -2589,30 +2150,122 @@
               "recreational-craft-power"
             ]
           }
-        },
-        "report_type": {
-          "type": "string",
-          "enum": [
-            "investigation-report",
-            "safety-bulletin",
-            "completed-preliminary-examination",
-            "overseas-report",
-            "discontinued-investigation"
-          ]
-        },
-        "date_of_occurrence": {
-          "type": "string",
-          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
         }
       }
+    },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
     },
     "medical_safety_alert_metadata": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "bulk_published": {
-          "type": "boolean"
-        },
         "alert_type": {
           "type": "string",
           "enum": [
@@ -2621,6 +2274,13 @@
             "field-safety-notices",
             "company-led-drugs"
           ]
+        },
+        "bulk_published": {
+          "type": "boolean"
+        },
+        "issued_date": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
         },
         "medical_specialism": {
           "type": "array",
@@ -2651,12 +2311,165 @@
               "vascular-cardiac-surgery"
             ]
           }
-        },
-        "issued_date": {
-          "type": "string",
-          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
         }
       }
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
+    },
+    "nested_headers": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "text",
+          "level",
+          "id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "headers": {
+            "$ref": "#/definitions/nested_headers"
+          },
+          "id": {
+            "type": "string"
+          },
+          "level": {
+            "type": "integer"
+          },
+          "text": {
+            "type": "string"
+          }
+        }
+      },
+      "minItems": 1
+    },
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
+    },
+    "public_updated_at": {
+      "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
     },
     "raib_report_metadata": {
       "type": "object",
@@ -2664,6 +2477,10 @@
       "properties": {
         "bulk_published": {
           "type": "boolean"
+        },
+        "date_of_occurrence": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
         },
         "railway_type": {
           "type": "array",
@@ -2686,10 +2503,113 @@
             "discontinuation-report",
             "safety-digest"
           ]
+        }
+      }
+    },
+    "redirect_route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
         },
-        "date_of_occurrence": {
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
           "type": "string",
-          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
         }
       }
     },
@@ -2697,12 +2617,53 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "bulk_published": {
-          "type": "boolean"
-        },
         "assessment_date": {
           "type": "string",
           "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        },
+        "bulk_published": {
+          "type": "boolean"
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       }
     },
@@ -2712,6 +2673,9 @@
       "properties": {
         "bulk_published": {
           "type": "boolean"
+        },
+        "hidden_indexable_content": {
+          "type": "string"
         },
         "tribunal_decision_category": {
           "type": "string",
@@ -2727,9 +2691,41 @@
         "tribunal_decision_decision_date": {
           "type": "string",
           "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
-        },
-        "hidden_indexable_content": {
-          "type": "string"
+        }
+      }
+    },
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
+      "type": "string"
+    },
+    "topic_groups": {
+      "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "description": "DEPRECATED",
+            "$ref": "#/definitions/guid_list"
+          },
+          "contents": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/absolute_path"
+            }
+          },
+          "description": {
+            "description": "DEPRECATED",
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
         }
       }
     },
@@ -2740,13 +2736,20 @@
         "bulk_published": {
           "type": "boolean"
         },
-        "tribunal_decision_judges": {
+        "hidden_indexable_content": {
+          "type": "string"
+        },
+        "tribunal_decision_categories": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "tribunal_decision_categories": {
+        "tribunal_decision_decision_date": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        },
+        "tribunal_decision_judges": {
           "type": "array",
           "items": {
             "type": "string"
@@ -2757,13 +2760,6 @@
           "items": {
             "type": "string"
           }
-        },
-        "tribunal_decision_decision_date": {
-          "type": "string",
-          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
-        },
-        "hidden_indexable_content": {
-          "type": "string"
         }
       }
     },
@@ -2771,6 +2767,18 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "alert_issue_date": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        },
+        "build_end_date": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        },
+        "build_start_date": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        },
         "bulk_published": {
           "type": "boolean"
         },
@@ -2780,6 +2788,9 @@
             "recall",
             "non_urgent_fault"
           ]
+        },
+        "faulty_item_model": {
+          "type": "string"
         },
         "faulty_item_type": {
           "type": "string",
@@ -2811,23 +2822,24 @@
             "other-manufacturer"
           ]
         },
-        "faulty_item_model": {
-          "type": "string"
-        },
         "serial_number": {
           "type": "string"
+        }
+      }
+    },
+    "will_continue_on": {
+      "description": "Description of the website the adjoining external link will be taking the user to",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
         },
-        "alert_issue_date": {
-          "type": "string",
-          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
-        },
-        "build_start_date": {
-          "type": "string",
-          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
-        },
-        "build_end_date": {
-          "type": "string",
-          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        "withdrawn_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/specialist_document/publisher_v2/links.json
+++ b/dist/formats/specialist_document/publisher_v2/links.json
@@ -3,25 +3,10 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "previous_version": {
-      "type": "string"
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/guid_list"
-        },
         "mainstream_browse_pages": {
           "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/guid_list"
@@ -30,8 +15,12 @@
           "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/guid_list"
         },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
@@ -51,38 +40,50 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/guid_list"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
         }
       }
+    },
+    "previous_version": {
+      "type": "string"
     }
   },
   "definitions": {
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
     "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
       "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
     "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
         {
           "type": "string"
@@ -90,22 +91,158 @@
         {
           "type": "null"
         }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+      ]
     },
-    "external_related_links": {
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -116,20 +253,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -146,212 +616,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -410,98 +690,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -510,10 +823,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -521,6 +830,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -543,79 +856,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -627,13 +1069,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -641,61 +1077,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -703,418 +1102,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1124,9 +1116,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/dist/formats/specialist_document/publisher_v2/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "title",
     "details",
@@ -13,12 +12,22 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "description": {
       "anyOf": [
@@ -30,84 +39,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "access_limited": {
-      "$ref": "#/definitions/access_limited"
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "change_note": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "previous_version": {
-      "type": "string"
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "links": {
-      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string",
@@ -272,1082 +205,157 @@
         "written_statement"
       ]
     },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "specialist_document"
       ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
-    "details": {
+    "aaib_report_metadata": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "body",
-        "metadata"
-      ],
       "properties": {
-        "body": {
-          "$ref": "#/definitions/body_html_and_govspeak"
+        "aircraft_category": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "commercial-fixed-wing",
+              "commercial-rotorcraft",
+              "general-aviation-fixed-wing",
+              "general-aviation-rotorcraft",
+              "sport-aviation-and-balloons"
+            ]
+          }
         },
-        "attachments": {
-          "$ref": "#/definitions/asset_link_list"
+        "aircraft_type": {
+          "type": "string"
         },
-        "metadata": {
-          "$ref": "#/definitions/any_metadata"
+        "bulk_published": {
+          "type": "boolean"
         },
-        "max_cache_time": {
-          "$ref": "#/definitions/max_cache_time"
+        "date_of_occurrence": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
         },
-        "headers": {
-          "$ref": "#/definitions/nested_headers"
+        "location": {
+          "type": "string"
         },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
+        "registration": {
+          "type": "string"
         },
-        "temporary_update_type": {
-          "type": "boolean",
-          "description": "Indicates that the user should choose a new update type on the next save."
+        "report_type": {
+          "type": "string",
+          "enum": [
+            "annual-safety-report",
+            "correspondence-investigation",
+            "field-investigation",
+            "pre-1997-monthly-report",
+            "foreign-report",
+            "formal-report",
+            "special-bulletin",
+            "safety-study"
+          ]
         }
       }
     },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "finder": {
-          "description": "The finder for this specialist document.",
-          "$ref": "#/definitions/guid_list",
-          "minItems": 1,
-          "maxItems": 1
-        },
-        "policy_areas": {
-          "$ref": "#/definitions/guid_list"
-        }
-      },
-      "required": [
-        "finder"
-      ]
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
     },
     "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
       "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
     "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/external_link"
-      }
-    },
-    "external_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "title",
-        "url"
-      ],
-      "properties": {
-        "title": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        }
-      }
-    },
-    "internal_link_without_guid": {
-      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "title",
-        "path"
-      ],
-      "properties": {
-        "title": {
-          "type": "string"
-        },
-        "path": {
-          "$ref": "#/definitions/absolute_fullpath"
-        }
-      }
-    },
-    "internal_or_external_link": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/external_link"
-        },
-        {
-          "$ref": "#/definitions/internal_link_without_guid"
-        },
-        {
-          "$ref": "#/definitions/guid"
-        }
-      ]
-    },
-    "government": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "title",
-        "slug",
-        "current"
-      ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url"
-      ],
-      "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
-          "type": "string"
-        },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
-          "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
-        }
-      }
-    },
-    "locale": {
-      "type": "string",
-      "enum": [
-        "ar",
-        "az",
-        "be",
-        "bg",
-        "bn",
-        "cs",
-        "cy",
-        "de",
-        "dr",
-        "el",
-        "en",
-        "es",
-        "es-419",
-        "et",
-        "fa",
-        "fr",
-        "he",
-        "hi",
-        "hu",
-        "hy",
-        "id",
-        "it",
-        "ja",
-        "ka",
-        "ko",
-        "lt",
-        "lv",
-        "ms",
-        "pl",
-        "ps",
-        "pt",
-        "ro",
-        "ru",
-        "si",
-        "sk",
-        "so",
-        "sq",
-        "sr",
-        "sw",
-        "ta",
-        "th",
-        "tk",
-        "tr",
-        "uk",
-        "ur",
-        "uz",
-        "vi",
-        "zh",
-        "zh-hk",
-        "zh-tw"
-      ]
-    },
-    "multiple_content_types": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "content_type",
-          "content"
-        ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
-          }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "nation_applicability": {
-      "description": "An object specifying the applicability of a particular nation.",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
-        "alternative_url": {
-          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
-          "type": "string"
-        },
-        "applicable": {
-          "description": "Whether the content applies to this nation or not.",
-          "type": "boolean"
-        }
-      }
-    },
-    "national_applicability": {
-      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "england": {
-          "$ref": "#/definitions/nation_applicability"
-        },
-        "northern_ireland": {
-          "$ref": "#/definitions/nation_applicability"
-        },
-        "scotland": {
-          "$ref": "#/definitions/nation_applicability"
-        },
-        "wales": {
-          "$ref": "#/definitions/nation_applicability"
-        }
-      }
-    },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
-        }
-      }
-    },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "public_updated_at": {
-      "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "tags": {
-      "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
-      "additionalProperties": false,
-      "properties": {
-        "browse_pages": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "primary_topic": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
-      "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
-    },
-    "topic_groups": {
-      "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
-            "description": "DEPRECATED",
-            "type": "string"
-          },
-          "contents": {
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/absolute_path"
-            }
-          },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
-          },
-          "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
         {
           "type": "string"
@@ -1356,51 +364,6 @@
           "type": "null"
         }
       ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "will_continue_on": {
-      "description": "Description of the website the adjoining external link will be taking the user to",
-      "type": "string"
-    },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
     },
     "any_metadata": {
       "type": "object",
@@ -1461,79 +424,40 @@
         }
       ]
     },
-    "nested_headers": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "text",
-          "level",
-          "id"
-        ],
-        "properties": {
-          "text": {
-            "type": "string"
-          },
-          "level": {
-            "type": "integer"
-          },
-          "id": {
-            "type": "string"
-          },
-          "headers": {
-            "$ref": "#/definitions/nested_headers"
-          }
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
         }
       }
     },
-    "aaib_report_metadata": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "bulk_published": {
-          "type": "boolean"
-        },
-        "aircraft_category": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "enum": [
-              "commercial-fixed-wing",
-              "commercial-rotorcraft",
-              "general-aviation-fixed-wing",
-              "general-aviation-rotorcraft",
-              "sport-aviation-and-balloons"
-            ]
-          }
-        },
-        "report_type": {
-          "type": "string",
-          "enum": [
-            "annual-safety-report",
-            "correspondence-investigation",
-            "field-investigation",
-            "pre-1997-monthly-report",
-            "foreign-report",
-            "formal-report",
-            "special-bulletin",
-            "safety-study"
-          ]
-        },
-        "date_of_occurrence": {
-          "type": "string",
-          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
-        },
-        "aircraft_type": {
-          "type": "string"
-        },
-        "location": {
-          "type": "string"
-        },
-        "registration": {
-          "type": "string"
-        }
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
       }
     },
     "asylum_support_decision_metadata": {
@@ -1543,19 +467,8 @@
         "bulk_published": {
           "type": "boolean"
         },
-        "tribunal_decision_judges": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "tribunal_decision_category": {
-          "type": "string",
-          "enum": [
-            "section-4-1-support-for-persons-who-are-neither-an-asylum-seeker-nor-a-failed-asylum-seeker",
-            "section-4-2-support-for-failed-asylum-seekers",
-            "section-95-support-for-asylum-seekers"
-          ]
+        "hidden_indexable_content": {
+          "type": "string"
         },
         "tribunal_decision_categories": {
           "type": "array",
@@ -1568,10 +481,19 @@
             ]
           }
         },
-        "tribunal_decision_sub_category": {
-          "type": "string"
+        "tribunal_decision_category": {
+          "type": "string",
+          "enum": [
+            "section-4-1-support-for-persons-who-are-neither-an-asylum-seeker-nor-a-failed-asylum-seeker",
+            "section-4-2-support-for-failed-asylum-seekers",
+            "section-95-support-for-asylum-seekers"
+          ]
         },
-        "tribunal_decision_sub_categories": {
+        "tribunal_decision_decision_date": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        },
+        "tribunal_decision_judges": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1587,14 +509,36 @@
         "tribunal_decision_reference_number": {
           "type": "string"
         },
-        "tribunal_decision_decision_date": {
-          "type": "string",
-          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        "tribunal_decision_sub_categories": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
-        "hidden_indexable_content": {
+        "tribunal_decision_sub_category": {
           "type": "string"
         }
       }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
     },
     "business_finance_support_scheme_metadata": {
       "type": "object",
@@ -1679,12 +623,47 @@
         }
       }
     },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "cma_case_metadata": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
         "bulk_published": {
           "type": "boolean"
+        },
+        "case_state": {
+          "type": "string",
+          "enum": [
+            "open",
+            "closed"
+          ]
         },
         "case_type": {
           "type": "string",
@@ -1699,12 +678,9 @@
             "review-of-orders-and-undertakings"
           ]
         },
-        "case_state": {
+        "closed_date": {
           "type": "string",
-          "enum": [
-            "open",
-            "closed"
-          ]
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
         },
         "market_sector": {
           "type": "array",
@@ -1743,6 +719,10 @@
             ]
           }
         },
+        "opened_date": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        },
         "outcome_type": {
           "type": "string",
           "enum": [
@@ -1776,14 +756,128 @@
             "consumer-enforcement-changes-to-business-practices-agreed",
             "regulatory-references-and-appeals-final-determination"
           ]
+        }
+      }
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
         },
-        "opened_date": {
-          "type": "string",
-          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        "slug": {
+          "type": "string"
         },
-        "closed_date": {
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "countryside_stewardship_grant_metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "bulk_published": {
+          "type": "boolean"
+        },
+        "funding_amount": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "up-to-100",
+              "101-to-200",
+              "201-to-300",
+              "301-to-400",
+              "401-to-500",
+              "more-than-500",
+              "up-to-50-actual-costs",
+              "more-than-50-actual-costs"
+            ]
+          }
+        },
+        "grant_type": {
           "type": "string",
-          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+          "enum": [
+            "option",
+            "capital-item",
+            "supplement"
+          ]
+        },
+        "land_use": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "arable-land",
+              "boundaries",
+              "coast",
+              "educational-access",
+              "flood-risk",
+              "grassland",
+              "historic-environment",
+              "livestock-management",
+              "organic-land",
+              "priority-habitats",
+              "trees-non-woodland",
+              "uplands",
+              "vegetation-control",
+              "water-quality",
+              "wildlife-package",
+              "woodland"
+            ]
+          }
+        },
+        "tiers_or_standalone_items": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "higher-tier",
+              "mid-tier",
+              "standalone-capital-items"
+            ]
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "required": [
+        "body",
+        "metadata"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "attachments": {
+          "$ref": "#/definitions/asset_link_list"
+        },
+        "body": {
+          "$ref": "#/definitions/body_html_and_govspeak"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "headers": {
+          "$ref": "#/definitions/nested_headers"
+        },
+        "max_cache_time": {
+          "$ref": "#/definitions/max_cache_time"
+        },
+        "metadata": {
+          "$ref": "#/definitions/any_metadata"
+        },
+        "temporary_update_type": {
+          "description": "Indicates that the user should choose a new update type on the next save.",
+          "type": "boolean"
         }
       }
     },
@@ -1793,13 +887,6 @@
       "properties": {
         "bulk_published": {
           "type": "boolean"
-        },
-        "dfid_review_status": {
-          "type": "string",
-          "enum": [
-            "unreviewed",
-            "peer_reviewed"
-          ]
         },
         "country": {
           "type": "array",
@@ -2011,30 +1098,6 @@
             "type": "string"
           }
         },
-        "first_published_at": {
-          "type": "string",
-          "pattern": "^[1-9][0-9]{3}[-/](0[1-9]|1[0-2])[-/](0[1-9]|[12][0-9]|3[0-1])$"
-        },
-        "dfid_theme": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "enum": [
-              "agriculture",
-              "climate_and_environment",
-              "economic_growth",
-              "education",
-              "food_and_nutrition",
-              "governance_and_conflict",
-              "health",
-              "humanitarian_disasters_and_emergencies",
-              "infrastructure",
-              "research_communication_and_uptake",
-              "social_change",
-              "water_and_sanitation"
-            ]
-          }
-        },
         "dfid_document_type": {
           "type": "string",
           "items": {
@@ -2064,74 +1127,37 @@
               "working_paper"
             ]
           }
-        }
-      }
-    },
-    "countryside_stewardship_grant_metadata": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "bulk_published": {
-          "type": "boolean"
         },
-        "grant_type": {
+        "dfid_review_status": {
           "type": "string",
           "enum": [
-            "option",
-            "capital-item",
-            "supplement"
+            "unreviewed",
+            "peer_reviewed"
           ]
         },
-        "land_use": {
+        "dfid_theme": {
           "type": "array",
           "items": {
             "type": "string",
             "enum": [
-              "arable-land",
-              "boundaries",
-              "coast",
-              "educational-access",
-              "flood-risk",
-              "grassland",
-              "historic-environment",
-              "livestock-management",
-              "organic-land",
-              "priority-habitats",
-              "trees-non-woodland",
-              "uplands",
-              "vegetation-control",
-              "water-quality",
-              "wildlife-package",
-              "woodland"
+              "agriculture",
+              "climate_and_environment",
+              "economic_growth",
+              "education",
+              "food_and_nutrition",
+              "governance_and_conflict",
+              "health",
+              "humanitarian_disasters_and_emergencies",
+              "infrastructure",
+              "research_communication_and_uptake",
+              "social_change",
+              "water_and_sanitation"
             ]
           }
         },
-        "tiers_or_standalone_items": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "enum": [
-              "higher-tier",
-              "mid-tier",
-              "standalone-capital-items"
-            ]
-          }
-        },
-        "funding_amount": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "enum": [
-              "up-to-100",
-              "101-to-200",
-              "201-to-300",
-              "301-to-400",
-              "401-to-500",
-              "more-than-500",
-              "up-to-50-actual-costs",
-              "more-than-50-actual-costs"
-            ]
-          }
+        "first_published_at": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}[-/](0[1-9]|1[0-2])[-/](0[1-9]|[12][0-9]|3[0-1])$"
         }
       }
     },
@@ -2141,6 +1167,10 @@
       "properties": {
         "bulk_published": {
           "type": "boolean"
+        },
+        "first_published_at": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
         },
         "therapeutic_area": {
           "type": "array",
@@ -2172,11 +1202,44 @@
               "urology-nephrology"
             ]
           }
-        },
-        "first_published_at": {
-          "type": "string",
-          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
         }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "employment_appeal_tribunal_decision_metadata": {
@@ -2195,11 +1258,9 @@
             "type": "string"
           }
         },
-        "tribunal_decision_sub_categories": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+        "tribunal_decision_decision_date": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
         },
         "tribunal_decision_landmark": {
           "type": "string",
@@ -2208,9 +1269,11 @@
             "not-landmark"
           ]
         },
-        "tribunal_decision_decision_date": {
-          "type": "string",
-          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        "tribunal_decision_sub_categories": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       }
     },
@@ -2221,12 +1284,8 @@
         "bulk_published": {
           "type": "boolean"
         },
-        "tribunal_decision_country": {
-          "type": "string",
-          "enum": [
-            "england-and-wales",
-            "scotland"
-          ]
+        "hidden_indexable_content": {
+          "type": "string"
         },
         "tribunal_decision_categories": {
           "type": "array",
@@ -2234,12 +1293,16 @@
             "type": "string"
           }
         },
+        "tribunal_decision_country": {
+          "type": "string",
+          "enum": [
+            "england-and-wales",
+            "scotland"
+          ]
+        },
         "tribunal_decision_decision_date": {
           "type": "string",
           "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
-        },
-        "hidden_indexable_content": {
-          "type": "string"
         }
       }
     },
@@ -2249,6 +1312,10 @@
       "properties": {
         "bulk_published": {
           "type": "boolean"
+        },
+        "closing_date": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
         },
         "fund_state": {
           "type": "string",
@@ -2278,6 +1345,17 @@
             ]
           }
         },
+        "funding_source": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "european-social-fund",
+              "european-regional-development-fund",
+              "european-agricoltural-fund-for-rural"
+            ]
+          }
+        },
         "location": {
           "type": "array",
           "items": {
@@ -2294,23 +1372,388 @@
               "london"
             ]
           }
-        },
-        "funding_source": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "enum": [
-              "european-social-fund",
-              "european-regional-development-fund",
-              "european-agricoltural-fund-for-rural"
-            ]
-          }
-        },
-        "closing_date": {
-          "type": "string",
-          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
         }
       }
+    },
+    "external_link": {
+      "type": "object",
+      "required": [
+        "title",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "internal_link_without_guid": {
+      "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
+      "type": "object",
+      "required": [
+        "title",
+        "path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
+        }
+      }
+    },
+    "internal_or_external_link": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external_link"
+        },
+        {
+          "$ref": "#/definitions/internal_link_without_guid"
+        },
+        {
+          "$ref": "#/definitions/guid"
+        }
+      ]
     },
     "international_development_fund_metadata": {
       "type": "object",
@@ -2318,6 +1761,45 @@
       "properties": {
         "bulk_published": {
           "type": "boolean"
+        },
+        "development_sector": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "agriculture",
+              "climate-change",
+              "disabilities",
+              "education",
+              "empowerment-and-accountability",
+              "environment",
+              "girls-and-women",
+              "health",
+              "humanitarian-emergencies-disasters",
+              "livelihoods",
+              "peace-and-access-to-justice",
+              "private-sector-business",
+              "technology",
+              "trade",
+              "water-and-sanitation"
+            ]
+          }
+        },
+        "eligible_entities": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "non-governmental-organisations",
+              "uk-based-non-profit-organisations",
+              "uk-based-small-and-diaspora-organisations",
+              "companies",
+              "local-government",
+              "educational-institutions",
+              "individuals",
+              "humanitarian-relief-organisations"
+            ]
+          }
         },
         "fund_state": {
           "type": "string",
@@ -2362,45 +1844,6 @@
             ]
           }
         },
-        "development_sector": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "enum": [
-              "agriculture",
-              "climate-change",
-              "disabilities",
-              "education",
-              "empowerment-and-accountability",
-              "environment",
-              "girls-and-women",
-              "health",
-              "humanitarian-emergencies-disasters",
-              "livelihoods",
-              "peace-and-access-to-justice",
-              "private-sector-business",
-              "technology",
-              "trade",
-              "water-and-sanitation"
-            ]
-          }
-        },
-        "eligible_entities": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "enum": [
-              "non-governmental-organisations",
-              "uk-based-non-profit-organisations",
-              "uk-based-small-and-diaspora-organisations",
-              "companies",
-              "local-government",
-              "educational-institutions",
-              "individuals",
-              "humanitarian-relief-organisations"
-            ]
-          }
-        },
         "value_of_funding": {
           "type": "array",
           "items": {
@@ -2415,12 +1858,118 @@
         }
       }
     },
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
+      "type": "object",
+      "required": [
+        "label",
+        "value"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "description": "A human readable label",
+          "type": "string"
+        },
+        "value": {
+          "description": "A value to use for form controls",
+          "type": "string"
+        }
+      }
+    },
+    "links": {
+      "type": "object",
+      "required": [
+        "finder"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "finder": {
+          "description": "The finder for this specialist document.",
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1,
+          "minItems": 1
+        },
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    },
+    "locale": {
+      "type": "string",
+      "enum": [
+        "ar",
+        "az",
+        "be",
+        "bg",
+        "bn",
+        "cs",
+        "cy",
+        "de",
+        "dr",
+        "el",
+        "en",
+        "es",
+        "es-419",
+        "et",
+        "fa",
+        "fr",
+        "he",
+        "hi",
+        "hu",
+        "hy",
+        "id",
+        "it",
+        "ja",
+        "ka",
+        "ko",
+        "lt",
+        "lv",
+        "ms",
+        "pl",
+        "ps",
+        "pt",
+        "ro",
+        "ru",
+        "si",
+        "sk",
+        "so",
+        "sq",
+        "sr",
+        "sw",
+        "ta",
+        "th",
+        "tk",
+        "tr",
+        "uk",
+        "ur",
+        "uz",
+        "vi",
+        "zh",
+        "zh-hk",
+        "zh-tw"
+      ]
+    },
     "maib_report_metadata": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
         "bulk_published": {
           "type": "boolean"
+        },
+        "date_of_occurrence": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        },
+        "report_type": {
+          "type": "string",
+          "enum": [
+            "investigation-report",
+            "safety-bulletin",
+            "completed-preliminary-examination",
+            "overseas-report",
+            "discontinued-investigation"
+          ]
         },
         "vessel_type": {
           "type": "array",
@@ -2434,30 +1983,122 @@
               "recreational-craft-power"
             ]
           }
-        },
-        "report_type": {
-          "type": "string",
-          "enum": [
-            "investigation-report",
-            "safety-bulletin",
-            "completed-preliminary-examination",
-            "overseas-report",
-            "discontinued-investigation"
-          ]
-        },
-        "date_of_occurrence": {
-          "type": "string",
-          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
         }
       }
+    },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
     },
     "medical_safety_alert_metadata": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "bulk_published": {
-          "type": "boolean"
-        },
         "alert_type": {
           "type": "string",
           "enum": [
@@ -2466,6 +2107,13 @@
             "field-safety-notices",
             "company-led-drugs"
           ]
+        },
+        "bulk_published": {
+          "type": "boolean"
+        },
+        "issued_date": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
         },
         "medical_specialism": {
           "type": "array",
@@ -2496,12 +2144,165 @@
               "vascular-cardiac-surgery"
             ]
           }
-        },
-        "issued_date": {
-          "type": "string",
-          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
         }
       }
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "nation_applicability": {
+      "description": "An object specifying the applicability of a particular nation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "alternative_url": {
+          "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
+          "type": "string"
+        },
+        "applicable": {
+          "description": "Whether the content applies to this nation or not.",
+          "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
+        }
+      }
+    },
+    "national_applicability": {
+      "description": "An object specifying the applicable nations for this content item. If it applies to all nations, it should be omitted.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "england": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "northern_ireland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "scotland": {
+          "$ref": "#/definitions/nation_applicability"
+        },
+        "wales": {
+          "$ref": "#/definitions/nation_applicability"
+        }
+      }
+    },
+    "nested_headers": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "text",
+          "level",
+          "id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "headers": {
+            "$ref": "#/definitions/nested_headers"
+          },
+          "id": {
+            "type": "string"
+          },
+          "level": {
+            "type": "integer"
+          },
+          "text": {
+            "type": "string"
+          }
+        }
+      },
+      "minItems": 1
+    },
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
+    },
+    "public_updated_at": {
+      "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
     },
     "raib_report_metadata": {
       "type": "object",
@@ -2509,6 +2310,10 @@
       "properties": {
         "bulk_published": {
           "type": "boolean"
+        },
+        "date_of_occurrence": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
         },
         "railway_type": {
           "type": "array",
@@ -2531,10 +2336,113 @@
             "discontinuation-report",
             "safety-digest"
           ]
+        }
+      }
+    },
+    "redirect_route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
         },
-        "date_of_occurrence": {
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
           "type": "string",
-          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
         }
       }
     },
@@ -2542,12 +2450,53 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "bulk_published": {
-          "type": "boolean"
-        },
         "assessment_date": {
           "type": "string",
           "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        },
+        "bulk_published": {
+          "type": "boolean"
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "browse_pages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "primary_topic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       }
     },
@@ -2557,6 +2506,9 @@
       "properties": {
         "bulk_published": {
           "type": "boolean"
+        },
+        "hidden_indexable_content": {
+          "type": "string"
         },
         "tribunal_decision_category": {
           "type": "string",
@@ -2572,9 +2524,41 @@
         "tribunal_decision_decision_date": {
           "type": "string",
           "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
-        },
-        "hidden_indexable_content": {
-          "type": "string"
+        }
+      }
+    },
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
+      "type": "string"
+    },
+    "topic_groups": {
+      "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "description": "DEPRECATED",
+            "$ref": "#/definitions/guid_list"
+          },
+          "contents": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/absolute_path"
+            }
+          },
+          "description": {
+            "description": "DEPRECATED",
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
         }
       }
     },
@@ -2585,13 +2569,20 @@
         "bulk_published": {
           "type": "boolean"
         },
-        "tribunal_decision_judges": {
+        "hidden_indexable_content": {
+          "type": "string"
+        },
+        "tribunal_decision_categories": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "tribunal_decision_categories": {
+        "tribunal_decision_decision_date": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        },
+        "tribunal_decision_judges": {
           "type": "array",
           "items": {
             "type": "string"
@@ -2602,13 +2593,6 @@
           "items": {
             "type": "string"
           }
-        },
-        "tribunal_decision_decision_date": {
-          "type": "string",
-          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
-        },
-        "hidden_indexable_content": {
-          "type": "string"
         }
       }
     },
@@ -2616,6 +2600,18 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "alert_issue_date": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        },
+        "build_end_date": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        },
+        "build_start_date": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        },
         "bulk_published": {
           "type": "boolean"
         },
@@ -2625,6 +2621,9 @@
             "recall",
             "non_urgent_fault"
           ]
+        },
+        "faulty_item_model": {
+          "type": "string"
         },
         "faulty_item_type": {
           "type": "string",
@@ -2656,23 +2655,24 @@
             "other-manufacturer"
           ]
         },
-        "faulty_item_model": {
-          "type": "string"
-        },
         "serial_number": {
           "type": "string"
+        }
+      }
+    },
+    "will_continue_on": {
+      "description": "Description of the website the adjoining external link will be taking the user to",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
         },
-        "alert_issue_date": {
-          "type": "string",
-          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
-        },
-        "build_start_date": {
-          "type": "string",
-          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
-        },
-        "build_end_date": {
-          "type": "string",
-          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        "withdrawn_at": {
+          "format": "date-time"
         }
       }
     }

--- a/dist/formats/speech/frontend/schema.json
+++ b/dist/formats/speech/frontend/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "links",
@@ -12,12 +11,25 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -29,144 +41,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "speaker": {
-          "description": "A speaker that has a GOV.UK profile",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "related_policies": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ministers": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "topical_events": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "world_locations": {
-          "$ref": "#/definitions/base_path_less_frontend_links"
-        },
-        "roles": {
-          "description": "Used to power Email Alert Api subscriptions for Whitehall content",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "people": {
-          "description": "Used to power Email Alert Api subscriptions for Whitehall content",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_pages": {
-          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "meets_user_needs": {
-          "description": "The user needs this piece of content meets.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "organisations": {
-          "description": "All organisations linked to this content item. This should include lead organisations.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "parent": {
-          "description": "The parent content item.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policy_areas": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "primary_publishing_organisation": {
-          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "available_translations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "children": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policies": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "document_collections": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "child_taxons": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -331,67 +207,678 @@
         "written_statement"
       ]
     },
+    "email_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "available_translations": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ministers": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "people": {
+          "description": "Used to power Email Alert Api subscriptions for Whitehall content",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policies": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policy_areas": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "primary_publishing_organisation": {
+          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "related_policies": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "roles": {
+          "description": "Used to power Email Alert Api subscriptions for Whitehall content",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "speaker": {
+          "description": "A speaker that has a GOV.UK profile",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "topical_events": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "world_locations": {
+          "$ref": "#/definitions/base_path_less_frontend_links"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "speech"
       ]
     },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    "title": {
+      "type": "string"
     },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
-    "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
     },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "base_path_less_frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "required": [
+        "body",
+        "government",
+        "political",
+        "delivered_on"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "body": {
+          "$ref": "#/definitions/body"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "delivered_on": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "emphasised_organisations": {
+          "$ref": "#/definitions/emphasised_organisations"
+        },
+        "first_public_at": {
+          "$ref": "#/definitions/first_public_at"
+        },
+        "government": {
+          "$ref": "#/definitions/government"
+        },
+        "image": {
+          "$ref": "#/definitions/image"
+        },
+        "location": {
+          "type": "string"
+        },
+        "political": {
+          "$ref": "#/definitions/political"
+        },
+        "speaker_without_profile": {
+          "description": "A speaker that does not have a GOV.UK profile (eg the Queen)",
+          "type": "string"
+        },
+        "speech_type_explanation": {
+          "description": "Details about the type of speech",
+          "type": "string"
+        },
+        "tags": {
+          "$ref": "#/definitions/tags"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "required": [
+        "title",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
     "frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "base_path",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
-          "document_type": {
-            "type": "string"
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
           },
-          "schema_name": {
-            "type": "string"
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
           },
-          "public_updated_at": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
             "type": "string"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
-            "type": "string"
+          "country": {
+            "$ref": "#/definitions/country"
           },
           "description": {
             "anyOf": [
@@ -403,36 +890,11 @@
               }
             ]
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "details": {
+            "type": "object",
+            "additionalProperties": true
           },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
+          "document_type": {
             "type": "string"
           },
           "links": {
@@ -442,165 +904,205 @@
                 "$ref": "#/definitions/frontend_links"
               }
             }
-          }
-        }
-      }
-    },
-    "base_path_less_frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "locale"
-        ],
-        "properties": {
-          "document_type": {
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
             "type": "string"
           },
           "schema_name": {
             "type": "string"
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
+          "title": {
+            "type": "string"
           },
           "web_url": {
             "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
             "type": "string",
             "format": "uri"
           },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
           },
-          "public_updated_at": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
             "type": "string"
           },
-          "content_id": {
-            "$ref": "#/definitions/guid"
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
           },
           "title": {
             "type": "string"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
           }
         }
       }
     },
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "body",
-        "government",
-        "political",
-        "delivered_on"
-      ],
-      "properties": {
-        "body": {
-          "$ref": "#/definitions/body"
-        },
-        "first_public_at": {
-          "$ref": "#/definitions/first_public_at"
-        },
-        "speech_type_explanation": {
-          "description": "Details about the type of speech",
-          "type": "string"
-        },
-        "speaker_without_profile": {
-          "description": "A speaker that does not have a GOV.UK profile (eg the Queen)",
-          "type": "string"
-        },
-        "location": {
-          "type": "string"
-        },
-        "delivered_on": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "government": {
-          "$ref": "#/definitions/government"
-        },
-        "political": {
-          "$ref": "#/definitions/political"
-        },
-        "image": {
-          "$ref": "#/definitions/image"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        },
-        "emphasised_organisations": {
-          "$ref": "#/definitions/emphasised_organisations"
-        },
-        "tags": {
-          "$ref": "#/definitions/tags"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
       }
     },
-    "external_link": {
+    "image": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
+        "alt_text": {
           "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "url": {
           "type": "string",
@@ -611,17 +1113,17 @@
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -638,212 +1140,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -902,98 +1214,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -1002,10 +1347,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -1013,6 +1354,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -1035,79 +1380,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1119,13 +1593,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1133,61 +1601,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1195,418 +1626,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1616,9 +1640,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/speech/notification/schema.json
+++ b/dist/formats/speech/notification/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "content_id",
@@ -17,12 +16,25 @@
     "title",
     "update_type"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -34,60 +46,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -252,60 +212,9 @@
         "written_statement"
       ]
     },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "speech"
-      ]
-    },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
-    },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
     "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "govuk_request_id": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
     },
     "expanded_links": {
       "type": "object",
@@ -314,39 +223,597 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "govuk_request_id": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "speech"
+      ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "base_path_less_frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "required": [
+        "body",
+        "government",
+        "political",
+        "delivered_on"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "body": {
+          "$ref": "#/definitions/body"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "delivered_on": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "emphasised_organisations": {
+          "$ref": "#/definitions/emphasised_organisations"
+        },
+        "first_public_at": {
+          "$ref": "#/definitions/first_public_at"
+        },
+        "government": {
+          "$ref": "#/definitions/government"
+        },
+        "image": {
+          "$ref": "#/definitions/image"
+        },
+        "location": {
+          "type": "string"
+        },
+        "political": {
+          "$ref": "#/definitions/political"
+        },
+        "speaker_without_profile": {
+          "description": "A speaker that does not have a GOV.UK profile (eg the Queen)",
+          "type": "string"
+        },
+        "speech_type_explanation": {
+          "description": "Details about the type of speech",
+          "type": "string"
+        },
+        "tags": {
+          "$ref": "#/definitions/tags"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "required": [
+        "title",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
     "frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "base_path",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
-          "document_type": {
-            "type": "string"
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
           },
-          "schema_name": {
-            "type": "string"
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
           },
-          "public_updated_at": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
             "type": "string"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
-            "type": "string"
+          "country": {
+            "$ref": "#/definitions/country"
           },
           "description": {
             "anyOf": [
@@ -358,36 +825,11 @@
               }
             ]
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "details": {
+            "type": "object",
+            "additionalProperties": true
           },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
+          "document_type": {
             "type": "string"
           },
           "links": {
@@ -397,165 +839,205 @@
                 "$ref": "#/definitions/frontend_links"
               }
             }
-          }
-        }
-      }
-    },
-    "base_path_less_frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "locale"
-        ],
-        "properties": {
-          "document_type": {
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
             "type": "string"
           },
           "schema_name": {
             "type": "string"
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
+          "title": {
+            "type": "string"
           },
           "web_url": {
             "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
             "type": "string",
             "format": "uri"
           },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
           },
-          "public_updated_at": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
             "type": "string"
           },
-          "content_id": {
-            "$ref": "#/definitions/guid"
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
           },
           "title": {
             "type": "string"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
           }
         }
       }
     },
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "body",
-        "government",
-        "political",
-        "delivered_on"
-      ],
-      "properties": {
-        "body": {
-          "$ref": "#/definitions/body"
-        },
-        "first_public_at": {
-          "$ref": "#/definitions/first_public_at"
-        },
-        "speech_type_explanation": {
-          "description": "Details about the type of speech",
-          "type": "string"
-        },
-        "speaker_without_profile": {
-          "description": "A speaker that does not have a GOV.UK profile (eg the Queen)",
-          "type": "string"
-        },
-        "location": {
-          "type": "string"
-        },
-        "delivered_on": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "government": {
-          "$ref": "#/definitions/government"
-        },
-        "political": {
-          "$ref": "#/definitions/political"
-        },
-        "image": {
-          "$ref": "#/definitions/image"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        },
-        "emphasised_organisations": {
-          "$ref": "#/definitions/emphasised_organisations"
-        },
-        "tags": {
-          "$ref": "#/definitions/tags"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
       }
     },
-    "external_link": {
+    "image": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
+        "alt_text": {
           "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "url": {
           "type": "string",
@@ -566,17 +1048,17 @@
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -593,212 +1075,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -857,98 +1149,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -957,10 +1282,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -968,6 +1289,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -990,79 +1315,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1074,13 +1528,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1088,61 +1536,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1150,418 +1561,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1571,9 +1575,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/speech/publisher_v2/links.json
+++ b/dist/formats/speech/publisher_v2/links.json
@@ -3,50 +3,10 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "previous_version": {
-      "type": "string"
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "speaker": {
-          "description": "A speaker that has a GOV.UK profile",
-          "$ref": "#/definitions/guid_list",
-          "maxItems": 1
-        },
-        "related_policies": {
-          "$ref": "#/definitions/guid_list"
-        },
-        "ministers": {
-          "$ref": "#/definitions/guid_list"
-        },
-        "topical_events": {
-          "$ref": "#/definitions/guid_list"
-        },
-        "world_locations": {
-          "$ref": "#/definitions/guid_list"
-        },
-        "roles": {
-          "$ref": "#/definitions/guid_list",
-          "description": "Used to power Email Alert Api subscriptions for Whitehall content"
-        },
-        "people": {
-          "$ref": "#/definitions/guid_list",
-          "description": "Used to power Email Alert Api subscriptions for Whitehall content"
-        },
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/guid_list"
-        },
         "mainstream_browse_pages": {
           "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/guid_list"
@@ -55,8 +15,15 @@
           "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/guid_list"
         },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+        "ministers": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
@@ -68,6 +35,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "people": {
+          "description": "Used to power Email Alert Api subscriptions for Whitehall content",
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"
@@ -76,38 +47,68 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "related_policies": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "roles": {
+          "description": "Used to power Email Alert Api subscriptions for Whitehall content",
+          "$ref": "#/definitions/guid_list"
+        },
+        "speaker": {
+          "description": "A speaker that has a GOV.UK profile",
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/guid_list"
+        },
+        "topical_events": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "world_locations": {
+          "$ref": "#/definitions/guid_list"
         }
       }
+    },
+    "previous_version": {
+      "type": "string"
     }
   },
   "definitions": {
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
     "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
       "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
     "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
         {
           "type": "string"
@@ -115,22 +116,158 @@
         {
           "type": "null"
         }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+      ]
     },
-    "external_related_links": {
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -141,20 +278,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -171,212 +641,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -435,98 +715,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -535,10 +848,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -546,6 +855,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -568,79 +881,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -652,13 +1094,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -666,61 +1102,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -728,418 +1127,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1149,9 +1141,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/speech/publisher_v2/schema.json
+++ b/dist/formats/speech/publisher_v2/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "title",
     "details",
@@ -13,12 +12,22 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "description": {
       "anyOf": [
@@ -30,84 +39,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "access_limited": {
-      "$ref": "#/definitions/access_limited"
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "change_note": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "previous_version": {
-      "type": "string"
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "links": {
-      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string",
@@ -272,101 +205,109 @@
         "written_statement"
       ]
     },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "speech"
       ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "body",
-        "government",
-        "political",
-        "delivered_on"
-      ],
-      "properties": {
-        "body": {
-          "$ref": "#/definitions/body"
-        },
-        "first_public_at": {
-          "$ref": "#/definitions/first_public_at"
-        },
-        "speech_type_explanation": {
-          "description": "Details about the type of speech",
-          "type": "string"
-        },
-        "speaker_without_profile": {
-          "description": "A speaker that does not have a GOV.UK profile (eg the Queen)",
-          "type": "string"
-        },
-        "location": {
-          "type": "string"
-        },
-        "delivered_on": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "government": {
-          "$ref": "#/definitions/government"
-        },
-        "political": {
-          "$ref": "#/definitions/political"
-        },
-        "image": {
-          "$ref": "#/definitions/image"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        },
-        "emphasised_organisations": {
-          "$ref": "#/definitions/emphasised_organisations"
-        },
-        "tags": {
-          "$ref": "#/definitions/tags"
-        }
-      }
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policy_areas": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
     },
     "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
       "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
     "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
         {
           "type": "string"
@@ -374,22 +315,209 @@
         {
           "type": "null"
         }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+      ]
     },
-    "external_related_links": {
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "required": [
+        "body",
+        "government",
+        "political",
+        "delivered_on"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "body": {
+          "$ref": "#/definitions/body"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "delivered_on": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "emphasised_organisations": {
+          "$ref": "#/definitions/emphasised_organisations"
+        },
+        "first_public_at": {
+          "$ref": "#/definitions/first_public_at"
+        },
+        "government": {
+          "$ref": "#/definitions/government"
+        },
+        "image": {
+          "$ref": "#/definitions/image"
+        },
+        "location": {
+          "type": "string"
+        },
+        "political": {
+          "$ref": "#/definitions/political"
+        },
+        "speaker_without_profile": {
+          "description": "A speaker that does not have a GOV.UK profile (eg the Queen)",
+          "type": "string"
+        },
+        "speech_type_explanation": {
+          "description": "Details about the type of speech",
+          "type": "string"
+        },
+        "tags": {
+          "$ref": "#/definitions/tags"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -400,20 +528,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -430,212 +891,31 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
         }
       }
     },
-    "redirect_route": {
+    "links": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
       "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
         }
       }
     },
@@ -694,98 +974,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -794,10 +1107,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -805,6 +1114,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -827,79 +1140,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -911,13 +1353,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -925,61 +1361,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -987,418 +1386,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1408,9 +1400,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/statistical_data_set/frontend/schema.json
+++ b/dist/formats/statistical_data_set/frontend/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "links",
@@ -12,12 +11,25 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -29,119 +41,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_pages": {
-          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "meets_user_needs": {
-          "description": "The user needs this piece of content meets.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "organisations": {
-          "description": "All organisations linked to this content item. This should include lead organisations.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "parent": {
-          "description": "The parent content item.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policy_areas": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "primary_publishing_organisation": {
-          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "available_translations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "children": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policies": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "document_collections": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "child_taxons": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -306,67 +207,635 @@
         "written_statement"
       ]
     },
+    "email_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "available_translations": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "policies": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policy_areas": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "primary_publishing_organisation": {
+          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "statistical_data_set"
       ]
     },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    "title": {
+      "type": "string"
     },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
-    "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
     },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "base_path_less_frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "required": [
+        "body",
+        "first_public_at",
+        "government",
+        "political"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "body": {
+          "$ref": "#/definitions/body"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "emphasised_organisations": {
+          "$ref": "#/definitions/emphasised_organisations"
+        },
+        "first_public_at": {
+          "$ref": "#/definitions/first_public_at"
+        },
+        "government": {
+          "$ref": "#/definitions/government"
+        },
+        "political": {
+          "$ref": "#/definitions/political"
+        },
+        "tags": {
+          "$ref": "#/definitions/tags"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "required": [
+        "title",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
     "frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "base_path",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
-          "document_type": {
-            "type": "string"
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
           },
-          "schema_name": {
-            "type": "string"
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
           },
-          "public_updated_at": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
             "type": "string"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
-            "type": "string"
+          "country": {
+            "$ref": "#/definitions/country"
           },
           "description": {
             "anyOf": [
@@ -378,36 +847,11 @@
               }
             ]
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "details": {
+            "type": "object",
+            "additionalProperties": true
           },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
+          "document_type": {
             "type": "string"
           },
           "links": {
@@ -417,147 +861,205 @@
                 "$ref": "#/definitions/frontend_links"
               }
             }
-          }
-        }
-      }
-    },
-    "base_path_less_frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "locale"
-        ],
-        "properties": {
-          "document_type": {
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
             "type": "string"
           },
           "schema_name": {
             "type": "string"
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
+          "title": {
+            "type": "string"
           },
           "web_url": {
             "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
             "type": "string",
             "format": "uri"
           },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
           },
-          "public_updated_at": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
             "type": "string"
           },
-          "content_id": {
-            "$ref": "#/definitions/guid"
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
           },
           "title": {
             "type": "string"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
           }
         }
       }
     },
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "body",
-        "first_public_at",
-        "government",
-        "political"
-      ],
-      "properties": {
-        "body": {
-          "$ref": "#/definitions/body"
-        },
-        "first_public_at": {
-          "$ref": "#/definitions/first_public_at"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        },
-        "tags": {
-          "$ref": "#/definitions/tags"
-        },
-        "government": {
-          "$ref": "#/definitions/government"
-        },
-        "political": {
-          "$ref": "#/definitions/political"
-        },
-        "emphasised_organisations": {
-          "$ref": "#/definitions/emphasised_organisations"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
       }
     },
-    "external_link": {
+    "image": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
+        "alt_text": {
           "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "url": {
           "type": "string",
@@ -568,17 +1070,17 @@
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -595,212 +1097,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -859,98 +1171,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -959,10 +1304,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -970,6 +1311,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -992,79 +1337,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1076,13 +1550,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1090,61 +1558,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1152,418 +1583,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1573,9 +1597,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/statistical_data_set/notification/schema.json
+++ b/dist/formats/statistical_data_set/notification/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "content_id",
@@ -17,12 +16,25 @@
     "title",
     "update_type"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -34,60 +46,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -252,60 +212,9 @@
         "written_statement"
       ]
     },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "statistical_data_set"
-      ]
-    },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
-    },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
     "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "govuk_request_id": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
     },
     "expanded_links": {
       "type": "object",
@@ -314,39 +223,579 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "govuk_request_id": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "statistical_data_set"
+      ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "base_path_less_frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "required": [
+        "body",
+        "first_public_at",
+        "government",
+        "political"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "body": {
+          "$ref": "#/definitions/body"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "emphasised_organisations": {
+          "$ref": "#/definitions/emphasised_organisations"
+        },
+        "first_public_at": {
+          "$ref": "#/definitions/first_public_at"
+        },
+        "government": {
+          "$ref": "#/definitions/government"
+        },
+        "political": {
+          "$ref": "#/definitions/political"
+        },
+        "tags": {
+          "$ref": "#/definitions/tags"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "required": [
+        "title",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
     "frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "base_path",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
-          "document_type": {
-            "type": "string"
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
           },
-          "schema_name": {
-            "type": "string"
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
           },
-          "public_updated_at": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
             "type": "string"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
-            "type": "string"
+          "country": {
+            "$ref": "#/definitions/country"
           },
           "description": {
             "anyOf": [
@@ -358,36 +807,11 @@
               }
             ]
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "details": {
+            "type": "object",
+            "additionalProperties": true
           },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
+          "document_type": {
             "type": "string"
           },
           "links": {
@@ -397,147 +821,205 @@
                 "$ref": "#/definitions/frontend_links"
               }
             }
-          }
-        }
-      }
-    },
-    "base_path_less_frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "locale"
-        ],
-        "properties": {
-          "document_type": {
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
             "type": "string"
           },
           "schema_name": {
             "type": "string"
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
+          "title": {
+            "type": "string"
           },
           "web_url": {
             "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
             "type": "string",
             "format": "uri"
           },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
           },
-          "public_updated_at": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
             "type": "string"
           },
-          "content_id": {
-            "$ref": "#/definitions/guid"
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
           },
           "title": {
             "type": "string"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
           }
         }
       }
     },
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "body",
-        "first_public_at",
-        "government",
-        "political"
-      ],
-      "properties": {
-        "body": {
-          "$ref": "#/definitions/body"
-        },
-        "first_public_at": {
-          "$ref": "#/definitions/first_public_at"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        },
-        "tags": {
-          "$ref": "#/definitions/tags"
-        },
-        "government": {
-          "$ref": "#/definitions/government"
-        },
-        "political": {
-          "$ref": "#/definitions/political"
-        },
-        "emphasised_organisations": {
-          "$ref": "#/definitions/emphasised_organisations"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
       }
     },
-    "external_link": {
+    "image": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
+        "alt_text": {
           "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "url": {
           "type": "string",
@@ -548,17 +1030,17 @@
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -575,212 +1057,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -839,98 +1131,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -939,10 +1264,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -950,6 +1271,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -972,79 +1297,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1056,13 +1510,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1070,61 +1518,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1132,418 +1543,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1553,9 +1557,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/statistical_data_set/publisher_v2/links.json
+++ b/dist/formats/statistical_data_set/publisher_v2/links.json
@@ -3,25 +3,10 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "previous_version": {
-      "type": "string"
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/guid_list"
-        },
         "mainstream_browse_pages": {
           "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/guid_list"
@@ -30,8 +15,12 @@
           "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/guid_list"
         },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
@@ -51,38 +40,50 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/guid_list"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
         }
       }
+    },
+    "previous_version": {
+      "type": "string"
     }
   },
   "definitions": {
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
     "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
       "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
     "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
         {
           "type": "string"
@@ -90,22 +91,158 @@
         {
           "type": "null"
         }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+      ]
     },
-    "external_related_links": {
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -116,20 +253,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -146,212 +616,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -410,98 +690,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -510,10 +823,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -521,6 +830,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -543,79 +856,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -627,13 +1069,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -641,61 +1077,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -703,418 +1102,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1124,9 +1116,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/statistical_data_set/publisher_v2/schema.json
+++ b/dist/formats/statistical_data_set/publisher_v2/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "title",
     "details",
@@ -13,12 +12,22 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "description": {
       "anyOf": [
@@ -30,84 +39,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "access_limited": {
-      "$ref": "#/definitions/access_limited"
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "change_note": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "previous_version": {
-      "type": "string"
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "links": {
-      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string",
@@ -272,83 +205,109 @@
         "written_statement"
       ]
     },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "statistical_data_set"
       ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "body",
-        "first_public_at",
-        "government",
-        "political"
-      ],
-      "properties": {
-        "body": {
-          "$ref": "#/definitions/body"
-        },
-        "first_public_at": {
-          "$ref": "#/definitions/first_public_at"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        },
-        "tags": {
-          "$ref": "#/definitions/tags"
-        },
-        "government": {
-          "$ref": "#/definitions/government"
-        },
-        "political": {
-          "$ref": "#/definitions/political"
-        },
-        "emphasised_organisations": {
-          "$ref": "#/definitions/emphasised_organisations"
-        }
-      }
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policy_areas": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
     },
     "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
       "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
     "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
         {
           "type": "string"
@@ -356,22 +315,191 @@
         {
           "type": "null"
         }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+      ]
     },
-    "external_related_links": {
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "required": [
+        "body",
+        "first_public_at",
+        "government",
+        "political"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "body": {
+          "$ref": "#/definitions/body"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "emphasised_organisations": {
+          "$ref": "#/definitions/emphasised_organisations"
+        },
+        "first_public_at": {
+          "$ref": "#/definitions/first_public_at"
+        },
+        "government": {
+          "$ref": "#/definitions/government"
+        },
+        "political": {
+          "$ref": "#/definitions/political"
+        },
+        "tags": {
+          "$ref": "#/definitions/tags"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -382,20 +510,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -412,212 +873,31 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
         }
       }
     },
-    "redirect_route": {
+    "links": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
       "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
         }
       }
     },
@@ -676,98 +956,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -776,10 +1089,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -787,6 +1096,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -809,79 +1122,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -893,13 +1335,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -907,61 +1343,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -969,418 +1368,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1390,9 +1382,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/statistics_announcement/frontend/schema.json
+++ b/dist/formats/statistics_announcement/frontend/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "links",
@@ -12,12 +11,25 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -29,119 +41,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "organisations": {
-          "description": "All organisations linked to this content item. This should include lead organisations.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policy_areas": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_pages": {
-          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "meets_user_needs": {
-          "description": "The user needs this piece of content meets.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "parent": {
-          "description": "The parent content item.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "primary_publishing_organisation": {
-          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "available_translations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "children": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policies": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "document_collections": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "child_taxons": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -306,67 +207,647 @@
         "written_statement"
       ]
     },
+    "email_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "available_translations": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "policies": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policy_areas": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "primary_publishing_organisation": {
+          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "statistics_announcement"
       ]
     },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    "title": {
+      "type": "string"
     },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
-    "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
     },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "base_path_less_frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "required": [
+        "display_date",
+        "state",
+        "format_sub_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "cancellation_reason": {
+          "type": "string"
+        },
+        "cancelled_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "display_date": {
+          "type": "string"
+        },
+        "format_sub_type": {
+          "type": "string",
+          "enum": [
+            "national",
+            "official"
+          ]
+        },
+        "latest_change_note": {
+          "type": "string"
+        },
+        "previous_display_date": {
+          "type": "string"
+        },
+        "state": {
+          "type": "string",
+          "enum": [
+            "cancelled",
+            "confirmed",
+            "provisional"
+          ]
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "required": [
+        "title",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
     "frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "base_path",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
-          "document_type": {
-            "type": "string"
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
           },
-          "schema_name": {
-            "type": "string"
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
           },
-          "public_updated_at": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
             "type": "string"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
-            "type": "string"
+          "country": {
+            "$ref": "#/definitions/country"
           },
           "description": {
             "anyOf": [
@@ -378,36 +859,11 @@
               }
             ]
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "details": {
+            "type": "object",
+            "additionalProperties": true
           },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
+          "document_type": {
             "type": "string"
           },
           "links": {
@@ -417,159 +873,205 @@
                 "$ref": "#/definitions/frontend_links"
               }
             }
-          }
-        }
-      }
-    },
-    "base_path_less_frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "locale"
-        ],
-        "properties": {
-          "document_type": {
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
             "type": "string"
           },
           "schema_name": {
             "type": "string"
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
+          "title": {
+            "type": "string"
           },
           "web_url": {
             "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
             "type": "string",
             "format": "uri"
           },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
           },
-          "public_updated_at": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
             "type": "string"
           },
-          "content_id": {
-            "$ref": "#/definitions/guid"
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
           },
           "title": {
             "type": "string"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
           }
         }
       }
     },
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "display_date",
-        "state",
-        "format_sub_type"
-      ],
-      "properties": {
-        "cancellation_reason": {
-          "type": "string"
-        },
-        "cancelled_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "latest_change_note": {
-          "type": "string"
-        },
-        "previous_display_date": {
-          "type": "string"
-        },
-        "display_date": {
-          "type": "string"
-        },
-        "state": {
-          "type": "string",
-          "enum": [
-            "cancelled",
-            "confirmed",
-            "provisional"
-          ]
-        },
-        "format_sub_type": {
-          "type": "string",
-          "enum": [
-            "national",
-            "official"
-          ]
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
       }
     },
-    "external_link": {
+    "image": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
+        "alt_text": {
           "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "url": {
           "type": "string",
@@ -580,17 +1082,17 @@
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -607,212 +1109,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -871,98 +1183,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -971,10 +1316,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -982,6 +1323,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -1004,79 +1349,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1088,13 +1562,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1102,61 +1570,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1164,418 +1595,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1585,9 +1609,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/statistics_announcement/notification/schema.json
+++ b/dist/formats/statistics_announcement/notification/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "content_id",
@@ -17,12 +16,25 @@
     "title",
     "update_type"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -34,60 +46,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -252,60 +212,9 @@
         "written_statement"
       ]
     },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "statistics_announcement"
-      ]
-    },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
-    },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
     "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "govuk_request_id": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
     },
     "expanded_links": {
       "type": "object",
@@ -314,39 +223,591 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "govuk_request_id": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "statistics_announcement"
+      ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "base_path_less_frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "required": [
+        "display_date",
+        "state",
+        "format_sub_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "cancellation_reason": {
+          "type": "string"
+        },
+        "cancelled_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "display_date": {
+          "type": "string"
+        },
+        "format_sub_type": {
+          "type": "string",
+          "enum": [
+            "national",
+            "official"
+          ]
+        },
+        "latest_change_note": {
+          "type": "string"
+        },
+        "previous_display_date": {
+          "type": "string"
+        },
+        "state": {
+          "type": "string",
+          "enum": [
+            "cancelled",
+            "confirmed",
+            "provisional"
+          ]
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "required": [
+        "title",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
     "frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "base_path",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
-          "document_type": {
-            "type": "string"
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
           },
-          "schema_name": {
-            "type": "string"
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
           },
-          "public_updated_at": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
             "type": "string"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
-            "type": "string"
+          "country": {
+            "$ref": "#/definitions/country"
           },
           "description": {
             "anyOf": [
@@ -358,36 +819,11 @@
               }
             ]
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "details": {
+            "type": "object",
+            "additionalProperties": true
           },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
+          "document_type": {
             "type": "string"
           },
           "links": {
@@ -397,159 +833,205 @@
                 "$ref": "#/definitions/frontend_links"
               }
             }
-          }
-        }
-      }
-    },
-    "base_path_less_frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "locale"
-        ],
-        "properties": {
-          "document_type": {
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
             "type": "string"
           },
           "schema_name": {
             "type": "string"
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
+          "title": {
+            "type": "string"
           },
           "web_url": {
             "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
             "type": "string",
             "format": "uri"
           },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
           },
-          "public_updated_at": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
             "type": "string"
           },
-          "content_id": {
-            "$ref": "#/definitions/guid"
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
           },
           "title": {
             "type": "string"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
           }
         }
       }
     },
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "display_date",
-        "state",
-        "format_sub_type"
-      ],
-      "properties": {
-        "cancellation_reason": {
-          "type": "string"
-        },
-        "cancelled_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "latest_change_note": {
-          "type": "string"
-        },
-        "previous_display_date": {
-          "type": "string"
-        },
-        "display_date": {
-          "type": "string"
-        },
-        "state": {
-          "type": "string",
-          "enum": [
-            "cancelled",
-            "confirmed",
-            "provisional"
-          ]
-        },
-        "format_sub_type": {
-          "type": "string",
-          "enum": [
-            "national",
-            "official"
-          ]
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
       }
     },
-    "external_link": {
+    "image": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
+        "alt_text": {
           "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "url": {
           "type": "string",
@@ -560,17 +1042,17 @@
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -587,212 +1069,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -851,98 +1143,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -951,10 +1276,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -962,6 +1283,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -984,79 +1309,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1068,13 +1522,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1082,61 +1530,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1144,418 +1555,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1565,9 +1569,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/statistics_announcement/publisher_v2/links.json
+++ b/dist/formats/statistics_announcement/publisher_v2/links.json
@@ -3,23 +3,16 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "previous_version": {
-      "type": "string"
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "organisations": {
-          "description": "All organisations linked to this content item. This should include lead organisations.",
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         },
-        "policy_areas": {
-          "description": "A largely deprecated tag currently only used to power email alerts.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
+        "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/guid_list"
         },
         "ordered_related_items": {
@@ -30,16 +23,8 @@
           "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/guid_list"
         },
-        "mainstream_browse_pages": {
-          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "meets_user_needs": {
-          "description": "The user needs this piece of content meets.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {
@@ -47,42 +32,58 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "policy_areas": {
+          "description": "A largely deprecated tag currently only used to power email alerts.",
+          "$ref": "#/definitions/guid_list"
+        },
         "primary_publishing_organisation": {
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/guid_list"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
         }
       }
+    },
+    "previous_version": {
+      "type": "string"
     }
   },
   "definitions": {
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
     "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
       "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
     "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
         {
           "type": "string"
@@ -90,22 +91,158 @@
         {
           "type": "null"
         }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+      ]
     },
-    "external_related_links": {
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -116,20 +253,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -146,212 +616,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -410,98 +690,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -510,10 +823,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -521,6 +830,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -543,79 +856,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -627,13 +1069,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -641,61 +1077,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -703,418 +1102,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1124,9 +1116,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/statistics_announcement/publisher_v2/schema.json
+++ b/dist/formats/statistics_announcement/publisher_v2/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "title",
     "details",
@@ -13,12 +12,22 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "description": {
       "anyOf": [
@@ -30,84 +39,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "access_limited": {
-      "$ref": "#/definitions/access_limited"
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "change_note": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "previous_version": {
-      "type": "string"
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "links": {
-      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string",
@@ -272,22 +205,232 @@
         "written_statement"
       ]
     },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "statistics_announcement"
       ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
-    "details": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
       "type": "object",
       "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
       "required": [
         "display_date",
         "state",
         "format_sub_type"
       ],
+      "additionalProperties": false,
       "properties": {
         "cancellation_reason": {
           "type": "string"
@@ -296,13 +439,20 @@
           "type": "string",
           "format": "date-time"
         },
+        "display_date": {
+          "type": "string"
+        },
+        "format_sub_type": {
+          "type": "string",
+          "enum": [
+            "national",
+            "official"
+          ]
+        },
         "latest_change_note": {
           "type": "string"
         },
         "previous_display_date": {
-          "type": "string"
-        },
-        "display_date": {
           "type": "string"
         },
         "state": {
@@ -312,75 +462,53 @@
             "confirmed",
             "provisional"
           ]
-        },
-        "format_sub_type": {
-          "type": "string",
-          "enum": [
-            "national",
-            "official"
-          ]
         }
       }
     },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policy_areas": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -391,20 +519,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -421,212 +882,31 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
         }
       }
     },
-    "redirect_route": {
+    "links": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
       "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
         }
       }
     },
@@ -685,98 +965,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -785,10 +1098,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -796,6 +1105,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -818,79 +1131,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -902,13 +1344,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -916,61 +1352,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -978,418 +1377,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1399,9 +1391,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/take_part/frontend/schema.json
+++ b/dist/formats/take_part/frontend/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "links",
@@ -12,12 +11,25 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -29,119 +41,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_pages": {
-          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "meets_user_needs": {
-          "description": "The user needs this piece of content meets.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "organisations": {
-          "description": "All organisations linked to this content item. This should include lead organisations.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "parent": {
-          "description": "The parent content item.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policy_areas": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "primary_publishing_organisation": {
-          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "available_translations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "children": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policies": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "document_collections": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "child_taxons": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -306,67 +207,621 @@
         "written_statement"
       ]
     },
+    "email_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "available_translations": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "policies": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policy_areas": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "primary_publishing_organisation": {
+          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "take_part"
       ]
     },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    "title": {
+      "type": "string"
     },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
-    "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
     },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "base_path_less_frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "required": [
+        "body",
+        "image"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "body": {
+          "$ref": "#/definitions/body"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "image": {
+          "$ref": "#/definitions/image"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "required": [
+        "title",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
     "frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "base_path",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
-          "document_type": {
-            "type": "string"
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
           },
-          "schema_name": {
-            "type": "string"
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
           },
-          "public_updated_at": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
             "type": "string"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
-            "type": "string"
+          "country": {
+            "$ref": "#/definitions/country"
           },
           "description": {
             "anyOf": [
@@ -378,36 +833,11 @@
               }
             ]
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "details": {
+            "type": "object",
+            "additionalProperties": true
           },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
+          "document_type": {
             "type": "string"
           },
           "links": {
@@ -417,133 +847,205 @@
                 "$ref": "#/definitions/frontend_links"
               }
             }
-          }
-        }
-      }
-    },
-    "base_path_less_frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "locale"
-        ],
-        "properties": {
-          "document_type": {
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
             "type": "string"
           },
           "schema_name": {
             "type": "string"
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
+          "title": {
+            "type": "string"
           },
           "web_url": {
             "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
             "type": "string",
             "format": "uri"
           },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
           },
-          "public_updated_at": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
             "type": "string"
           },
-          "content_id": {
-            "$ref": "#/definitions/guid"
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
           },
           "title": {
             "type": "string"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
           }
         }
       }
     },
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "body",
-        "image"
-      ],
-      "properties": {
-        "body": {
-          "$ref": "#/definitions/body"
-        },
-        "image": {
-          "$ref": "#/definitions/image"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
       }
     },
-    "external_link": {
+    "image": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
+        "alt_text": {
           "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "url": {
           "type": "string",
@@ -554,17 +1056,17 @@
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -581,212 +1083,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -845,98 +1157,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -945,10 +1290,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -956,6 +1297,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -978,79 +1323,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1062,13 +1536,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1076,61 +1544,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1138,418 +1569,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1559,9 +1583,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/take_part/notification/schema.json
+++ b/dist/formats/take_part/notification/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "content_id",
@@ -17,12 +16,25 @@
     "title",
     "update_type"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -34,60 +46,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -252,60 +212,9 @@
         "written_statement"
       ]
     },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "take_part"
-      ]
-    },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
-    },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
     "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "govuk_request_id": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
     },
     "expanded_links": {
       "type": "object",
@@ -314,39 +223,565 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "govuk_request_id": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "take_part"
+      ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "base_path_less_frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "required": [
+        "body",
+        "image"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "body": {
+          "$ref": "#/definitions/body"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "image": {
+          "$ref": "#/definitions/image"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "required": [
+        "title",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
     "frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "base_path",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
-          "document_type": {
-            "type": "string"
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
           },
-          "schema_name": {
-            "type": "string"
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
           },
-          "public_updated_at": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
             "type": "string"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
-            "type": "string"
+          "country": {
+            "$ref": "#/definitions/country"
           },
           "description": {
             "anyOf": [
@@ -358,36 +793,11 @@
               }
             ]
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "details": {
+            "type": "object",
+            "additionalProperties": true
           },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
+          "document_type": {
             "type": "string"
           },
           "links": {
@@ -397,133 +807,205 @@
                 "$ref": "#/definitions/frontend_links"
               }
             }
-          }
-        }
-      }
-    },
-    "base_path_less_frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "locale"
-        ],
-        "properties": {
-          "document_type": {
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
             "type": "string"
           },
           "schema_name": {
             "type": "string"
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
+          "title": {
+            "type": "string"
           },
           "web_url": {
             "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
             "type": "string",
             "format": "uri"
           },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
           },
-          "public_updated_at": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
             "type": "string"
           },
-          "content_id": {
-            "$ref": "#/definitions/guid"
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
           },
           "title": {
             "type": "string"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
           }
         }
       }
     },
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "body",
-        "image"
-      ],
-      "properties": {
-        "body": {
-          "$ref": "#/definitions/body"
-        },
-        "image": {
-          "$ref": "#/definitions/image"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
       }
     },
-    "external_link": {
+    "image": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
+        "alt_text": {
           "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "url": {
           "type": "string",
@@ -534,17 +1016,17 @@
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -561,212 +1043,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -825,98 +1117,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -925,10 +1250,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -936,6 +1257,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -958,79 +1283,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1042,13 +1496,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1056,61 +1504,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1118,418 +1529,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1539,9 +1543,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/take_part/publisher_v2/links.json
+++ b/dist/formats/take_part/publisher_v2/links.json
@@ -3,25 +3,10 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "previous_version": {
-      "type": "string"
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/guid_list"
-        },
         "mainstream_browse_pages": {
           "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/guid_list"
@@ -30,8 +15,12 @@
           "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/guid_list"
         },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
@@ -51,38 +40,50 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/guid_list"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
         }
       }
+    },
+    "previous_version": {
+      "type": "string"
     }
   },
   "definitions": {
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
     "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
       "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
     "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
         {
           "type": "string"
@@ -90,22 +91,158 @@
         {
           "type": "null"
         }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+      ]
     },
-    "external_related_links": {
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -116,20 +253,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -146,212 +616,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -410,98 +690,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -510,10 +823,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -521,6 +830,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -543,79 +856,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -627,13 +1069,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -641,61 +1077,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -703,418 +1102,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1124,9 +1116,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/take_part/publisher_v2/schema.json
+++ b/dist/formats/take_part/publisher_v2/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "title",
     "details",
@@ -13,12 +12,22 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "description": {
       "anyOf": [
@@ -30,84 +39,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "access_limited": {
-      "$ref": "#/definitions/access_limited"
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "change_note": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "previous_version": {
-      "type": "string"
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "links": {
-      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string",
@@ -272,21 +205,231 @@
         "written_statement"
       ]
     },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "take_part"
       ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
-    "details": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
       "type": "object",
       "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
       "required": [
         "body",
         "image"
       ],
+      "additionalProperties": false,
       "properties": {
         "body": {
           "$ref": "#/definitions/body"
@@ -296,65 +439,50 @@
         }
       }
     },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policy_areas": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -365,20 +493,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -395,212 +856,31 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
         }
       }
     },
-    "redirect_route": {
+    "links": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
       "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
         }
       }
     },
@@ -659,98 +939,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -759,10 +1072,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -770,6 +1079,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -792,79 +1105,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -876,13 +1318,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -890,61 +1326,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -952,418 +1351,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1373,9 +1365,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/taxon/frontend/schema.json
+++ b/dist/formats/taxon/frontend/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "links",
@@ -12,12 +11,25 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -29,127 +41,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "parent_taxons": {
-          "description": "The list of taxon parents.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_pages": {
-          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "meets_user_needs": {
-          "description": "The user needs this piece of content meets.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "organisations": {
-          "description": "All organisations linked to this content item. This should include lead organisations.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "parent": {
-          "description": "The parent content item.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policy_areas": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "primary_publishing_organisation": {
-          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "associated_taxons": {
-          "description": "A list of associated taxons whose children should be included as children of this taxon",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "available_translations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "children": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policies": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "document_collections": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "child_taxons": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -314,67 +207,630 @@
         "written_statement"
       ]
     },
+    "email_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "associated_taxons": {
+          "description": "A list of associated taxons whose children should be included as children of this taxon",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "available_translations": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "parent_taxons": {
+          "description": "The list of taxon parents.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policies": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policy_areas": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "primary_publishing_organisation": {
+          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "taxon"
       ]
     },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    "title": {
+      "type": "string"
     },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
-    "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
     },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "base_path_less_frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "internal_name": {
+          "$ref": "#/definitions/taxonomy_internal_name"
+        },
+        "notes_for_editors": {
+          "description": "Usage notes for editors when tagging content to a taxon.",
+          "type": "string"
+        },
+        "visible_to_departmental_editors": {
+          "description": "Should this taxon be made visible to Content Editors in publishing apps? It's currently only a consideration for Root Taxons in a draft state.",
+          "type": "boolean"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "required": [
+        "title",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
     "frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "base_path",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
-          "document_type": {
-            "type": "string"
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
           },
-          "schema_name": {
-            "type": "string"
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
           },
-          "public_updated_at": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
             "type": "string"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
-            "type": "string"
+          "country": {
+            "$ref": "#/definitions/country"
           },
           "description": {
             "anyOf": [
@@ -386,36 +842,11 @@
               }
             ]
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "details": {
+            "type": "object",
+            "additionalProperties": true
           },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
+          "document_type": {
             "type": "string"
           },
           "links": {
@@ -425,134 +856,205 @@
                 "$ref": "#/definitions/frontend_links"
               }
             }
-          }
-        }
-      }
-    },
-    "base_path_less_frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "locale"
-        ],
-        "properties": {
-          "document_type": {
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
             "type": "string"
           },
           "schema_name": {
             "type": "string"
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
+          "title": {
+            "type": "string"
           },
           "web_url": {
             "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
             "type": "string",
             "format": "uri"
           },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
           },
-          "public_updated_at": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
             "type": "string"
           },
-          "content_id": {
-            "$ref": "#/definitions/guid"
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
           },
           "title": {
             "type": "string"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
           }
         }
       }
     },
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "internal_name": {
-          "$ref": "#/definitions/taxonomy_internal_name"
-        },
-        "notes_for_editors": {
-          "type": "string",
-          "description": "Usage notes for editors when tagging content to a taxon."
-        },
-        "visible_to_departmental_editors": {
-          "type": "boolean",
-          "description": "Should this taxon be made visible to Content Editors in publishing apps? It's currently only a consideration for Root Taxons in a draft state."
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
       }
     },
-    "external_link": {
+    "image": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
+        "alt_text": {
           "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "url": {
           "type": "string",
@@ -563,17 +1065,17 @@
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -590,212 +1092,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -854,98 +1166,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -954,10 +1299,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -965,6 +1306,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -987,79 +1332,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1071,13 +1545,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1085,61 +1553,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1147,418 +1578,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1568,9 +1592,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/taxon/notification/schema.json
+++ b/dist/formats/taxon/notification/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "content_id",
@@ -17,12 +16,25 @@
     "title",
     "update_type"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -34,60 +46,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -252,60 +212,9 @@
         "written_statement"
       ]
     },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "taxon"
-      ]
-    },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
-    },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
     "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "govuk_request_id": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
     },
     "expanded_links": {
       "type": "object",
@@ -314,39 +223,566 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "govuk_request_id": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "taxon"
+      ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "base_path_less_frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "internal_name": {
+          "$ref": "#/definitions/taxonomy_internal_name"
+        },
+        "notes_for_editors": {
+          "description": "Usage notes for editors when tagging content to a taxon.",
+          "type": "string"
+        },
+        "visible_to_departmental_editors": {
+          "description": "Should this taxon be made visible to Content Editors in publishing apps? It's currently only a consideration for Root Taxons in a draft state.",
+          "type": "boolean"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "required": [
+        "title",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
     "frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "base_path",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
-          "document_type": {
-            "type": "string"
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
           },
-          "schema_name": {
-            "type": "string"
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
           },
-          "public_updated_at": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
             "type": "string"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
-            "type": "string"
+          "country": {
+            "$ref": "#/definitions/country"
           },
           "description": {
             "anyOf": [
@@ -358,36 +794,11 @@
               }
             ]
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "details": {
+            "type": "object",
+            "additionalProperties": true
           },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
+          "document_type": {
             "type": "string"
           },
           "links": {
@@ -397,134 +808,205 @@
                 "$ref": "#/definitions/frontend_links"
               }
             }
-          }
-        }
-      }
-    },
-    "base_path_less_frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "locale"
-        ],
-        "properties": {
-          "document_type": {
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
             "type": "string"
           },
           "schema_name": {
             "type": "string"
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
+          "title": {
+            "type": "string"
           },
           "web_url": {
             "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
             "type": "string",
             "format": "uri"
           },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
           },
-          "public_updated_at": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
             "type": "string"
           },
-          "content_id": {
-            "$ref": "#/definitions/guid"
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
           },
           "title": {
             "type": "string"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
           }
         }
       }
     },
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "internal_name": {
-          "$ref": "#/definitions/taxonomy_internal_name"
-        },
-        "notes_for_editors": {
-          "type": "string",
-          "description": "Usage notes for editors when tagging content to a taxon."
-        },
-        "visible_to_departmental_editors": {
-          "type": "boolean",
-          "description": "Should this taxon be made visible to Content Editors in publishing apps? It's currently only a consideration for Root Taxons in a draft state."
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
       }
     },
-    "external_link": {
+    "image": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
+        "alt_text": {
           "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "url": {
           "type": "string",
@@ -535,17 +1017,17 @@
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -562,212 +1044,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -826,98 +1118,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -926,10 +1251,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -937,6 +1258,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -959,79 +1284,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1043,13 +1497,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1057,61 +1505,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1119,418 +1530,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1540,9 +1544,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/taxon/publisher_v2/links.json
+++ b/dist/formats/taxon/publisher_v2/links.json
@@ -3,29 +3,10 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "previous_version": {
-      "type": "string"
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "parent_taxons": {
-          "description": "The list of taxon parents (DEPRECATED: use the edition links instead)",
-          "$ref": "#/definitions/guid_list"
-        },
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/guid_list"
-        },
         "mainstream_browse_pages": {
           "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/guid_list"
@@ -34,8 +15,12 @@
           "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/guid_list"
         },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
@@ -47,6 +32,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "parent_taxons": {
+          "description": "The list of taxon parents (DEPRECATED: use the edition links instead)",
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"
@@ -55,38 +44,50 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/guid_list"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
         }
       }
+    },
+    "previous_version": {
+      "type": "string"
     }
   },
   "definitions": {
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
     "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
       "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
     "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
         {
           "type": "string"
@@ -94,22 +95,158 @@
         {
           "type": "null"
         }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+      ]
     },
-    "external_related_links": {
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -120,20 +257,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -150,212 +620,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -414,98 +694,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -514,10 +827,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -525,6 +834,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -547,79 +860,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -631,13 +1073,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -645,61 +1081,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -707,418 +1106,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1128,9 +1120,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/taxon/publisher_v2/schema.json
+++ b/dist/formats/taxon/publisher_v2/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "title",
     "details",
@@ -13,12 +12,22 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "description": {
       "anyOf": [
@@ -30,84 +39,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "access_limited": {
-      "$ref": "#/definitions/access_limited"
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "change_note": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "previous_version": {
-      "type": "string"
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "links": {
-      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string",
@@ -272,14 +205,224 @@
         "written_statement"
       ]
     },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "taxon"
       ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,
@@ -288,82 +431,59 @@
           "$ref": "#/definitions/taxonomy_internal_name"
         },
         "notes_for_editors": {
-          "type": "string",
-          "description": "Usage notes for editors when tagging content to a taxon."
-        },
-        "visible_to_departmental_editors": {
-          "type": "boolean",
-          "description": "Should this taxon be made visible to Content Editors in publishing apps? It's currently only a consideration for Root Taxons in a draft state."
-        }
-      }
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "parent_taxons": {
-          "description": "The list of taxon parents.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "associated_taxons": {
-          "description": "A list of associated taxons whose children should be included as children of this taxon",
-          "$ref": "#/definitions/guid_list"
-        },
-        "policy_areas": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
+          "description": "Usage notes for editors when tagging content to a taxon.",
           "type": "string"
         },
-        {
-          "type": "null"
+        "visible_to_departmental_editors": {
+          "description": "Should this taxon be made visible to Content Editors in publishing apps? It's currently only a consideration for Root Taxons in a draft state.",
+          "type": "boolean"
         }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+      }
     },
-    "external_related_links": {
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -374,20 +494,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -404,212 +857,39 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
         }
       }
     },
-    "redirect_route": {
+    "links": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
       "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
+        "associated_taxons": {
+          "description": "A list of associated taxons whose children should be included as children of this taxon",
+          "$ref": "#/definitions/guid_list"
         },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
+        "parent_taxons": {
+          "description": "The list of taxon parents.",
+          "$ref": "#/definitions/guid_list"
         },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
         }
       }
     },
@@ -668,98 +948,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -768,10 +1081,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -779,6 +1088,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -801,79 +1114,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -885,13 +1327,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -899,61 +1335,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -961,418 +1360,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1382,9 +1374,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/topic/frontend/schema.json
+++ b/dist/formats/topic/frontend/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "links",
@@ -12,12 +11,25 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -29,123 +41,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "linked_items": {
-          "description": "Includes all content ids referenced in 'details'. This is a temporary measure to expand content ids for frontends which is planned to be replaced by a dependency resolution service.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_pages": {
-          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "meets_user_needs": {
-          "description": "The user needs this piece of content meets.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "organisations": {
-          "description": "All organisations linked to this content item. This should include lead organisations.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "parent": {
-          "description": "The parent content item.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policy_areas": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "primary_publishing_organisation": {
-          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "available_translations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "children": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policies": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "document_collections": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "child_taxons": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -310,67 +207,621 @@
         "written_statement"
       ]
     },
+    "email_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "available_translations": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "linked_items": {
+          "description": "Includes all content ids referenced in 'details'. This is a temporary measure to expand content ids for frontends which is planned to be replaced by a dependency resolution service.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "policies": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policy_areas": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "primary_publishing_organisation": {
+          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "topic"
       ]
     },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    "title": {
+      "type": "string"
     },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
-    "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
     },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "base_path_less_frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "groups": {
+          "$ref": "#/definitions/topic_groups"
+        },
+        "internal_name": {
+          "$ref": "#/definitions/taxonomy_internal_name"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "required": [
+        "title",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
     "frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "base_path",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
-          "document_type": {
-            "type": "string"
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
           },
-          "schema_name": {
-            "type": "string"
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
           },
-          "public_updated_at": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
             "type": "string"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
-            "type": "string"
+          "country": {
+            "$ref": "#/definitions/country"
           },
           "description": {
             "anyOf": [
@@ -382,36 +833,11 @@
               }
             ]
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "details": {
+            "type": "object",
+            "additionalProperties": true
           },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
+          "document_type": {
             "type": "string"
           },
           "links": {
@@ -421,129 +847,205 @@
                 "$ref": "#/definitions/frontend_links"
               }
             }
-          }
-        }
-      }
-    },
-    "base_path_less_frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "locale"
-        ],
-        "properties": {
-          "document_type": {
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
             "type": "string"
           },
           "schema_name": {
             "type": "string"
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
+          "title": {
+            "type": "string"
           },
           "web_url": {
             "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
             "type": "string",
             "format": "uri"
           },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
           },
-          "public_updated_at": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
             "type": "string"
           },
-          "content_id": {
-            "$ref": "#/definitions/guid"
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
           },
           "title": {
             "type": "string"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
           }
         }
       }
     },
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "internal_name": {
-          "$ref": "#/definitions/taxonomy_internal_name"
-        },
-        "groups": {
-          "$ref": "#/definitions/topic_groups"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
       }
     },
-    "external_link": {
+    "image": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
+        "alt_text": {
           "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "url": {
           "type": "string",
@@ -554,17 +1056,17 @@
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -581,212 +1083,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -845,98 +1157,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -945,10 +1290,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -956,6 +1297,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -978,79 +1323,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1062,13 +1536,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1076,61 +1544,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1138,418 +1569,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1559,9 +1583,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/topic/notification/schema.json
+++ b/dist/formats/topic/notification/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "content_id",
@@ -17,12 +16,25 @@
     "title",
     "update_type"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -34,60 +46,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -252,60 +212,9 @@
         "written_statement"
       ]
     },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "topic"
-      ]
-    },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
-    },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
     "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "govuk_request_id": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
     },
     "expanded_links": {
       "type": "object",
@@ -314,39 +223,561 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "govuk_request_id": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "topic"
+      ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "base_path_less_frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "groups": {
+          "$ref": "#/definitions/topic_groups"
+        },
+        "internal_name": {
+          "$ref": "#/definitions/taxonomy_internal_name"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "required": [
+        "title",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
     "frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "base_path",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
-          "document_type": {
-            "type": "string"
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
           },
-          "schema_name": {
-            "type": "string"
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
           },
-          "public_updated_at": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
             "type": "string"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
-            "type": "string"
+          "country": {
+            "$ref": "#/definitions/country"
           },
           "description": {
             "anyOf": [
@@ -358,36 +789,11 @@
               }
             ]
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "details": {
+            "type": "object",
+            "additionalProperties": true
           },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
+          "document_type": {
             "type": "string"
           },
           "links": {
@@ -397,129 +803,205 @@
                 "$ref": "#/definitions/frontend_links"
               }
             }
-          }
-        }
-      }
-    },
-    "base_path_less_frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "locale"
-        ],
-        "properties": {
-          "document_type": {
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
             "type": "string"
           },
           "schema_name": {
             "type": "string"
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
+          "title": {
+            "type": "string"
           },
           "web_url": {
             "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
             "type": "string",
             "format": "uri"
           },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
           },
-          "public_updated_at": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
             "type": "string"
           },
-          "content_id": {
-            "$ref": "#/definitions/guid"
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
           },
           "title": {
             "type": "string"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
           }
         }
       }
     },
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "internal_name": {
-          "$ref": "#/definitions/taxonomy_internal_name"
-        },
-        "groups": {
-          "$ref": "#/definitions/topic_groups"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
       }
     },
-    "external_link": {
+    "image": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
+        "alt_text": {
           "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "url": {
           "type": "string",
@@ -530,17 +1012,17 @@
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -557,212 +1039,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -821,98 +1113,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -921,10 +1246,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -932,6 +1253,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -954,79 +1279,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1038,13 +1492,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1052,61 +1500,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1114,418 +1525,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1535,9 +1539,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/topic/publisher_v2/links.json
+++ b/dist/formats/topic/publisher_v2/links.json
@@ -3,27 +3,12 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "previous_version": {
-      "type": "string"
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
         "linked_items": {
           "description": "Includes all content ids referenced in 'details'. This is a temporary measure to expand content ids for frontends which is planned to be replaced by a dependency resolution service.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/guid_list"
         },
         "mainstream_browse_pages": {
@@ -34,8 +19,12 @@
           "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/guid_list"
         },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
@@ -55,38 +44,50 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/guid_list"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
         }
       }
+    },
+    "previous_version": {
+      "type": "string"
     }
   },
   "definitions": {
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
     "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
       "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
     "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
         {
           "type": "string"
@@ -94,22 +95,158 @@
         {
           "type": "null"
         }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+      ]
     },
-    "external_related_links": {
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -120,20 +257,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -150,212 +620,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -414,98 +694,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -514,10 +827,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -525,6 +834,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -547,79 +860,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -631,13 +1073,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -645,61 +1081,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -707,418 +1106,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1128,9 +1120,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/topic/publisher_v2/schema.json
+++ b/dist/formats/topic/publisher_v2/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "title",
     "details",
@@ -13,12 +12,22 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "description": {
       "anyOf": [
@@ -30,84 +39,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "access_limited": {
-      "$ref": "#/definitions/access_limited"
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "change_note": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "previous_version": {
-      "type": "string"
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "links": {
-      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string",
@@ -272,62 +205,109 @@
         "written_statement"
       ]
     },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "topic"
       ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "internal_name": {
-          "$ref": "#/definitions/taxonomy_internal_name"
-        },
-        "groups": {
-          "$ref": "#/definitions/topic_groups"
-        }
-      }
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policy_areas": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
     },
     "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
       "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
     "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
         {
           "type": "string"
@@ -335,22 +315,170 @@
         {
           "type": "null"
         }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+      ]
     },
-    "external_related_links": {
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "groups": {
+          "$ref": "#/definitions/topic_groups"
+        },
+        "internal_name": {
+          "$ref": "#/definitions/taxonomy_internal_name"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -361,20 +489,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -391,212 +852,31 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
         }
       }
     },
-    "redirect_route": {
+    "links": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
       "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
         }
       }
     },
@@ -655,98 +935,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -755,10 +1068,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -766,6 +1075,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -788,79 +1101,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -872,13 +1314,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -886,61 +1322,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -948,418 +1347,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1369,9 +1361,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/topical_event_about_page/frontend/schema.json
+++ b/dist/formats/topical_event_about_page/frontend/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "links",
@@ -12,12 +11,25 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -29,119 +41,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_pages": {
-          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "meets_user_needs": {
-          "description": "The user needs this piece of content meets.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "organisations": {
-          "description": "All organisations linked to this content item. This should include lead organisations.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "parent": {
-          "description": "The parent content item.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policy_areas": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "primary_publishing_organisation": {
-          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "available_translations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "children": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policies": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "document_collections": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "child_taxons": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -306,67 +207,621 @@
         "written_statement"
       ]
     },
+    "email_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "available_translations": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "policies": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policy_areas": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "primary_publishing_organisation": {
+          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "topical_event_about_page"
       ]
     },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    "title": {
+      "type": "string"
     },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
-    "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
     },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "base_path_less_frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "required": [
+        "read_more",
+        "body"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "body": {
+          "$ref": "#/definitions/body"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "read_more": {
+          "type": "string"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "required": [
+        "title",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
     "frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "base_path",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
-          "document_type": {
-            "type": "string"
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
           },
-          "schema_name": {
-            "type": "string"
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
           },
-          "public_updated_at": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
             "type": "string"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
-            "type": "string"
+          "country": {
+            "$ref": "#/definitions/country"
           },
           "description": {
             "anyOf": [
@@ -378,36 +833,11 @@
               }
             ]
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "details": {
+            "type": "object",
+            "additionalProperties": true
           },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
+          "document_type": {
             "type": "string"
           },
           "links": {
@@ -417,133 +847,205 @@
                 "$ref": "#/definitions/frontend_links"
               }
             }
-          }
-        }
-      }
-    },
-    "base_path_less_frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "locale"
-        ],
-        "properties": {
-          "document_type": {
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
             "type": "string"
           },
           "schema_name": {
             "type": "string"
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
+          "title": {
+            "type": "string"
           },
           "web_url": {
             "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
             "type": "string",
             "format": "uri"
           },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
           },
-          "public_updated_at": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
             "type": "string"
           },
-          "content_id": {
-            "$ref": "#/definitions/guid"
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
           },
           "title": {
             "type": "string"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
           }
         }
       }
     },
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "read_more",
-        "body"
-      ],
-      "properties": {
-        "read_more": {
-          "type": "string"
-        },
-        "body": {
-          "$ref": "#/definitions/body"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
       }
     },
-    "external_link": {
+    "image": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
+        "alt_text": {
           "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "url": {
           "type": "string",
@@ -554,17 +1056,17 @@
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -581,212 +1083,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -845,98 +1157,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -945,10 +1290,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -956,6 +1297,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -978,79 +1323,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1062,13 +1536,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1076,61 +1544,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1138,418 +1569,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1559,9 +1583,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/topical_event_about_page/notification/schema.json
+++ b/dist/formats/topical_event_about_page/notification/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "content_id",
@@ -17,12 +16,25 @@
     "title",
     "update_type"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -34,60 +46,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -252,60 +212,9 @@
         "written_statement"
       ]
     },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "topical_event_about_page"
-      ]
-    },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
-    },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
     "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "govuk_request_id": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
     },
     "expanded_links": {
       "type": "object",
@@ -314,39 +223,565 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "govuk_request_id": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "topical_event_about_page"
+      ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "base_path_less_frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "required": [
+        "read_more",
+        "body"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "body": {
+          "$ref": "#/definitions/body"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "read_more": {
+          "type": "string"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "required": [
+        "title",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
     "frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "base_path",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
-          "document_type": {
-            "type": "string"
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
           },
-          "schema_name": {
-            "type": "string"
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
           },
-          "public_updated_at": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
             "type": "string"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
-            "type": "string"
+          "country": {
+            "$ref": "#/definitions/country"
           },
           "description": {
             "anyOf": [
@@ -358,36 +793,11 @@
               }
             ]
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "details": {
+            "type": "object",
+            "additionalProperties": true
           },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
+          "document_type": {
             "type": "string"
           },
           "links": {
@@ -397,133 +807,205 @@
                 "$ref": "#/definitions/frontend_links"
               }
             }
-          }
-        }
-      }
-    },
-    "base_path_less_frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "locale"
-        ],
-        "properties": {
-          "document_type": {
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
             "type": "string"
           },
           "schema_name": {
             "type": "string"
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
+          "title": {
+            "type": "string"
           },
           "web_url": {
             "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
             "type": "string",
             "format": "uri"
           },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
           },
-          "public_updated_at": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
             "type": "string"
           },
-          "content_id": {
-            "$ref": "#/definitions/guid"
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
           },
           "title": {
             "type": "string"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
           }
         }
       }
     },
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "read_more",
-        "body"
-      ],
-      "properties": {
-        "read_more": {
-          "type": "string"
-        },
-        "body": {
-          "$ref": "#/definitions/body"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
       }
     },
-    "external_link": {
+    "image": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
+        "alt_text": {
           "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "url": {
           "type": "string",
@@ -534,17 +1016,17 @@
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -561,212 +1043,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -825,98 +1117,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -925,10 +1250,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -936,6 +1257,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -958,79 +1283,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1042,13 +1496,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1056,61 +1504,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1118,418 +1529,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1539,9 +1543,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/topical_event_about_page/publisher_v2/links.json
+++ b/dist/formats/topical_event_about_page/publisher_v2/links.json
@@ -3,25 +3,10 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "previous_version": {
-      "type": "string"
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/guid_list"
-        },
         "mainstream_browse_pages": {
           "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/guid_list"
@@ -30,8 +15,12 @@
           "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/guid_list"
         },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
@@ -51,38 +40,50 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/guid_list"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
         }
       }
+    },
+    "previous_version": {
+      "type": "string"
     }
   },
   "definitions": {
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
     "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
       "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
     "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
         {
           "type": "string"
@@ -90,22 +91,158 @@
         {
           "type": "null"
         }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+      ]
     },
-    "external_related_links": {
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -116,20 +253,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -146,212 +616,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -410,98 +690,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -510,10 +823,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -521,6 +830,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -543,79 +856,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -627,13 +1069,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -641,61 +1077,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -703,418 +1102,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1124,9 +1116,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/topical_event_about_page/publisher_v2/schema.json
+++ b/dist/formats/topical_event_about_page/publisher_v2/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "title",
     "details",
@@ -13,12 +12,22 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "description": {
       "anyOf": [
@@ -30,84 +39,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "access_limited": {
-      "$ref": "#/definitions/access_limited"
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "change_note": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "previous_version": {
-      "type": "string"
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "links": {
-      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string",
@@ -272,66 +205,109 @@
         "written_statement"
       ]
     },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "topical_event_about_page"
       ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "read_more",
-        "body"
-      ],
-      "properties": {
-        "read_more": {
-          "type": "string"
-        },
-        "body": {
-          "$ref": "#/definitions/body"
-        }
-      }
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policy_areas": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
     },
     "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
       "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
     "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
         {
           "type": "string"
@@ -339,22 +315,174 @@
         {
           "type": "null"
         }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+      ]
     },
-    "external_related_links": {
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "required": [
+        "read_more",
+        "body"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "body": {
+          "$ref": "#/definitions/body"
+        },
+        "read_more": {
+          "type": "string"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -365,20 +493,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -395,212 +856,31 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
         }
       }
     },
-    "redirect_route": {
+    "links": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
       "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
         }
       }
     },
@@ -659,98 +939,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -759,10 +1072,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -770,6 +1079,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -792,79 +1105,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -876,13 +1318,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -890,61 +1326,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -952,418 +1351,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1373,9 +1365,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/transaction/frontend/schema.json
+++ b/dist/formats/transaction/frontend/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "links",
@@ -12,12 +11,25 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -29,119 +41,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_pages": {
-          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "meets_user_needs": {
-          "description": "The user needs this piece of content meets.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "organisations": {
-          "description": "All organisations linked to this content item. This should include lead organisations.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "parent": {
-          "description": "The parent content item.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policy_areas": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "primary_publishing_organisation": {
-          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "available_translations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "children": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policies": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "document_collections": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "child_taxons": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -306,67 +207,645 @@
         "written_statement"
       ]
     },
+    "email_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "available_translations": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "policies": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policy_areas": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "primary_publishing_organisation": {
+          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "transaction"
       ]
     },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    "title": {
+      "type": "string"
     },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
-    "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
     },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "base_path_less_frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "department_analytics_profile": {
+          "description": "Analytics identifier with which to record views",
+          "type": "string"
+        },
+        "downtime_message": {
+          "description": "Text of the message alerting the user of service downtime",
+          "type": "string"
+        },
+        "external_related_links": {
+          "$ref": "#/definitions/external_related_links"
+        },
+        "introductory_paragraph": {
+          "$ref": "#/definitions/body_html_and_govspeak"
+        },
+        "more_information": {
+          "$ref": "#/definitions/body_html_and_govspeak"
+        },
+        "other_ways_to_apply": {
+          "$ref": "#/definitions/body_html_and_govspeak"
+        },
+        "start_button_text": {
+          "$ref": "#/definitions/start_button_text"
+        },
+        "transaction_start_link": {
+          "description": "Link the Start button will lead the user to.",
+          "type": "string",
+          "format": "uri"
+        },
+        "what_you_need_to_know": {
+          "$ref": "#/definitions/body_html_and_govspeak"
+        },
+        "will_continue_on": {
+          "$ref": "#/definitions/will_continue_on"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "required": [
+        "title",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
     "frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "base_path",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
-          "document_type": {
-            "type": "string"
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
           },
-          "schema_name": {
-            "type": "string"
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
           },
-          "public_updated_at": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
             "type": "string"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
-            "type": "string"
+          "country": {
+            "$ref": "#/definitions/country"
           },
           "description": {
             "anyOf": [
@@ -378,36 +857,11 @@
               }
             ]
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "details": {
+            "type": "object",
+            "additionalProperties": true
           },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
+          "document_type": {
             "type": "string"
           },
           "links": {
@@ -417,157 +871,205 @@
                 "$ref": "#/definitions/frontend_links"
               }
             }
-          }
-        }
-      }
-    },
-    "base_path_less_frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "locale"
-        ],
-        "properties": {
-          "document_type": {
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
             "type": "string"
           },
           "schema_name": {
             "type": "string"
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
+          "title": {
+            "type": "string"
           },
           "web_url": {
             "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
             "type": "string",
             "format": "uri"
           },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
           },
-          "public_updated_at": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
             "type": "string"
           },
-          "content_id": {
-            "$ref": "#/definitions/guid"
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
           },
           "title": {
             "type": "string"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
           }
         }
       }
     },
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "introductory_paragraph": {
-          "$ref": "#/definitions/body_html_and_govspeak"
-        },
-        "will_continue_on": {
-          "$ref": "#/definitions/will_continue_on"
-        },
-        "transaction_start_link": {
-          "description": "Link the Start button will lead the user to.",
-          "type": "string",
-          "format": "uri"
-        },
-        "more_information": {
-          "$ref": "#/definitions/body_html_and_govspeak"
-        },
-        "other_ways_to_apply": {
-          "$ref": "#/definitions/body_html_and_govspeak"
-        },
-        "what_you_need_to_know": {
-          "$ref": "#/definitions/body_html_and_govspeak"
-        },
-        "external_related_links": {
-          "$ref": "#/definitions/external_related_links"
-        },
-        "department_analytics_profile": {
-          "description": "Analytics identifier with which to record views",
-          "type": "string"
-        },
-        "downtime_message": {
-          "description": "Text of the message alerting the user of service downtime",
-          "type": "string"
-        },
-        "start_button_text": {
-          "$ref": "#/definitions/start_button_text"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
       }
     },
-    "external_link": {
+    "image": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
+        "alt_text": {
           "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "url": {
           "type": "string",
@@ -578,17 +1080,17 @@
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -605,212 +1107,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -869,98 +1181,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -969,10 +1314,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -980,6 +1321,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -1002,79 +1347,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1086,13 +1560,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1100,61 +1568,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1162,418 +1593,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1583,9 +1607,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/transaction/notification/schema.json
+++ b/dist/formats/transaction/notification/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "content_id",
@@ -17,12 +16,25 @@
     "title",
     "update_type"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -34,60 +46,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -252,60 +212,9 @@
         "written_statement"
       ]
     },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "transaction"
-      ]
-    },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
-    },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
     "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "govuk_request_id": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
     },
     "expanded_links": {
       "type": "object",
@@ -314,39 +223,589 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "govuk_request_id": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "transaction"
+      ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "base_path_less_frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "department_analytics_profile": {
+          "description": "Analytics identifier with which to record views",
+          "type": "string"
+        },
+        "downtime_message": {
+          "description": "Text of the message alerting the user of service downtime",
+          "type": "string"
+        },
+        "external_related_links": {
+          "$ref": "#/definitions/external_related_links"
+        },
+        "introductory_paragraph": {
+          "$ref": "#/definitions/body_html_and_govspeak"
+        },
+        "more_information": {
+          "$ref": "#/definitions/body_html_and_govspeak"
+        },
+        "other_ways_to_apply": {
+          "$ref": "#/definitions/body_html_and_govspeak"
+        },
+        "start_button_text": {
+          "$ref": "#/definitions/start_button_text"
+        },
+        "transaction_start_link": {
+          "description": "Link the Start button will lead the user to.",
+          "type": "string",
+          "format": "uri"
+        },
+        "what_you_need_to_know": {
+          "$ref": "#/definitions/body_html_and_govspeak"
+        },
+        "will_continue_on": {
+          "$ref": "#/definitions/will_continue_on"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "required": [
+        "title",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
     "frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "base_path",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
-          "document_type": {
-            "type": "string"
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
           },
-          "schema_name": {
-            "type": "string"
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
           },
-          "public_updated_at": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
             "type": "string"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
-            "type": "string"
+          "country": {
+            "$ref": "#/definitions/country"
           },
           "description": {
             "anyOf": [
@@ -358,36 +817,11 @@
               }
             ]
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "details": {
+            "type": "object",
+            "additionalProperties": true
           },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
+          "document_type": {
             "type": "string"
           },
           "links": {
@@ -397,157 +831,205 @@
                 "$ref": "#/definitions/frontend_links"
               }
             }
-          }
-        }
-      }
-    },
-    "base_path_less_frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "locale"
-        ],
-        "properties": {
-          "document_type": {
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
             "type": "string"
           },
           "schema_name": {
             "type": "string"
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
+          "title": {
+            "type": "string"
           },
           "web_url": {
             "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
             "type": "string",
             "format": "uri"
           },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
           },
-          "public_updated_at": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
             "type": "string"
           },
-          "content_id": {
-            "$ref": "#/definitions/guid"
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
           },
           "title": {
             "type": "string"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
           }
         }
       }
     },
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "introductory_paragraph": {
-          "$ref": "#/definitions/body_html_and_govspeak"
-        },
-        "will_continue_on": {
-          "$ref": "#/definitions/will_continue_on"
-        },
-        "transaction_start_link": {
-          "description": "Link the Start button will lead the user to.",
-          "type": "string",
-          "format": "uri"
-        },
-        "more_information": {
-          "$ref": "#/definitions/body_html_and_govspeak"
-        },
-        "other_ways_to_apply": {
-          "$ref": "#/definitions/body_html_and_govspeak"
-        },
-        "what_you_need_to_know": {
-          "$ref": "#/definitions/body_html_and_govspeak"
-        },
-        "external_related_links": {
-          "$ref": "#/definitions/external_related_links"
-        },
-        "department_analytics_profile": {
-          "description": "Analytics identifier with which to record views",
-          "type": "string"
-        },
-        "downtime_message": {
-          "description": "Text of the message alerting the user of service downtime",
-          "type": "string"
-        },
-        "start_button_text": {
-          "$ref": "#/definitions/start_button_text"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
       }
     },
-    "external_link": {
+    "image": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
+        "alt_text": {
           "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "url": {
           "type": "string",
@@ -558,17 +1040,17 @@
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -585,212 +1067,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -849,98 +1141,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -949,10 +1274,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -960,6 +1281,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -982,79 +1307,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1066,13 +1520,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1080,61 +1528,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1142,418 +1553,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1563,9 +1567,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/transaction/publisher_v2/links.json
+++ b/dist/formats/transaction/publisher_v2/links.json
@@ -3,25 +3,10 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "previous_version": {
-      "type": "string"
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/guid_list"
-        },
         "mainstream_browse_pages": {
           "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/guid_list"
@@ -30,8 +15,12 @@
           "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/guid_list"
         },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
@@ -51,38 +40,50 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/guid_list"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
         }
       }
+    },
+    "previous_version": {
+      "type": "string"
     }
   },
   "definitions": {
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
     "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
       "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
     "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
         {
           "type": "string"
@@ -90,22 +91,158 @@
         {
           "type": "null"
         }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+      ]
     },
-    "external_related_links": {
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -116,20 +253,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -146,212 +616,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -410,98 +690,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -510,10 +823,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -521,6 +830,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -543,79 +856,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -627,13 +1069,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -641,61 +1077,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -703,418 +1102,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1124,9 +1116,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/transaction/publisher_v2/schema.json
+++ b/dist/formats/transaction/publisher_v2/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "title",
     "details",
@@ -13,12 +12,22 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "description": {
       "anyOf": [
@@ -30,84 +39,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "access_limited": {
-      "$ref": "#/definitions/access_limited"
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "change_note": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "previous_version": {
-      "type": "string"
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "links": {
-      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string",
@@ -272,41 +205,228 @@
         "written_statement"
       ]
     },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "transaction"
       ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "introductory_paragraph": {
-          "$ref": "#/definitions/body_html_and_govspeak"
-        },
-        "will_continue_on": {
-          "$ref": "#/definitions/will_continue_on"
-        },
-        "transaction_start_link": {
-          "description": "Link the Start button will lead the user to.",
-          "type": "string",
-          "format": "uri"
-        },
-        "more_information": {
-          "$ref": "#/definitions/body_html_and_govspeak"
-        },
-        "other_ways_to_apply": {
-          "$ref": "#/definitions/body_html_and_govspeak"
-        },
-        "what_you_need_to_know": {
-          "$ref": "#/definitions/body_html_and_govspeak"
-        },
-        "external_related_links": {
-          "$ref": "#/definitions/external_related_links"
-        },
         "department_analytics_profile": {
           "description": "Analytics identifier with which to record views",
           "type": "string"
@@ -315,70 +435,78 @@
           "description": "Text of the message alerting the user of service downtime",
           "type": "string"
         },
+        "external_related_links": {
+          "$ref": "#/definitions/external_related_links"
+        },
+        "introductory_paragraph": {
+          "$ref": "#/definitions/body_html_and_govspeak"
+        },
+        "more_information": {
+          "$ref": "#/definitions/body_html_and_govspeak"
+        },
+        "other_ways_to_apply": {
+          "$ref": "#/definitions/body_html_and_govspeak"
+        },
         "start_button_text": {
           "$ref": "#/definitions/start_button_text"
-        }
-      }
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policy_areas": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
         },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        "transaction_start_link": {
+          "description": "Link the Start button will lead the user to.",
+          "type": "string",
+          "format": "uri"
+        },
+        "what_you_need_to_know": {
+          "$ref": "#/definitions/body_html_and_govspeak"
+        },
+        "will_continue_on": {
+          "$ref": "#/definitions/will_continue_on"
         }
       }
     },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -389,20 +517,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -419,212 +880,31 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
         }
       }
     },
-    "redirect_route": {
+    "links": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
       "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
         }
       }
     },
@@ -683,98 +963,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -783,10 +1096,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -794,6 +1103,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -816,79 +1129,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -900,13 +1342,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -914,61 +1350,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -976,418 +1375,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1397,9 +1389,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/travel_advice/frontend/schema.json
+++ b/dist/formats/travel_advice/frontend/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "links",
@@ -12,12 +11,25 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -29,122 +41,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "related": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_pages": {
-          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "meets_user_needs": {
-          "description": "The user needs this piece of content meets.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "organisations": {
-          "description": "All organisations linked to this content item. This should include lead organisations.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "parent": {
-          "description": "The parent content item.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policy_areas": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "primary_publishing_organisation": {
-          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "available_translations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "children": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policies": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "document_collections": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "child_taxons": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -309,67 +207,665 @@
         "written_statement"
       ]
     },
+    "email_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "available_translations": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "policies": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policy_areas": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "primary_publishing_organisation": {
+          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "related": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "travel_advice"
       ]
     },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    "title": {
+      "type": "string"
     },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
-    "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
     },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "base_path_less_frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "required": [
+        "summary",
+        "country",
+        "updated_at",
+        "reviewed_at",
+        "change_description",
+        "alert_status",
+        "email_signup_link",
+        "parts"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alert_status": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "change_description": {
+          "type": "string"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "country": {
+          "$ref": "#/definitions/country"
+        },
+        "document": {
+          "$ref": "#/definitions/asset_link"
+        },
+        "email_signup_link": {
+          "$ref": "#/definitions/email_signup_link"
+        },
+        "image": {
+          "$ref": "#/definitions/asset_link"
+        },
+        "max_cache_time": {
+          "$ref": "#/definitions/max_cache_time"
+        },
+        "parts": {
+          "$ref": "#/definitions/parts"
+        },
+        "publishing_request_id": {
+          "$ref": "#/definitions/publishing_request_id"
+        },
+        "reviewed_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "summary": {
+          "type": "string"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "required": [
+        "title",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
     "frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "base_path",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
-          "document_type": {
-            "type": "string"
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
           },
-          "schema_name": {
-            "type": "string"
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
           },
-          "public_updated_at": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
             "type": "string"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
-            "type": "string"
+          "country": {
+            "$ref": "#/definitions/country"
           },
           "description": {
             "anyOf": [
@@ -381,36 +877,11 @@
               }
             ]
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "details": {
+            "type": "object",
+            "additionalProperties": true
           },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
+          "document_type": {
             "type": "string"
           },
           "links": {
@@ -420,174 +891,205 @@
                 "$ref": "#/definitions/frontend_links"
               }
             }
-          }
-        }
-      }
-    },
-    "base_path_less_frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "locale"
-        ],
-        "properties": {
-          "document_type": {
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
             "type": "string"
           },
           "schema_name": {
             "type": "string"
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
+          "title": {
+            "type": "string"
           },
           "web_url": {
             "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
             "type": "string",
             "format": "uri"
           },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
           },
-          "public_updated_at": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
             "type": "string"
           },
-          "content_id": {
-            "$ref": "#/definitions/guid"
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
           },
           "title": {
             "type": "string"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
           }
         }
       }
     },
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "summary",
-        "country",
-        "updated_at",
-        "reviewed_at",
-        "change_description",
-        "alert_status",
-        "email_signup_link",
-        "parts"
-      ],
-      "properties": {
-        "summary": {
-          "type": "string"
-        },
-        "country": {
-          "$ref": "#/definitions/country"
-        },
-        "updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "reviewed_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "change_description": {
-          "type": "string"
-        },
-        "alert_status": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "email_signup_link": {
-          "$ref": "#/definitions/email_signup_link"
-        },
-        "image": {
-          "$ref": "#/definitions/asset_link"
-        },
-        "document": {
-          "$ref": "#/definitions/asset_link"
-        },
-        "parts": {
-          "$ref": "#/definitions/parts"
-        },
-        "max_cache_time": {
-          "$ref": "#/definitions/max_cache_time"
-        },
-        "publishing_request_id": {
-          "$ref": "#/definitions/publishing_request_id"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
       }
     },
-    "external_link": {
+    "image": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
+        "alt_text": {
           "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "url": {
           "type": "string",
@@ -598,17 +1100,17 @@
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -625,212 +1127,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -889,98 +1201,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -989,10 +1334,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -1000,6 +1341,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -1022,79 +1367,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1106,13 +1580,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1120,61 +1588,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1182,418 +1613,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1603,9 +1627,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/travel_advice/notification/schema.json
+++ b/dist/formats/travel_advice/notification/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "content_id",
@@ -17,12 +16,25 @@
     "title",
     "update_type"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -34,60 +46,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -252,60 +212,9 @@
         "written_statement"
       ]
     },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "travel_advice"
-      ]
-    },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
-    },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
     "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "govuk_request_id": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
     },
     "expanded_links": {
       "type": "object",
@@ -314,39 +223,606 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "govuk_request_id": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "travel_advice"
+      ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "base_path_less_frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "required": [
+        "summary",
+        "country",
+        "updated_at",
+        "reviewed_at",
+        "change_description",
+        "alert_status",
+        "email_signup_link",
+        "parts"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alert_status": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "change_description": {
+          "type": "string"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "country": {
+          "$ref": "#/definitions/country"
+        },
+        "document": {
+          "$ref": "#/definitions/asset_link"
+        },
+        "email_signup_link": {
+          "$ref": "#/definitions/email_signup_link"
+        },
+        "image": {
+          "$ref": "#/definitions/asset_link"
+        },
+        "max_cache_time": {
+          "$ref": "#/definitions/max_cache_time"
+        },
+        "parts": {
+          "$ref": "#/definitions/parts"
+        },
+        "publishing_request_id": {
+          "$ref": "#/definitions/publishing_request_id"
+        },
+        "reviewed_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "summary": {
+          "type": "string"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "required": [
+        "title",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
     "frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "base_path",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
-          "document_type": {
-            "type": "string"
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
           },
-          "schema_name": {
-            "type": "string"
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
           },
-          "public_updated_at": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
             "type": "string"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
-            "type": "string"
+          "country": {
+            "$ref": "#/definitions/country"
           },
           "description": {
             "anyOf": [
@@ -358,36 +834,11 @@
               }
             ]
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "details": {
+            "type": "object",
+            "additionalProperties": true
           },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
+          "document_type": {
             "type": "string"
           },
           "links": {
@@ -397,174 +848,205 @@
                 "$ref": "#/definitions/frontend_links"
               }
             }
-          }
-        }
-      }
-    },
-    "base_path_less_frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "locale"
-        ],
-        "properties": {
-          "document_type": {
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
             "type": "string"
           },
           "schema_name": {
             "type": "string"
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
+          "title": {
+            "type": "string"
           },
           "web_url": {
             "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
             "type": "string",
             "format": "uri"
           },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
           },
-          "public_updated_at": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
             "type": "string"
           },
-          "content_id": {
-            "$ref": "#/definitions/guid"
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
           },
           "title": {
             "type": "string"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
           }
         }
       }
     },
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "summary",
-        "country",
-        "updated_at",
-        "reviewed_at",
-        "change_description",
-        "alert_status",
-        "email_signup_link",
-        "parts"
-      ],
-      "properties": {
-        "summary": {
-          "type": "string"
-        },
-        "country": {
-          "$ref": "#/definitions/country"
-        },
-        "updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "reviewed_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "change_description": {
-          "type": "string"
-        },
-        "alert_status": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "email_signup_link": {
-          "$ref": "#/definitions/email_signup_link"
-        },
-        "image": {
-          "$ref": "#/definitions/asset_link"
-        },
-        "document": {
-          "$ref": "#/definitions/asset_link"
-        },
-        "parts": {
-          "$ref": "#/definitions/parts"
-        },
-        "max_cache_time": {
-          "$ref": "#/definitions/max_cache_time"
-        },
-        "publishing_request_id": {
-          "$ref": "#/definitions/publishing_request_id"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
       }
     },
-    "external_link": {
+    "image": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
+        "alt_text": {
           "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "url": {
           "type": "string",
@@ -575,17 +1057,17 @@
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -602,212 +1084,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -866,98 +1158,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -966,10 +1291,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -977,6 +1298,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -999,79 +1324,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1083,13 +1537,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1097,61 +1545,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1159,418 +1570,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1580,9 +1584,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/travel_advice/publisher_v2/links.json
+++ b/dist/formats/travel_advice/publisher_v2/links.json
@@ -3,28 +3,10 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "previous_version": {
-      "type": "string"
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "related": {
-          "$ref": "#/definitions/guid_list"
-        },
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/guid_list"
-        },
         "mainstream_browse_pages": {
           "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/guid_list"
@@ -33,8 +15,12 @@
           "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/guid_list"
         },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
@@ -54,38 +40,53 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "related": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/guid_list"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
         }
       }
+    },
+    "previous_version": {
+      "type": "string"
     }
   },
   "definitions": {
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
     "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
       "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
     "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
         {
           "type": "string"
@@ -93,22 +94,158 @@
         {
           "type": "null"
         }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+      ]
     },
-    "external_related_links": {
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -119,20 +256,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -149,212 +619,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -413,98 +693,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -513,10 +826,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -524,6 +833,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -546,79 +859,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -630,13 +1072,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -644,61 +1080,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -706,418 +1105,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1127,9 +1119,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/travel_advice/publisher_v2/schema.json
+++ b/dist/formats/travel_advice/publisher_v2/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "title",
     "details",
@@ -13,12 +12,22 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "description": {
       "anyOf": [
@@ -30,84 +39,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "access_limited": {
-      "$ref": "#/definitions/access_limited"
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "change_note": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "previous_version": {
-      "type": "string"
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "links": {
-      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string",
@@ -272,17 +205,226 @@
         "written_statement"
       ]
     },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "travel_advice"
       ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
-    "details": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
       "type": "object",
       "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
       "required": [
         "summary",
         "country",
@@ -293,29 +435,22 @@
         "email_signup_link",
         "parts"
       ],
+      "additionalProperties": false,
       "properties": {
-        "summary": {
-          "$ref": "#/definitions/multiple_content_types"
-        },
-        "country": {
-          "$ref": "#/definitions/country"
-        },
-        "updated_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "reviewed_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "change_description": {
-          "type": "string"
-        },
         "alert_status": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "change_description": {
+          "type": "string"
+        },
+        "country": {
+          "$ref": "#/definitions/country"
+        },
+        "document": {
+          "$ref": "#/definitions/asset_link"
         },
         "email_signup_link": {
           "$ref": "#/definitions/email_signup_link"
@@ -323,79 +458,72 @@
         "image": {
           "$ref": "#/definitions/asset_link"
         },
-        "document": {
-          "$ref": "#/definitions/asset_link"
+        "max_cache_time": {
+          "$ref": "#/definitions/max_cache_time"
         },
         "parts": {
           "$ref": "#/definitions/parts"
         },
-        "max_cache_time": {
-          "$ref": "#/definitions/max_cache_time"
-        },
         "publishing_request_id": {
           "$ref": "#/definitions/publishing_request_id"
-        }
-      }
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policy_areas": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
         },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
+        "reviewed_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "summary": {
+          "$ref": "#/definitions/multiple_content_types"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
         }
       }
     },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -406,20 +534,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -436,212 +897,31 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
         }
       }
     },
-    "redirect_route": {
+    "links": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
       "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
         }
       }
     },
@@ -700,98 +980,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -800,10 +1113,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -811,6 +1120,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -833,79 +1146,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -917,13 +1359,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -931,61 +1367,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -993,418 +1392,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1414,9 +1406,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/travel_advice_index/frontend/schema.json
+++ b/dist/formats/travel_advice_index/frontend/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "links",
@@ -12,12 +11,25 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -29,122 +41,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "related": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_pages": {
-          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "meets_user_needs": {
-          "description": "The user needs this piece of content meets.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "organisations": {
-          "description": "All organisations linked to this content item. This should include lead organisations.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "parent": {
-          "description": "The parent content item.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policy_areas": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "primary_publishing_organisation": {
-          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "available_translations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "children": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policies": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "document_collections": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "child_taxons": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -309,67 +207,626 @@
         "written_statement"
       ]
     },
+    "email_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "available_translations": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "policies": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policy_areas": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "primary_publishing_organisation": {
+          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "related": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "travel_advice_index"
       ]
     },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    "title": {
+      "type": "string"
     },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
-    "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
     },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "base_path_less_frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "required": [
+        "email_signup_link"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "email_signup_link": {
+          "$ref": "#/definitions/email_signup_link"
+        },
+        "max_cache_time": {
+          "$ref": "#/definitions/max_cache_time"
+        },
+        "publishing_request_id": {
+          "$ref": "#/definitions/publishing_request_id"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "required": [
+        "title",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
     "frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "base_path",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
-          "document_type": {
-            "type": "string"
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
           },
-          "schema_name": {
-            "type": "string"
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
           },
-          "public_updated_at": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
             "type": "string"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
-            "type": "string"
+          "country": {
+            "$ref": "#/definitions/country"
           },
           "description": {
             "anyOf": [
@@ -381,36 +838,11 @@
               }
             ]
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "details": {
+            "type": "object",
+            "additionalProperties": true
           },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
+          "document_type": {
             "type": "string"
           },
           "links": {
@@ -420,135 +852,205 @@
                 "$ref": "#/definitions/frontend_links"
               }
             }
-          }
-        }
-      }
-    },
-    "base_path_less_frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "locale"
-        ],
-        "properties": {
-          "document_type": {
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
             "type": "string"
           },
           "schema_name": {
             "type": "string"
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
+          "title": {
+            "type": "string"
           },
           "web_url": {
             "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
             "type": "string",
             "format": "uri"
           },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
           },
-          "public_updated_at": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
             "type": "string"
           },
-          "content_id": {
-            "$ref": "#/definitions/guid"
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
           },
           "title": {
             "type": "string"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
           }
         }
       }
     },
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "email_signup_link"
-      ],
-      "properties": {
-        "email_signup_link": {
-          "$ref": "#/definitions/email_signup_link"
-        },
-        "max_cache_time": {
-          "$ref": "#/definitions/max_cache_time"
-        },
-        "publishing_request_id": {
-          "$ref": "#/definitions/publishing_request_id"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
       }
     },
-    "external_link": {
+    "image": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
+        "alt_text": {
           "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "url": {
           "type": "string",
@@ -559,17 +1061,17 @@
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -586,212 +1088,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -850,98 +1162,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -950,10 +1295,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -961,6 +1302,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -983,79 +1328,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1067,13 +1541,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1081,61 +1549,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1143,418 +1574,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1564,9 +1588,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/travel_advice_index/notification/schema.json
+++ b/dist/formats/travel_advice_index/notification/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "content_id",
@@ -17,12 +16,25 @@
     "title",
     "update_type"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -34,60 +46,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -252,60 +212,9 @@
         "written_statement"
       ]
     },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "travel_advice_index"
-      ]
-    },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
-    },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
     "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "govuk_request_id": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
     },
     "expanded_links": {
       "type": "object",
@@ -314,39 +223,567 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "govuk_request_id": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "travel_advice_index"
+      ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "base_path_less_frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "required": [
+        "email_signup_link"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "email_signup_link": {
+          "$ref": "#/definitions/email_signup_link"
+        },
+        "max_cache_time": {
+          "$ref": "#/definitions/max_cache_time"
+        },
+        "publishing_request_id": {
+          "$ref": "#/definitions/publishing_request_id"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "required": [
+        "title",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
     "frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "base_path",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
-          "document_type": {
-            "type": "string"
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
           },
-          "schema_name": {
-            "type": "string"
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
           },
-          "public_updated_at": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
             "type": "string"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
-            "type": "string"
+          "country": {
+            "$ref": "#/definitions/country"
           },
           "description": {
             "anyOf": [
@@ -358,36 +795,11 @@
               }
             ]
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "details": {
+            "type": "object",
+            "additionalProperties": true
           },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
+          "document_type": {
             "type": "string"
           },
           "links": {
@@ -397,135 +809,205 @@
                 "$ref": "#/definitions/frontend_links"
               }
             }
-          }
-        }
-      }
-    },
-    "base_path_less_frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "locale"
-        ],
-        "properties": {
-          "document_type": {
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
             "type": "string"
           },
           "schema_name": {
             "type": "string"
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
+          "title": {
+            "type": "string"
           },
           "web_url": {
             "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
             "type": "string",
             "format": "uri"
           },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
           },
-          "public_updated_at": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
             "type": "string"
           },
-          "content_id": {
-            "$ref": "#/definitions/guid"
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
           },
           "title": {
             "type": "string"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
           }
         }
       }
     },
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "email_signup_link"
-      ],
-      "properties": {
-        "email_signup_link": {
-          "$ref": "#/definitions/email_signup_link"
-        },
-        "max_cache_time": {
-          "$ref": "#/definitions/max_cache_time"
-        },
-        "publishing_request_id": {
-          "$ref": "#/definitions/publishing_request_id"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
       }
     },
-    "external_link": {
+    "image": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
+        "alt_text": {
           "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "url": {
           "type": "string",
@@ -536,17 +1018,17 @@
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -563,212 +1045,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -827,98 +1119,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -927,10 +1252,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -938,6 +1259,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -960,79 +1285,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1044,13 +1498,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1058,61 +1506,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1120,418 +1531,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1541,9 +1545,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/travel_advice_index/publisher_v2/links.json
+++ b/dist/formats/travel_advice_index/publisher_v2/links.json
@@ -3,28 +3,10 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "previous_version": {
-      "type": "string"
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "related": {
-          "$ref": "#/definitions/guid_list"
-        },
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/guid_list"
-        },
         "mainstream_browse_pages": {
           "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/guid_list"
@@ -33,8 +15,12 @@
           "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/guid_list"
         },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
@@ -54,38 +40,53 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "related": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/guid_list"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
         }
       }
+    },
+    "previous_version": {
+      "type": "string"
     }
   },
   "definitions": {
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
     "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
       "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
     "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
         {
           "type": "string"
@@ -93,22 +94,158 @@
         {
           "type": "null"
         }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+      ]
     },
-    "external_related_links": {
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -119,20 +256,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -149,212 +619,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -413,98 +693,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -513,10 +826,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -524,6 +833,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -546,79 +859,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -630,13 +1072,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -644,61 +1080,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -706,418 +1105,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1127,9 +1119,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/travel_advice_index/publisher_v2/schema.json
+++ b/dist/formats/travel_advice_index/publisher_v2/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "title",
     "details",
@@ -13,12 +12,22 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "description": {
       "anyOf": [
@@ -30,84 +39,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "access_limited": {
-      "$ref": "#/definitions/access_limited"
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "change_note": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "previous_version": {
-      "type": "string"
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "links": {
-      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string",
@@ -272,20 +205,230 @@
         "written_statement"
       ]
     },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "travel_advice_index"
       ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
-    "details": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
       "type": "object",
       "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
       "required": [
         "email_signup_link"
       ],
+      "additionalProperties": false,
       "properties": {
         "email_signup_link": {
           "$ref": "#/definitions/email_signup_link"
@@ -298,65 +441,50 @@
         }
       }
     },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policy_areas": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -367,20 +495,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -397,212 +858,31 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
         }
       }
     },
-    "redirect_route": {
+    "links": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
       "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
         }
       }
     },
@@ -661,98 +941,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -761,10 +1074,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -772,6 +1081,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -794,79 +1107,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -878,13 +1320,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -892,61 +1328,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -954,418 +1353,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1375,9 +1367,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/unpublishing/frontend/schema.json
+++ b/dist/formats/unpublishing/frontend/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "links",
@@ -12,12 +11,25 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -29,119 +41,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_pages": {
-          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "meets_user_needs": {
-          "description": "The user needs this piece of content meets.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "organisations": {
-          "description": "All organisations linked to this content item. This should include lead organisations.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "parent": {
-          "description": "The parent content item.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policy_areas": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "primary_publishing_organisation": {
-          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "available_translations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "children": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policies": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "document_collections": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "child_taxons": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -306,67 +207,634 @@
         "written_statement"
       ]
     },
+    "email_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "available_translations": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "policies": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policy_areas": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "primary_publishing_organisation": {
+          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "unpublishing"
       ]
     },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    "title": {
+      "type": "string"
     },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
-    "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
     },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "base_path_less_frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "required": [
+        "unpublished_at"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alternative_url": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "uri"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "explanation": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "public_updated_at": {
+          "$ref": "#/definitions/public_updated_at"
+        },
+        "unpublished_at": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "required": [
+        "title",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
     "frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "base_path",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
-          "document_type": {
-            "type": "string"
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
           },
-          "schema_name": {
-            "type": "string"
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
           },
-          "public_updated_at": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
             "type": "string"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
-            "type": "string"
+          "country": {
+            "$ref": "#/definitions/country"
           },
           "description": {
             "anyOf": [
@@ -378,36 +846,11 @@
               }
             ]
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "details": {
+            "type": "object",
+            "additionalProperties": true
           },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
+          "document_type": {
             "type": "string"
           },
           "links": {
@@ -417,146 +860,205 @@
                 "$ref": "#/definitions/frontend_links"
               }
             }
-          }
-        }
-      }
-    },
-    "base_path_less_frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "locale"
-        ],
-        "properties": {
-          "document_type": {
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
             "type": "string"
           },
           "schema_name": {
             "type": "string"
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
+          "title": {
+            "type": "string"
           },
           "web_url": {
             "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
             "type": "string",
             "format": "uri"
           },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
           },
-          "public_updated_at": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
             "type": "string"
           },
-          "content_id": {
-            "$ref": "#/definitions/guid"
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
           },
           "title": {
             "type": "string"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
           }
         }
       }
     },
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "unpublished_at"
-      ],
-      "properties": {
-        "explanation": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "unpublished_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "alternative_url": {
-          "type": [
-            "string",
-            "null"
-          ],
-          "format": "uri"
-        },
-        "public_updated_at": {
-          "$ref": "#/definitions/public_updated_at"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
       }
     },
-    "external_link": {
+    "image": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
+        "alt_text": {
           "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "url": {
           "type": "string",
@@ -567,17 +1069,17 @@
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -594,212 +1096,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -858,98 +1170,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -958,10 +1303,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -969,6 +1310,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -991,79 +1336,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1075,13 +1549,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1089,61 +1557,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1151,418 +1582,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1572,9 +1596,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/unpublishing/notification/schema.json
+++ b/dist/formats/unpublishing/notification/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "content_id",
@@ -17,12 +16,25 @@
     "title",
     "update_type"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -34,60 +46,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -252,60 +212,9 @@
         "written_statement"
       ]
     },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "unpublishing"
-      ]
-    },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
-    },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
     "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "govuk_request_id": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
     },
     "expanded_links": {
       "type": "object",
@@ -314,39 +223,578 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "govuk_request_id": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "unpublishing"
+      ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "base_path_less_frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "required": [
+        "unpublished_at"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alternative_url": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "uri"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "explanation": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "public_updated_at": {
+          "$ref": "#/definitions/public_updated_at"
+        },
+        "unpublished_at": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "required": [
+        "title",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
     "frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "base_path",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
-          "document_type": {
-            "type": "string"
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
           },
-          "schema_name": {
-            "type": "string"
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
           },
-          "public_updated_at": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
             "type": "string"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
-            "type": "string"
+          "country": {
+            "$ref": "#/definitions/country"
           },
           "description": {
             "anyOf": [
@@ -358,36 +806,11 @@
               }
             ]
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "details": {
+            "type": "object",
+            "additionalProperties": true
           },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
+          "document_type": {
             "type": "string"
           },
           "links": {
@@ -397,146 +820,205 @@
                 "$ref": "#/definitions/frontend_links"
               }
             }
-          }
-        }
-      }
-    },
-    "base_path_less_frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "locale"
-        ],
-        "properties": {
-          "document_type": {
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
             "type": "string"
           },
           "schema_name": {
             "type": "string"
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
+          "title": {
+            "type": "string"
           },
           "web_url": {
             "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
             "type": "string",
             "format": "uri"
           },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
           },
-          "public_updated_at": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
             "type": "string"
           },
-          "content_id": {
-            "$ref": "#/definitions/guid"
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
           },
           "title": {
             "type": "string"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
           }
         }
       }
     },
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "unpublished_at"
-      ],
-      "properties": {
-        "explanation": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "unpublished_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "alternative_url": {
-          "type": [
-            "string",
-            "null"
-          ],
-          "format": "uri"
-        },
-        "public_updated_at": {
-          "$ref": "#/definitions/public_updated_at"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
       }
     },
-    "external_link": {
+    "image": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
+        "alt_text": {
           "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "url": {
           "type": "string",
@@ -547,17 +1029,17 @@
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -574,212 +1056,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -838,98 +1130,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -938,10 +1263,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -949,6 +1270,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -971,79 +1296,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1055,13 +1509,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1069,61 +1517,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1131,418 +1542,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1552,9 +1556,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/unpublishing/publisher_v2/links.json
+++ b/dist/formats/unpublishing/publisher_v2/links.json
@@ -3,25 +3,10 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "previous_version": {
-      "type": "string"
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/guid_list"
-        },
         "mainstream_browse_pages": {
           "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/guid_list"
@@ -30,8 +15,12 @@
           "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/guid_list"
         },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
@@ -51,38 +40,50 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/guid_list"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
         }
       }
+    },
+    "previous_version": {
+      "type": "string"
     }
   },
   "definitions": {
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
     "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
       "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
     "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
         {
           "type": "string"
@@ -90,22 +91,158 @@
         {
           "type": "null"
         }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+      ]
     },
-    "external_related_links": {
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -116,20 +253,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -146,212 +616,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -410,98 +690,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -510,10 +823,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -521,6 +830,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -543,79 +856,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -627,13 +1069,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -641,61 +1077,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -703,418 +1102,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1124,9 +1116,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/unpublishing/publisher_v2/schema.json
+++ b/dist/formats/unpublishing/publisher_v2/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "title",
     "details",
@@ -13,12 +12,22 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "description": {
       "anyOf": [
@@ -30,84 +39,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "access_limited": {
-      "$ref": "#/definitions/access_limited"
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "change_note": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "previous_version": {
-      "type": "string"
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "links": {
-      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string",
@@ -272,79 +205,109 @@
         "written_statement"
       ]
     },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "unpublishing"
       ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "unpublished_at"
-      ],
-      "properties": {
-        "explanation": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "unpublished_at": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "alternative_url": {
-          "type": [
-            "string",
-            "null"
-          ],
-          "format": "uri"
-        },
-        "public_updated_at": {
-          "$ref": "#/definitions/public_updated_at"
-        }
-      }
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policy_areas": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
     },
     "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
       "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
     "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
         {
           "type": "string"
@@ -352,22 +315,187 @@
         {
           "type": "null"
         }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+      ]
     },
-    "external_related_links": {
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "required": [
+        "unpublished_at"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alternative_url": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "uri"
+        },
+        "explanation": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "public_updated_at": {
+          "$ref": "#/definitions/public_updated_at"
+        },
+        "unpublished_at": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -378,20 +506,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -408,212 +869,31 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
         }
       }
     },
-    "redirect_route": {
+    "links": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
       "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
         }
       }
     },
@@ -672,98 +952,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -772,10 +1085,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -783,6 +1092,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -805,79 +1118,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -889,13 +1331,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -903,61 +1339,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -965,418 +1364,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1386,9 +1378,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/working_group/frontend/schema.json
+++ b/dist/formats/working_group/frontend/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "links",
@@ -12,12 +11,25 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -29,119 +41,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_pages": {
-          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "meets_user_needs": {
-          "description": "The user needs this piece of content meets.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "organisations": {
-          "description": "All organisations linked to this content item. This should include lead organisations.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "parent": {
-          "description": "The parent content item.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policy_areas": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "primary_publishing_organisation": {
-          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "available_translations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "children": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policies": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "document_collections": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "child_taxons": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -306,67 +207,617 @@
         "written_statement"
       ]
     },
+    "email_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "available_translations": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "policies": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policy_areas": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "primary_publishing_organisation": {
+          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "working_group"
       ]
     },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    "title": {
+      "type": "string"
     },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
-    "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
     },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "base_path_less_frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "body": {
+          "$ref": "#/definitions/body"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "email": {
+          "type": "string"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "required": [
+        "title",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
     "frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "base_path",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
-          "document_type": {
-            "type": "string"
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
           },
-          "schema_name": {
-            "type": "string"
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
           },
-          "public_updated_at": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
             "type": "string"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
-            "type": "string"
+          "country": {
+            "$ref": "#/definitions/country"
           },
           "description": {
             "anyOf": [
@@ -378,36 +829,11 @@
               }
             ]
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "details": {
+            "type": "object",
+            "additionalProperties": true
           },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
+          "document_type": {
             "type": "string"
           },
           "links": {
@@ -417,129 +843,205 @@
                 "$ref": "#/definitions/frontend_links"
               }
             }
-          }
-        }
-      }
-    },
-    "base_path_less_frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "locale"
-        ],
-        "properties": {
-          "document_type": {
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
             "type": "string"
           },
           "schema_name": {
             "type": "string"
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
+          "title": {
+            "type": "string"
           },
           "web_url": {
             "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
             "type": "string",
             "format": "uri"
           },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
           },
-          "public_updated_at": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
             "type": "string"
           },
-          "content_id": {
-            "$ref": "#/definitions/guid"
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
           },
           "title": {
             "type": "string"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
           }
         }
       }
     },
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "email": {
-          "type": "string"
-        },
-        "body": {
-          "$ref": "#/definitions/body"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
       }
     },
-    "external_link": {
+    "image": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
+        "alt_text": {
           "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "url": {
           "type": "string",
@@ -550,17 +1052,17 @@
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -577,212 +1079,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -841,98 +1153,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -941,10 +1286,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -952,6 +1293,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -974,79 +1319,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1058,13 +1532,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1072,61 +1540,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1134,418 +1565,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1555,9 +1579,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/working_group/notification/schema.json
+++ b/dist/formats/working_group/notification/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "content_id",
@@ -17,12 +16,25 @@
     "title",
     "update_type"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -34,60 +46,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -252,60 +212,9 @@
         "written_statement"
       ]
     },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "working_group"
-      ]
-    },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
-    },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
     "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "govuk_request_id": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
     },
     "expanded_links": {
       "type": "object",
@@ -314,39 +223,561 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "govuk_request_id": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "working_group"
+      ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "base_path_less_frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "body": {
+          "$ref": "#/definitions/body"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "email": {
+          "type": "string"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "required": [
+        "title",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
     "frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "base_path",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
-          "document_type": {
-            "type": "string"
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
           },
-          "schema_name": {
-            "type": "string"
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
           },
-          "public_updated_at": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
             "type": "string"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
-            "type": "string"
+          "country": {
+            "$ref": "#/definitions/country"
           },
           "description": {
             "anyOf": [
@@ -358,36 +789,11 @@
               }
             ]
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "details": {
+            "type": "object",
+            "additionalProperties": true
           },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
+          "document_type": {
             "type": "string"
           },
           "links": {
@@ -397,129 +803,205 @@
                 "$ref": "#/definitions/frontend_links"
               }
             }
-          }
-        }
-      }
-    },
-    "base_path_less_frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "locale"
-        ],
-        "properties": {
-          "document_type": {
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
             "type": "string"
           },
           "schema_name": {
             "type": "string"
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
+          "title": {
+            "type": "string"
           },
           "web_url": {
             "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
             "type": "string",
             "format": "uri"
           },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
           },
-          "public_updated_at": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
             "type": "string"
           },
-          "content_id": {
-            "$ref": "#/definitions/guid"
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
           },
           "title": {
             "type": "string"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
           }
         }
       }
     },
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "email": {
-          "type": "string"
-        },
-        "body": {
-          "$ref": "#/definitions/body"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
       }
     },
-    "external_link": {
+    "image": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
+        "alt_text": {
           "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "url": {
           "type": "string",
@@ -530,17 +1012,17 @@
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -557,212 +1039,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -821,98 +1113,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -921,10 +1246,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -932,6 +1253,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -954,79 +1279,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1038,13 +1492,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1052,61 +1500,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1114,418 +1525,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1535,9 +1539,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/working_group/publisher_v2/links.json
+++ b/dist/formats/working_group/publisher_v2/links.json
@@ -3,25 +3,10 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "previous_version": {
-      "type": "string"
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/guid_list"
-        },
         "mainstream_browse_pages": {
           "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/guid_list"
@@ -30,8 +15,12 @@
           "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/guid_list"
         },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
@@ -51,38 +40,50 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/guid_list"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
         }
       }
+    },
+    "previous_version": {
+      "type": "string"
     }
   },
   "definitions": {
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
     "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
       "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
     "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
         {
           "type": "string"
@@ -90,22 +91,158 @@
         {
           "type": "null"
         }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+      ]
     },
-    "external_related_links": {
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -116,20 +253,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -146,212 +616,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -410,98 +690,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -510,10 +823,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -521,6 +830,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -543,79 +856,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -627,13 +1069,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -641,61 +1077,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -703,418 +1102,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1124,9 +1116,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/working_group/publisher_v2/schema.json
+++ b/dist/formats/working_group/publisher_v2/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "title",
     "details",
@@ -13,12 +12,22 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "description": {
       "anyOf": [
@@ -30,84 +39,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "access_limited": {
-      "$ref": "#/definitions/access_limited"
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "change_note": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "previous_version": {
-      "type": "string"
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "links": {
-      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string",
@@ -272,62 +205,109 @@
         "written_statement"
       ]
     },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "working_group"
       ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "email": {
-          "type": "string"
-        },
-        "body": {
-          "$ref": "#/definitions/body"
-        }
-      }
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policy_areas": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
     },
     "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
       "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
     "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
         {
           "type": "string"
@@ -335,22 +315,170 @@
         {
           "type": "null"
         }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+      ]
     },
-    "external_related_links": {
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "body": {
+          "$ref": "#/definitions/body"
+        },
+        "email": {
+          "type": "string"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -361,20 +489,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -391,212 +852,31 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
         }
       }
     },
-    "redirect_route": {
+    "links": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
       "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
         }
       }
     },
@@ -655,98 +935,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -755,10 +1068,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -766,6 +1075,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -788,79 +1101,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -872,13 +1314,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -886,61 +1322,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -948,418 +1347,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1369,9 +1361,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/world_location/frontend/schema.json
+++ b/dist/formats/world_location/frontend/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "links",
@@ -12,12 +11,25 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -29,123 +41,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_pages": {
-          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "meets_user_needs": {
-          "description": "The user needs this piece of content meets.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "organisations": {
-          "description": "All organisations linked to this content item. This should include lead organisations.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "parent": {
-          "description": "The parent content item.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policy_areas": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "primary_publishing_organisation": {
-          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "featured_policies": {
-          "description": "Featured policies primarily for use with Whitehall organisations",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "available_translations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "children": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policies": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "document_collections": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "child_taxons": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -310,140 +207,266 @@
         "written_statement"
       ]
     },
+    "email_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "available_translations": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "featured_policies": {
+          "description": "Featured policies primarily for use with Whitehall organisations",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "policies": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policy_areas": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "primary_publishing_organisation": {
+          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "world_location"
       ]
     },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    "title": {
+      "type": "string"
     },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
-    "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
     },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
-    "frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "base_path",
-          "locale"
-        ],
-        "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
-          },
-          "document_type": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
             "type": "string"
-          },
-          "schema_name": {
-            "type": "string"
-          },
-          "public_updated_at": {
-            "type": "string"
-          },
-          "content_id": {
-            "$ref": "#/definitions/guid"
-          },
-          "title": {
-            "type": "string"
-          },
-          "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
-            "type": "string"
-          },
-          "links": {
-            "type": "object",
-            "patternProperties": {
-              "^[a-z_]+$": {
-                "$ref": "#/definitions/frontend_links"
-              }
-            }
           }
         }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
       }
     },
     "base_path_less_frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "document_type": {
-            "type": "string"
-          },
-          "schema_name": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
           "api_path": {
             "$ref": "#/definitions/absolute_path"
@@ -453,25 +476,93 @@
             "type": "string",
             "format": "uri"
           },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "public_updated_at": {
-            "type": "string"
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
+          "document_type": {
             "type": "string"
           },
           "locale": {
             "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
           }
         }
       }
@@ -483,6 +574,9 @@
         "analytics_identifier": {
           "$ref": "#/definitions/analytics_identifier"
         },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
         "change_note": {
           "$ref": "#/definitions/change_note"
         },
@@ -491,62 +585,53 @@
         },
         "tags": {
           "$ref": "#/definitions/tags"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
         }
       }
     },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -557,20 +642,437 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "base_path",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
+            "type": "string"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "country": {
+            "$ref": "#/definitions/country"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "details": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "links": {
+            "type": "object",
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links"
+              }
+            }
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -587,212 +1089,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -851,98 +1163,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -951,10 +1296,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -962,6 +1303,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -984,79 +1329,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1068,13 +1542,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1082,61 +1550,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1144,418 +1575,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1565,9 +1589,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/world_location/notification/schema.json
+++ b/dist/formats/world_location/notification/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "content_id",
@@ -17,12 +16,25 @@
     "title",
     "update_type"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -34,60 +46,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -252,60 +212,9 @@
         "written_statement"
       ]
     },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "world_location"
-      ]
-    },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
-    },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
     "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "govuk_request_id": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
     },
     "expanded_links": {
       "type": "object",
@@ -314,112 +223,206 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "govuk_request_id": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "world_location"
+      ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
-    "frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "base_path",
-          "locale"
-        ],
-        "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
-          },
-          "document_type": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
             "type": "string"
-          },
-          "schema_name": {
-            "type": "string"
-          },
-          "public_updated_at": {
-            "type": "string"
-          },
-          "content_id": {
-            "$ref": "#/definitions/guid"
-          },
-          "title": {
-            "type": "string"
-          },
-          "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
-            "type": "string"
-          },
-          "links": {
-            "type": "object",
-            "patternProperties": {
-              "^[a-z_]+$": {
-                "$ref": "#/definitions/frontend_links"
-              }
-            }
           }
         }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
       }
     },
     "base_path_less_frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "document_type": {
-            "type": "string"
-          },
-          "schema_name": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
           "api_path": {
             "$ref": "#/definitions/absolute_path"
@@ -429,25 +432,93 @@
             "type": "string",
             "format": "uri"
           },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "public_updated_at": {
-            "type": "string"
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
+          "document_type": {
             "type": "string"
           },
           "locale": {
             "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
           }
         }
       }
@@ -459,6 +530,9 @@
         "analytics_identifier": {
           "$ref": "#/definitions/analytics_identifier"
         },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
         "change_note": {
           "$ref": "#/definitions/change_note"
         },
@@ -467,62 +541,53 @@
         },
         "tags": {
           "$ref": "#/definitions/tags"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
         }
       }
     },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -533,20 +598,437 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "base_path",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
+            "type": "string"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "country": {
+            "$ref": "#/definitions/country"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "details": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "links": {
+            "type": "object",
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links"
+              }
+            }
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -563,212 +1045,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -827,98 +1119,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -927,10 +1252,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -938,6 +1259,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -960,79 +1285,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1044,13 +1498,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1058,61 +1506,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1120,418 +1531,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1541,9 +1545,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/world_location/publisher_v2/links.json
+++ b/dist/formats/world_location/publisher_v2/links.json
@@ -3,25 +3,10 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "previous_version": {
-      "type": "string"
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/guid_list"
-        },
         "mainstream_browse_pages": {
           "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/guid_list"
@@ -30,8 +15,12 @@
           "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/guid_list"
         },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
@@ -51,38 +40,50 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/guid_list"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
         }
       }
+    },
+    "previous_version": {
+      "type": "string"
     }
   },
   "definitions": {
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
     "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
       "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
     "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
         {
           "type": "string"
@@ -90,22 +91,158 @@
         {
           "type": "null"
         }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+      ]
     },
-    "external_related_links": {
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -116,20 +253,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -146,212 +616,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -410,98 +690,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -510,10 +823,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -521,6 +830,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -543,79 +856,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -627,13 +1069,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -641,61 +1077,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -703,418 +1102,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1124,9 +1116,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/world_location/publisher_v2/schema.json
+++ b/dist/formats/world_location/publisher_v2/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "title",
     "details",
@@ -10,12 +9,22 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "description": {
       "anyOf": [
@@ -27,84 +36,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "access_limited": {
-      "$ref": "#/definitions/access_limited"
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "change_note": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "previous_version": {
-      "type": "string"
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "links": {
-      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string",
@@ -269,14 +202,224 @@
         "written_statement"
       ]
     },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "world_location"
       ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "details": {
       "type": "object",
       "additionalProperties": false,
@@ -295,69 +438,50 @@
         }
       }
     },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "featured_policies": {
-          "description": "Featured policies primarily for use with Whitehall organisations",
-          "$ref": "#/definitions/guid_list"
-        },
-        "policy_areas": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -368,20 +492,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -398,212 +855,35 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
         }
       }
     },
-    "redirect_route": {
+    "links": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
       "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
+        "featured_policies": {
+          "description": "Featured policies primarily for use with Whitehall organisations",
+          "$ref": "#/definitions/guid_list"
         },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
         }
       }
     },
@@ -662,98 +942,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -762,10 +1075,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -773,6 +1082,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -795,79 +1108,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -879,13 +1321,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -893,61 +1329,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -955,418 +1354,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1376,9 +1368,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/world_location_news_article/frontend/schema.json
+++ b/dist/formats/world_location_news_article/frontend/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "links",
@@ -12,12 +11,25 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -29,128 +41,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "topical_events": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "worldwide_organisations": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "world_locations": {
-          "$ref": "#/definitions/base_path_less_frontend_links"
-        },
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "mainstream_browse_pages": {
-          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "meets_user_needs": {
-          "description": "The user needs this piece of content meets.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "organisations": {
-          "description": "All organisations linked to this content item. This should include lead organisations.",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "parent": {
-          "description": "The parent content item.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policy_areas": {
-          "$ref": "#/definitions/frontend_links"
-        },
-        "primary_publishing_organisation": {
-          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
-          "maxItems": 1,
-          "$ref": "#/definitions/frontend_links"
-        },
-        "available_translations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "children": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "policies": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "document_collections": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        },
-        "child_taxons": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -315,67 +207,644 @@
         "written_statement"
       ]
     },
+    "email_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "available_translations": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "children": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "document_collections": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "policies": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "policy_areas": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "primary_publishing_organisation": {
+          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links",
+          "maxItems": 1
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "topical_events": {
+          "$ref": "#/definitions/frontend_links"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "world_locations": {
+          "$ref": "#/definitions/base_path_less_frontend_links"
+        },
+        "worldwide_organisations": {
+          "$ref": "#/definitions/frontend_links"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "world_location_news_article"
       ]
     },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
+    "title": {
+      "type": "string"
     },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
-    "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
     },
     "updated_at": {
       "type": "string",
       "format": "date-time"
     },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "base_path_less_frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "required": [
+        "body",
+        "first_public_at",
+        "government",
+        "political"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "body": {
+          "$ref": "#/definitions/body"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "first_public_at": {
+          "$ref": "#/definitions/first_public_at"
+        },
+        "government": {
+          "$ref": "#/definitions/government"
+        },
+        "image": {
+          "$ref": "#/definitions/image"
+        },
+        "political": {
+          "$ref": "#/definitions/political"
+        },
+        "tags": {
+          "$ref": "#/definitions/tags"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "required": [
+        "title",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
     "frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "base_path",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
-          "document_type": {
-            "type": "string"
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
           },
-          "schema_name": {
-            "type": "string"
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
           },
-          "public_updated_at": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
             "type": "string"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
-            "type": "string"
+          "country": {
+            "$ref": "#/definitions/country"
           },
           "description": {
             "anyOf": [
@@ -387,36 +856,11 @@
               }
             ]
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "details": {
+            "type": "object",
+            "additionalProperties": true
           },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
+          "document_type": {
             "type": "string"
           },
           "links": {
@@ -426,147 +870,205 @@
                 "$ref": "#/definitions/frontend_links"
               }
             }
-          }
-        }
-      }
-    },
-    "base_path_less_frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "locale"
-        ],
-        "properties": {
-          "document_type": {
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
             "type": "string"
           },
           "schema_name": {
             "type": "string"
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
+          "title": {
+            "type": "string"
           },
           "web_url": {
             "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
             "type": "string",
             "format": "uri"
           },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
           },
-          "public_updated_at": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
             "type": "string"
           },
-          "content_id": {
-            "$ref": "#/definitions/guid"
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
           },
           "title": {
             "type": "string"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
           }
         }
       }
     },
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "body",
-        "first_public_at",
-        "government",
-        "political"
-      ],
-      "properties": {
-        "body": {
-          "$ref": "#/definitions/body"
-        },
-        "image": {
-          "$ref": "#/definitions/image"
-        },
-        "first_public_at": {
-          "$ref": "#/definitions/first_public_at"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        },
-        "tags": {
-          "$ref": "#/definitions/tags"
-        },
-        "government": {
-          "$ref": "#/definitions/government"
-        },
-        "political": {
-          "$ref": "#/definitions/political"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
       }
     },
-    "external_link": {
+    "image": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
+        "alt_text": {
           "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "url": {
           "type": "string",
@@ -577,17 +1079,17 @@
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -604,212 +1106,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -868,98 +1180,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -968,10 +1313,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -979,6 +1320,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -1001,79 +1346,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1085,13 +1559,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1099,61 +1567,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1161,418 +1592,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1582,9 +1606,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/world_location_news_article/notification/schema.json
+++ b/dist/formats/world_location_news_article/notification/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "base_path",
     "content_id",
@@ -17,12 +16,25 @@
     "title",
     "update_type"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
     },
     "description": {
       "anyOf": [
@@ -34,60 +46,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "content_id": {
-      "$ref": "#/definitions/guid"
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "links": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z_]+$": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
     },
     "document_type": {
       "type": "string",
@@ -252,60 +212,9 @@
         "written_statement"
       ]
     },
-    "schema_name": {
-      "type": "string",
-      "enum": [
-        "world_location_news_article"
-      ]
-    },
-    "navigation_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering the new taxonomy-based navigation pages"
-    },
-    "user_journey_document_supertype": {
-      "type": "string",
-      "description": "Document type grouping powering analytics of user journeys"
-    },
     "email_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "government_document_supertype": {
-      "type": "string",
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions"
-    },
-    "updated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "publishing_request_id": {
-      "$ref": "#/definitions/publishing_request_id"
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "govuk_request_id": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
     },
     "expanded_links": {
       "type": "object",
@@ -314,39 +223,579 @@
           "$ref": "#/definitions/frontend_links"
         }
       }
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "govuk_request_id": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z_]+$": {
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "world_location_news_article"
+      ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "base_path_less_frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "title",
+          "locale"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "required": [
+        "body",
+        "first_public_at",
+        "government",
+        "political"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "body": {
+          "$ref": "#/definitions/body"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "first_public_at": {
+          "$ref": "#/definitions/first_public_at"
+        },
+        "government": {
+          "$ref": "#/definitions/government"
+        },
+        "image": {
+          "$ref": "#/definitions/image"
+        },
+        "political": {
+          "$ref": "#/definitions/political"
+        },
+        "tags": {
+          "$ref": "#/definitions/tags"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      }
+    },
+    "external_link": {
+      "type": "object",
+      "required": [
+        "title",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
     "frontend_links": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": true,
         "required": [
           "content_id",
           "title",
           "base_path",
           "locale"
         ],
+        "additionalProperties": true,
         "properties": {
-          "details": {
-            "type": "object",
-            "additionalProperties": true
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
           },
-          "document_type": {
-            "type": "string"
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
           },
-          "schema_name": {
-            "type": "string"
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
           },
-          "public_updated_at": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_description": {
             "type": "string"
           },
           "content_id": {
             "$ref": "#/definitions/guid"
           },
-          "title": {
-            "type": "string"
+          "country": {
+            "$ref": "#/definitions/country"
           },
           "description": {
             "anyOf": [
@@ -358,36 +807,11 @@
               }
             ]
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
+          "details": {
+            "type": "object",
+            "additionalProperties": true
           },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "web_url": {
-            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
-          },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
-          },
-          "withdrawn": {
-            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
-            "type": "boolean"
-          },
-          "country": {
-            "$ref": "#/definitions/country"
-          },
-          "change_description": {
+          "document_type": {
             "type": "string"
           },
           "links": {
@@ -397,147 +821,205 @@
                 "$ref": "#/definitions/frontend_links"
               }
             }
-          }
-        }
-      }
-    },
-    "base_path_less_frontend_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": [
-          "content_id",
-          "title",
-          "locale"
-        ],
-        "properties": {
-          "document_type": {
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
             "type": "string"
           },
           "schema_name": {
             "type": "string"
           },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "api_url": {
-            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
-            "type": "string",
-            "format": "uri"
+          "title": {
+            "type": "string"
           },
           "web_url": {
             "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
             "type": "string",
             "format": "uri"
           },
-          "analytics_identifier": {
-            "$ref": "#/definitions/analytics_identifier"
+          "withdrawn": {
+            "description": "Indicates whether the item has been unpublished as withdrawn, https://github.com/alphagov/publishing-api/blob/master/doc/model.md#workflow",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
           },
-          "public_updated_at": {
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
             "type": "string"
           },
-          "content_id": {
-            "$ref": "#/definitions/guid"
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
           },
           "title": {
             "type": "string"
-          },
-          "locale": {
-            "$ref": "#/definitions/locale"
           }
         }
       }
     },
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "body",
-        "first_public_at",
-        "government",
-        "political"
-      ],
-      "properties": {
-        "body": {
-          "$ref": "#/definitions/body"
-        },
-        "image": {
-          "$ref": "#/definitions/image"
-        },
-        "first_public_at": {
-          "$ref": "#/definitions/first_public_at"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        },
-        "tags": {
-          "$ref": "#/definitions/tags"
-        },
-        "government": {
-          "$ref": "#/definitions/government"
-        },
-        "political": {
-          "$ref": "#/definitions/political"
-        }
-      }
-    },
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
-    },
-    "access_limited": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
-        }
-      }
-    },
-    "analytics_identifier": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
-    },
-    "external_related_links": {
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
       }
     },
-    "external_link": {
+    "image": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
+        "alt_text": {
           "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "url": {
           "type": "string",
@@ -548,17 +1030,17 @@
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -575,212 +1057,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -839,98 +1131,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -939,10 +1264,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -950,6 +1271,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -972,79 +1297,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1056,13 +1510,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -1070,61 +1518,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -1132,418 +1543,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1553,9 +1557,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/world_location_news_article/publisher_v2/links.json
+++ b/dist/formats/world_location_news_article/publisher_v2/links.json
@@ -3,34 +3,10 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "previous_version": {
-      "type": "string"
-    },
     "links": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "topical_events": {
-          "$ref": "#/definitions/guid_list"
-        },
-        "worldwide_organisations": {
-          "$ref": "#/definitions/guid_list"
-        },
-        "world_locations": {
-          "$ref": "#/definitions/guid_list"
-        },
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/guid_list"
-        },
         "mainstream_browse_pages": {
           "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/guid_list"
@@ -39,8 +15,12 @@
           "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/guid_list"
         },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
@@ -60,38 +40,59 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/guid_list"
+        },
+        "topical_events": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "world_locations": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "worldwide_organisations": {
+          "$ref": "#/definitions/guid_list"
         }
       }
+    },
+    "previous_version": {
+      "type": "string"
     }
   },
   "definitions": {
-    "absolute_path": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
     "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
       "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
     "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
         {
           "type": "string"
@@ -99,22 +100,158 @@
         {
           "type": "null"
         }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+      ]
     },
-    "external_related_links": {
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -125,20 +262,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -155,212 +625,22 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "redirect_route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
-      "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
         }
       }
     },
@@ -419,98 +699,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -519,10 +832,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -530,6 +839,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -552,79 +865,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -636,13 +1078,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -650,61 +1086,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -712,418 +1111,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1133,9 +1125,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/dist/formats/world_location_news_article/publisher_v2/schema.json
+++ b/dist/formats/world_location_news_article/publisher_v2/schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "title",
     "details",
@@ -13,12 +12,22 @@
     "document_type",
     "schema_name"
   ],
+  "additionalProperties": false,
   "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
     "base_path": {
       "$ref": "#/definitions/absolute_path"
     },
-    "title": {
-      "type": "string"
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "description": {
       "anyOf": [
@@ -30,84 +39,8 @@
         }
       ]
     },
-    "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
-    },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "publishing_app": {
-      "$ref": "#/definitions/publishing_app_name"
-    },
-    "rendering_app": {
-      "$ref": "#/definitions/rendering_app_name"
-    },
-    "locale": {
-      "$ref": "#/definitions/locale"
-    },
-    "need_ids": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "routes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "$ref": "#/definitions/route"
-      }
-    },
-    "redirects": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/redirect_route"
-      }
-    },
-    "access_limited": {
-      "$ref": "#/definitions/access_limited"
-    },
-    "analytics_identifier": {
-      "$ref": "#/definitions/analytics_identifier"
-    },
-    "phase": {
-      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
-      "type": "string",
-      "enum": [
-        "alpha",
-        "beta",
-        "live"
-      ]
-    },
     "details": {
       "$ref": "#/definitions/details"
-    },
-    "withdrawn_notice": {
-      "$ref": "#/definitions/withdrawn_notice"
-    },
-    "change_note": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "last_edited_at": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Last time when the content received a major or minor update."
-    },
-    "previous_version": {
-      "type": "string"
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
-    },
-    "links": {
-      "$ref": "#/definitions/links"
     },
     "document_type": {
       "type": "string",
@@ -272,83 +205,109 @@
         "written_statement"
       ]
     },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "$ref": "#/definitions/links"
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "redirects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redirect_route"
+      }
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app_name"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
     "schema_name": {
       "type": "string",
       "enum": [
         "world_location_news_article"
       ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
     }
   },
   "definitions": {
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "body",
-        "first_public_at",
-        "government",
-        "political"
-      ],
-      "properties": {
-        "body": {
-          "$ref": "#/definitions/body"
-        },
-        "image": {
-          "$ref": "#/definitions/image"
-        },
-        "first_public_at": {
-          "$ref": "#/definitions/first_public_at"
-        },
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        },
-        "tags": {
-          "$ref": "#/definitions/tags"
-        },
-        "government": {
-          "$ref": "#/definitions/government"
-        },
-        "political": {
-          "$ref": "#/definitions/political"
-        }
-      }
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policy_areas": {
-          "$ref": "#/definitions/guid_list"
-        }
-      }
+    "absolute_fullpath": {
+      "description": "A path with optional query string and/or fragment.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
     },
     "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
       "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
-      "description": "A path only. Query string and/or fragment are not allowed."
-    },
-    "absolute_fullpath": {
-      "type": "string",
-      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$",
-      "description": "A path with optional query string and/or fragment."
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
     "access_limited": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "auth_bypass_ids": {
+          "description": "A list of ids that will allow access to this item for non-authenticated users",
+          "$ref": "#/definitions/guid_list"
+        },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "auth_bypass_ids": {
-          "$ref": "#/definitions/guid_list",
-          "description": "A list of ids that will allow access to this item for non-authenticated users"
         }
       }
     },
     "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
         {
           "type": "string"
@@ -356,22 +315,191 @@
         {
           "type": "null"
         }
-      ],
-      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations."
+      ]
     },
-    "external_related_links": {
+    "asset_link": {
+      "type": "object",
+      "required": [
+        "url",
+        "content_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "content_id": {
+          "$ref": "#/definitions/guid"
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "asset_link_list": {
+      "description": "An ordered list of asset links",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/external_link"
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "attachments_with_thumbnails": {
+      "description": "An ordered list of attachments",
+      "type": "array",
+      "items": {
+        "description": "Generated HTML for each attachment including thumbnail and download link",
+        "type": "string"
+      }
+    },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
+    "body_html_and_govspeak": {
+      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/multiple_content_types"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "change_note": {
+      "description": "Change note for the most recent update",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": "object",
+      "required": [
+        "slug",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "details": {
+      "type": "object",
+      "required": [
+        "body",
+        "first_public_at",
+        "government",
+        "political"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "body": {
+          "$ref": "#/definitions/body"
+        },
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        },
+        "first_public_at": {
+          "$ref": "#/definitions/first_public_at"
+        },
+        "government": {
+          "$ref": "#/definitions/government"
+        },
+        "image": {
+          "$ref": "#/definitions/image"
+        },
+        "political": {
+          "$ref": "#/definitions/political"
+        },
+        "tags": {
+          "$ref": "#/definitions/tags"
+        }
+      }
+    },
+    "email_alert_signup_breadcrumbs": {
+      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "link",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "email_alert_signup_summary": {
+      "description": "TODO: Use top-level description instead",
+      "type": "string"
+    },
+    "email_signup_link": {
+      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
+      "type": "string",
+      "format": "uri"
+    },
+    "emphasised_organisations": {
+      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
       }
     },
     "external_link": {
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "url"
       ],
+      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string"
@@ -382,20 +510,353 @@
         }
       }
     },
+    "external_related_links": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/external_link"
+      }
+    },
+    "finder_beta": {
+      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "finder_default_documents_per_page": {
+      "description": "Specify this to paginate results",
+      "type": "integer"
+    },
+    "finder_default_order": {
+      "description": "Rummager fields to order the results by",
+      "type": "string"
+    },
+    "finder_document_noun": {
+      "description": "How to refer to documents when presenting the search results",
+      "type": "string"
+    },
+    "finder_facets": {
+      "description": "The facets shown to the user to refine their search.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "filterable",
+          "display_as_result_metadata"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "allowed_values": {
+            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/label_value_pair"
+            }
+          },
+          "closed_value": {
+            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "display_as_result_metadata": {
+            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
+            "type": "boolean"
+          },
+          "filterable": {
+            "description": "This must be true to show the facet to users.",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The rummager field name used for this facet.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Label for the facet.",
+            "type": "string"
+          },
+          "open_value": {
+            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
+            "$ref": "#/definitions/label_value_pair"
+          },
+          "preposition": {
+            "description": "Text used to augment the description of the search when the facet is used.",
+            "type": "string"
+          },
+          "short_name": {
+            "type": "string"
+          },
+          "type": {
+            "description": "Defines the UI component and how the facet is queried from the search API",
+            "type": "string",
+            "enum": [
+              "text",
+              "date",
+              "topical"
+            ]
+          }
+        }
+      }
+    },
+    "finder_filter": {
+      "description": "This is the fixed filter that scopes the finder",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "document_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_reject_filter": {
+      "description": "A fixed filter that rejects documents which match the conditions",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_summary": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "first_public_at": {
+      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "government": {
+      "type": "object",
+      "required": [
+        "title",
+        "slug",
+        "current"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "description": "Is the government that published this document still the current government.",
+          "type": "boolean"
+        },
+        "slug": {
+          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'.",
+          "type": "string"
+        }
+      }
+    },
+    "grouped_lists_of_links": {
+      "description": "Lists of links with titles in named groups",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "contents"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contents": {
+            "description": "An ordered list of links, either internal with GUID or external with URL and title",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/internal_or_external_link"
+            }
+          },
+          "name": {
+            "description": "Title of the group",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "hmrc_manual_breadcrumbs": {
+      "description": "Breadcrumbs for HMRC manuals based on section",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "section_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "section_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_change_notes": {
+      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "section_id",
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "section_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "hmrc_manual_child_section_groups": {
+      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "section_id",
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "section_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
     "internal_link_without_guid": {
       "description": "Links to pages on GOV.UK without a corresponding GUID. eg A filtered list of publications",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "title",
         "path"
       ],
+      "additionalProperties": false,
       "properties": {
-        "title": {
-          "type": "string"
-        },
         "path": {
           "$ref": "#/definitions/absolute_fullpath"
+        },
+        "title": {
+          "type": "string"
         }
       }
     },
@@ -412,212 +873,31 @@
         }
       ]
     },
-    "government": {
+    "label_value_pair": {
+      "description": "One of many possible values a user can select from",
       "type": "object",
-      "additionalProperties": false,
       "required": [
-        "title",
-        "slug",
-        "current"
+        "label",
+        "value"
       ],
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Name of the government that first published this document, eg '1970 to 1974 Conservative government'."
-        },
-        "slug": {
-          "type": "string",
-          "description": "Government slug, used for analytics, eg '1970-to-1974-conservative-government'."
-        },
-        "current": {
-          "type": "boolean",
-          "description": "Is the government that published this document still the current government."
-        }
-      }
-    },
-    "guid": {
-      "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "publishing_app_name": {
-      "description": "The application that published this item.",
-      "type": "string",
-      "enum": [
-        "calculators",
-        "calendars",
-        "collections-publisher",
-        "contacts",
-        "content-tagger",
-        "design-principles",
-        "external-link-tracker",
-        "feedback",
-        "frontend",
-        "hmrc-manuals-api",
-        "info-frontend",
-        "licencefinder",
-        "manuals-frontend",
-        "manuals-publisher",
-        "maslow",
-        "need-api",
-        "performanceplatform-big-screen-view",
-        "policy-publisher",
-        "publisher",
-        "rummager",
-        "service-manual-publisher",
-        "share-sale-publisher",
-        "short-url-manager",
-        "smartanswers",
-        "specialist-publisher",
-        "spotlight",
-        "static",
-        "tariff",
-        "travel-advice-publisher",
-        "whitehall"
-      ]
-    },
-    "rendering_app_name": {
-      "description": "The application that renders this item.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "calculators",
-            "calendars",
-            "collections",
-            "designprinciples",
-            "email-alert-frontend",
-            "email-campaign-frontend",
-            "feedback",
-            "finder-frontend",
-            "frontend",
-            "government-frontend",
-            "info-frontend",
-            "licencefinder",
-            "manuals-frontend",
-            "performanceplatform-big-screen-view",
-            "publicapi",
-            "rummager",
-            "service-manual-frontend",
-            "smartanswers",
-            "spotlight",
-            "static",
-            "tariff",
-            "whitehall-frontend"
-          ]
-        },
-        {
-          "type": "null",
-          "description": "Items like 'gone' and 'redirect' do not have a rendering_app"
-        }
-      ]
-    },
-    "image": {
-      "type": "object",
       "additionalProperties": false,
-      "required": [
-        "url"
-      ],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "alt_text": {
+        "label": {
+          "description": "A human readable label",
           "type": "string"
         },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          }
-        }
-      }
-    },
-    "political": {
-      "type": "boolean",
-      "description": "If the content is considered political in nature, reflecting views of the government it was published under."
-    },
-    "route": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "path",
-        "type"
-      ],
-      "properties": {
-        "path": {
+        "value": {
+          "description": "A value to use for form controls",
           "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
         }
       }
     },
-    "redirect_route": {
+    "links": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "path",
-        "type",
-        "destination"
-      ],
       "properties": {
-        "path": {
-          "$ref": "#/definitions/absolute_path"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        },
-        "destination": {
-          "$ref": "#/definitions/absolute_fullpath"
-        },
-        "segments_mode": {
-          "enum": [
-            "preserve",
-            "ignore"
-          ],
-          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring."
+        "policy_areas": {
+          "$ref": "#/definitions/guid_list"
         }
       }
     },
@@ -676,98 +956,131 @@
         "zh-tw"
       ]
     },
+    "manual_change_notes": {
+      "description": "A history of changes to manuals and the associated section",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "title",
+          "change_note",
+          "published_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "change_note": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_child_section_groups": {
+      "description": "Grouped sections of a manual",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "child_sections"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "child_sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "description",
+                "base_path"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "base_path": {
+                  "$ref": "#/definitions/absolute_path"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_organisations": {
+      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "abbreviation",
+          "web_url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "abbreviation": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "manual_section_parent": {
+      "description": "The parent manual for a manual section",
+      "type": "object",
+      "required": [
+        "base_path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "base_path": {
+          "$ref": "#/definitions/absolute_path"
+        }
+      }
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds",
+      "type": "integer"
+    },
     "multiple_content_types": {
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "content_type",
           "content"
         ],
-        "properties": {
-          "content_type": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "asset_link": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url",
-        "content_type"
-      ],
-      "properties": {
-        "content_id": {
-          "$ref": "#/definitions/guid"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "content_type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time"
-        },
-        "updated_at": {
-          "format": "date-time"
-        }
-      }
-    },
-    "asset_link_list": {
-      "description": "An ordered list of asset links",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/asset_link"
-      }
-    },
-    "change_note": {
-      "description": "Change note for the most recent update",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
         "additionalProperties": false,
         "properties": {
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
+          "content": {
+            "type": "string"
           },
-          "note": {
-            "type": "string",
-            "description": "A summary of the change"
+          "content_type": {
+            "type": "string"
           }
-        },
-        "required": [
-          "public_timestamp",
-          "note"
-        ]
-      }
-    },
-    "withdrawn_notice": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "explanation": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "format": "date-time"
         }
       }
     },
@@ -776,10 +1089,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "label": {
-          "description": "The pretty-printed, translated label for this nation.",
-          "type": "string"
-        },
         "alternative_url": {
           "description": "An optional alternative URL to link to for more information on this content item pertaining to this nation.",
           "type": "string"
@@ -787,6 +1096,10 @@
         "applicable": {
           "description": "Whether the content applies to this nation or not.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "The pretty-printed, translated label for this nation.",
+          "type": "string"
         }
       }
     },
@@ -809,79 +1122,208 @@
         }
       }
     },
-    "label_value_pair": {
-      "description": "One of many possible values a user can select from",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "label",
-        "value"
-      ],
-      "properties": {
-        "label": {
-          "description": "A human readable label",
-          "type": "string"
-        },
-        "value": {
-          "description": "A value to use for form controls",
-          "type": "string"
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "slug",
+          "body"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "$ref": "#/definitions/body_html_and_govspeak"
+          },
+          "slug": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          }
         }
       }
     },
-    "emphasised_organisations": {
-      "description": "The content ids of the organisations that should be displayed first in the list of organisations related to the item, these content ids must be present in the item organisation links hash.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      }
-    },
-    "body": {
-      "description": "The main content provided as HTML rendered from govspeak",
-      "type": "string"
-    },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
-    "attachments_with_thumbnails": {
-      "description": "An ordered list of attachments",
-      "type": "array",
-      "items": {
-        "description": "Generated HTML for each attachment including thumbnail and download link",
-        "type": "string"
-      }
-    },
-    "first_public_at": {
-      "description": "DEPRECATED. The date the content was first published. Used in details. Will be deprecated in favour of top level first_published_at when publishing API allows it to be edited.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "first_published_at": {
-      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
-      "type": "string",
-      "format": "date-time"
+    "political": {
+      "description": "If the content is considered political in nature, reflecting views of the government it was published under.",
+      "type": "boolean"
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
       "format": "date-time"
     },
-    "tags": {
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-tagger",
+        "design-principles",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "manuals-frontend",
+        "manuals-publisher",
+        "maslow",
+        "need-api",
+        "performanceplatform-big-screen-view",
+        "policy-publisher",
+        "publisher",
+        "rummager",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "specialist-publisher",
+        "spotlight",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "type": "string"
+    },
+    "redirect_route": {
       "type": "object",
-      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "required": [
+        "path",
+        "type",
+        "destination"
+      ],
       "additionalProperties": false,
       "properties": {
+        "destination": {
+          "$ref": "#/definitions/absolute_fullpath"
+        },
+        "path": {
+          "$ref": "#/definitions/absolute_path"
+        },
+        "segments_mode": {
+          "description": "For prefix redirects, preserve or ignore the rest of the fullpath. For exact, preserve or ignore the querystring.",
+          "enum": [
+            "preserve",
+            "ignore"
+          ]
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "rendering_app_name": {
+      "description": "The application that renders this item.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "calculators",
+            "calendars",
+            "collections",
+            "designprinciples",
+            "email-alert-frontend",
+            "email-campaign-frontend",
+            "feedback",
+            "finder-frontend",
+            "frontend",
+            "government-frontend",
+            "info-frontend",
+            "licencefinder",
+            "manuals-frontend",
+            "performanceplatform-big-screen-view",
+            "publicapi",
+            "rummager",
+            "service-manual-frontend",
+            "smartanswers",
+            "spotlight",
+            "static",
+            "tariff",
+            "whitehall-frontend"
+          ]
+        },
+        {
+          "description": "Items like 'gone' and 'redirect' do not have a rendering_app",
+          "type": "null"
+        }
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "service_manual_topic_groups": {
+      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content_ids": {
+            "$ref": "#/definitions/guid_list"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "start_button_text": {
+      "description": "Custom text to be displayed on the green button that takes you to another page",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Field used by email-alert-api to trigger email alerts for subscriptions to topics (gov.uk/topic) and policies (gov.uk/policies).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additional_topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "browse_pages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "topics": {
+        "policies": {
           "type": "array",
           "items": {
             "type": "string"
@@ -893,13 +1335,7 @@
             "type": "string"
           }
         },
-        "additional_topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
+        "topics": {
           "type": "array",
           "items": {
             "type": "string"
@@ -907,61 +1343,24 @@
         }
       }
     },
-    "email_signup_link": {
-      "description": "Path to email signup form. TODO: Check if can be switched to use links instead",
-      "type": "string",
-      "format": "uri"
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
+    "taxonomy_internal_name": {
+      "description": "An internal name for taxonomy admin interfaces. Includes parent.",
       "type": "string"
-    },
-    "max_cache_time": {
-      "description": "The maximum length of time the content should be cached, in seconds",
-      "type": "integer"
-    },
-    "grouped_lists_of_links": {
-      "description": "Lists of links with titles in named groups",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "contents"
-        ],
-        "properties": {
-          "name": {
-            "description": "Title of the group",
-            "type": "string"
-          },
-          "contents": {
-            "description": "An ordered list of links, either internal with GUID or external with URL and title",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/internal_or_external_link"
-            }
-          }
-        }
-      }
     },
     "topic_groups": {
       "description": "Lists of items with titles & paths in named groups, used for showing curated links on browse pages and topics",
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "required": [
           "name",
           "contents"
         ],
+        "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "content_ids": {
             "description": "DEPRECATED",
-            "type": "string"
+            "$ref": "#/definitions/guid_list"
           },
           "contents": {
             "type": "array",
@@ -969,418 +1368,11 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "content_ids": {
-            "description": "DEPRECATED",
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "service_manual_topic_groups": {
-      "description": "Lists of items with titles & content IDs in named groups, used for service manual topic pages",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "description": "DEPRECATED",
             "type": "string"
-          },
-          "content_ids": {
-            "$ref": "#/definitions/guid_list"
-          }
-        }
-      }
-    },
-    "taxonomy_internal_name": {
-      "type": "string",
-      "description": "An internal name for taxonomy admin interfaces. Includes parent."
-    },
-    "manual_section_parent": {
-      "description": "The parent manual for a manual section",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "base_path"
-      ],
-      "properties": {
-        "base_path": {
-          "$ref": "#/definitions/absolute_path"
-        }
-      }
-    },
-    "manual_organisations": {
-      "description": "A manual’s organisations. TODO: Switch to use organisations in links",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "abbreviation",
-          "web_url"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "abbreviation": {
-            "type": "string"
-          },
-          "web_url": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "hmrc_manual_change_notes": {
-      "description": "A history of changes to HMRC manuals and the associated section. section_id is included and required making it different to manual_change_notes",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "section_id",
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "section_id": {
-            "type": "string"
-          },
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_change_notes": {
-      "description": "A history of changes to manuals and the associated section",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "title",
-          "change_note",
-          "published_at"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "title": {
-            "type": "string"
-          },
-          "change_note": {
-            "type": "string"
-          },
-          "published_at": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "manual_child_section_groups": {
-      "description": "Grouped sections of a manual",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "title",
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_child_section_groups": {
-      "description": "Grouped sections of an HMRC manual. Differs from manuals as section_id is required and group titles are optional.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "child_sections"
-        ],
-        "properties": {
-          "title": {
-            "type": "string"
-          },
-          "child_sections": {
-            "type": "array",
-            "items": {
-              "required": [
-                "section_id",
-                "title",
-                "description",
-                "base_path"
-              ],
-              "additionalProperties": false,
-              "type": "object",
-              "properties": {
-                "section_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "base_path": {
-                  "$ref": "#/definitions/absolute_path"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "hmrc_manual_breadcrumbs": {
-      "description": "Breadcrumbs for HMRC manuals based on section",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "base_path",
-          "section_id"
-        ],
-        "properties": {
-          "base_path": {
-            "$ref": "#/definitions/absolute_path"
-          },
-          "section_id": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "email_alert_signup_breadcrumbs": {
-      "description": "DEPRECATED. Breadcrumbs for email alert signup. Should use parent in links as other formats do.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "link",
-          "title"
-        ],
-        "properties": {
-          "link": {
-            "type": "string",
-            "format": "uri"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_document_noun": {
-      "description": "How to refer to documents when presenting the search results",
-      "type": "string"
-    },
-    "finder_default_documents_per_page": {
-      "description": "Specify this to paginate results",
-      "type": "integer"
-    },
-    "finder_default_order": {
-      "description": "Rummager fields to order the results by",
-      "type": "string"
-    },
-    "finder_filter": {
-      "description": "This is the fixed filter that scopes the finder",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "document_type": {
-          "type": "string"
-        },
-        "organisations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "finder_reject_filter": {
-      "description": "A fixed filter that rejects documents which match the conditions",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "policies": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "finder_facets": {
-      "description": "The facets shown to the user to refine their search.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "key",
-          "filterable",
-          "display_as_result_metadata"
-        ],
-        "properties": {
-          "key": {
-            "description": "The rummager field name used for this facet.",
-            "type": "string"
-          },
-          "filterable": {
-            "description": "This must be true to show the facet to users.",
-            "type": "boolean"
-          },
-          "display_as_result_metadata": {
-            "description": "Include this in search result metadata. Can be set for non-filterable facets.",
-            "type": "boolean"
           },
           "name": {
-            "description": "Label for the facet.",
-            "type": "string"
-          },
-          "preposition": {
-            "description": "Text used to augment the description of the search when the facet is used.",
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
-          "type": {
-            "description": "Defines the UI component and how the facet is queried from the search API",
-            "type": "string",
-            "enum": [
-              "text",
-              "date",
-              "topical"
-            ]
-          },
-          "allowed_values": {
-            "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/label_value_pair"
-            }
-          },
-          "open_value": {
-            "description": "Value that determines the open state (the key field is in the future) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          },
-          "closed_value": {
-            "description": "Value that determines the closed state (the key field is in the past) of a topical facet.",
-            "$ref": "#/definitions/label_value_pair"
-          }
-        }
-      }
-    },
-    "finder_show_summaries": {
-      "type": "boolean"
-    },
-    "finder_summary": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "finder_beta": {
-      "description": "Indicates if finder is in beta. TODO: Switch to top-level phase label",
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "email_alert_signup_summary": {
-      "description": "TODO: Use top-level description instead",
-      "type": "string"
-    },
-    "country": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "slug",
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "synonyms": {
-          "type": "array",
-          "items": {
             "type": "string"
           }
         }
@@ -1390,9 +1382,17 @@
       "description": "Description of the website the adjoining external link will be taking the user to",
       "type": "string"
     },
-    "start_button_text": {
-      "description": "Custom text to be displayed on the green button that takes you to another page",
-      "type": "string"
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
     }
   }
 }

--- a/lib/schema_generator/frontend_schema_generator.rb
+++ b/lib/schema_generator/frontend_schema_generator.rb
@@ -93,17 +93,6 @@ module SchemaGenerator
           "$ref" => "#/definitions/publishing_request_id",
         },
       )
-
-      # TODO: This is done to make sure that this rewrite produces the exact same
-      # JSON as before. After this is merged we can simplify this by just removing
-      # the fields from the publisher_content_schema we don't want.
-      props.slice(*%w[
-        base_path title description public_updated_at first_published_at
-        publishing_app rendering_app locale need_ids analytics_identifier phase
-        details withdrawn_notice content_id last_edited_at links document_type
-        schema_name format navigation_document_supertype user_journey_document_supertype email_document_supertype government_document_supertype updated_at
-        publishing_request_id
-      ])
     end
 
     def definitions

--- a/lib/schema_generator/schema.rb
+++ b/lib/schema_generator/schema.rb
@@ -1,15 +1,65 @@
 # Read and write the schemas
 module SchemaGenerator
+  module SortedHash
+    refine Hash do
+      def deep_sort(&block)
+        recursive_deep_sort(self, &block)
+      end
+
+    private
+
+      def recursive_deep_sort(property, parent_key = nil, &block)
+        if property.is_a?(Hash)
+          children_sorted = property.each_with_object({}) do |(k, v), memo|
+            memo[k] = recursive_deep_sort(v, k, &block)
+          end
+
+          sorted = children_sorted.sort do |a, b|
+            block.call(a, b, parent_key)
+          end
+
+          Hash[sorted]
+        elsif property.respond_to?(:map)
+          property.map { |item| recursive_deep_sort(item, nil, &block) }
+        else
+          property
+        end
+      end
+    end
+  end
+
   class Schema
+    using SchemaGenerator::SortedHash
+
     def self.read(filename)
       @parsed_json_cache ||= {}
       @parsed_json_cache[filename] ||= JSON.parse(File.read(filename))
     end
 
     def self.write(full_filename, schema_hash)
-      schema_json = JSON.pretty_generate(schema_hash) + "\n"
+      schema_json = JSON.pretty_generate(ordered_schema(schema_hash)) + "\n"
       FileUtils.mkdir_p(File.dirname(full_filename))
       File.write(full_filename, schema_json)
+    end
+
+    def self.ordered_schema(schema_hash)
+      # Custom consistent sorting for JSON Schema objects
+      sorted_hash = schema_hash.deep_sort do |(a, _), (b, _), parent_key|
+        a, b = [a.to_s, b.to_s]
+        # We don't want to sort any items properties
+        next a <=> b if parent_key == "properties"
+        # a description is always first
+        next (a == "description" ? -1 : 1) if [a, b].include?("description")
+        # then we want anything prefixed with a $
+        next a <=> b if [a, b].grep(/^\$/).any?
+        # Then we want type and required
+        next (a == "type" ? -1 : 1) if [a, b].include?("type")
+        next (a == "required" ? -1 : 1) if [a, b].include?("required")
+        # definitions are the last item
+        next (a == "definitions" ? 1 : -1) if [a, b].include?("definitions")
+        # otherwise it's alphabetical
+        a <=> b
+      end
     end
   end
 end

--- a/spec/lib/schema_generator/schema_spec.rb
+++ b/spec/lib/schema_generator/schema_spec.rb
@@ -1,0 +1,75 @@
+require "spec_helper"
+require "schema_generator/schema"
+
+RSpec.describe SchemaGenerator::Schema do
+  describe ".ordered_schema" do
+    subject(:ordered_schema) { described_class.ordered_schema(schema_hash) }
+
+    context "when provided with a json schema hash" do
+      let(:schema_hash) do
+        {
+          "$ref" => "http://www.example.com",
+          "type" => "object",
+          "definitions" => [],
+          "description" => "My description",
+          "required" => [],
+          "properties" => {},
+        }
+      end
+
+      let(:expected_ordering) do
+        %w(
+          description
+          $ref
+          type
+          required
+          properties
+          definitions
+        )
+      end
+
+      it "orders the schema" do
+        expect(ordered_schema.keys).to eq expected_ordering
+      end
+    end
+
+    context "when there are fields inside a properties object" do
+      let(:schema_hash) do
+        {
+          "properties" => {
+            "z" => 1,
+            "a" => 2,
+            "_" => 3,
+          }
+        }
+      end
+
+      let(:expected_ordering) { %w(_ a z) }
+
+      it "orders the property alphabetically" do
+        expect(ordered_schema["properties"].keys).to eq expected_ordering
+      end
+    end
+
+    context "when a nested object is given" do
+      let(:schema_hash) do
+        {
+          "type" => "object",
+          "description" => "My object",
+          "nested" => {
+            "type" => "object",
+            "description" => "My object",
+            "nested" => {}
+          }
+        }
+      end
+
+      let(:expected_ordering) { %w(description type nested) }
+
+      it "orders the nested object" do
+        expect(ordered_schema.keys).to eq expected_ordering
+        expect(ordered_schema["nested"].keys).to eq expected_ordering
+      end
+    end
+  end
+end


### PR DESCRIPTION
This specifies a set of rules of how a schema should be ordered and applies them when schemas are generated. 

This is to make the output schemas to be less determined by their inputs (which has led to things like [this](https://github.com/alphagov/govuk-content-schemas/blob/master/lib/schema_generator/frontend_schema_generator.rb#L105-L114)) and instead be predictable in their output.

The rules are:

- For an object with a key of "properties" the fields are sorted alphabetically

Otherwise:

- A description field is at the top
- Followed by any fields prefixed with a $ (eg $ref)
- Then we have the type field
- Followed by required
- Other fields are alphabetical
- Any definitions are at the end

The reason this is a somewhat complex ordering rather than a simple alphabetical one is that schema files end up being swamped by "definitions".